### PR TITLE
Api load tests for SMS verification and Email Verification

### DIFF
--- a/makefile
+++ b/makefile
@@ -28,7 +28,7 @@ SET_LOCAL_LOCUST_ENV_VARS := \
 	export DIRECTORY_API_URL=http://www.api.dev.playground.directory.uktrade.io/; \
 	export DIRECTORY_SSO_URL=http://www.sso.dev.playground.directory.uktrade.io/; \
 	export DIRECTORY_UI_URL=http://www.dev.playground.directory.uktrade.io/; \
-	export LOCUST_NUM_REQUEST=40; \
+	export LOCUST_NUM_REQUEST=100; \
 	export LOCUST_NUM_CLIENTS=5; \
 	export LOCUST_HATCH_RATE=5
 

--- a/tests/locust/test_api.py
+++ b/tests/locust/test_api.py
@@ -29,6 +29,16 @@ class AuthenticatedPagesAPI(TaskSet):
         url = get_relative_url('api:companies-house-profile')
         self.client.get('{url}?number=09466011'.format(url=url))
 
+    @task
+    def test_sms_verify_invalid_data(self):
+        url = get_relative_url('api:sms-verify')
+        data = {'phone_number': 'a' * 50}  # invalid phone number
+        with self.client.post(url, data=data, catch_response=True) as response:
+            if response.status_code == 400:
+                response.success()
+            else:
+                response.failure("Expected 400 status for invalid data")
+
 
 class RegularUserAPI(HttpLocust):
     host = settings.DIRECTORY_API_URL

--- a/tests/locust/test_api.py
+++ b/tests/locust/test_api.py
@@ -39,6 +39,16 @@ class AuthenticatedPagesAPI(TaskSet):
             else:
                 response.failure("Expected 400 status for invalid data")
 
+    @task
+    def test_confirm_company_email_invalid_data(self):
+        url = get_relative_url('api:confirm-company-email')
+        data = {'confirmation_code': 'invalid'}
+        with self.client.post(url, data=data, catch_response=True) as response:
+            if response.status_code == 400:
+                response.success()
+            else:
+                response.failure("Expected 400 status for invalid data")
+
 
 class RegularUserAPI(HttpLocust):
     host = settings.DIRECTORY_API_URL

--- a/tests/locust/test_api.py
+++ b/tests/locust/test_api.py
@@ -52,8 +52,10 @@ class AuthenticatedPagesAPI(TaskSet):
     @task
     def test_sms_verify_invalid_data(self):
         url = get_relative_url('api:sms-verify')
-        data = {'phone_number': 'a' * 50}  # invalid phone number
-        with self.client.post(url, data=data, catch_response=True) as response:
+        headers = {'content-type': 'application/json'}
+        data = json.dumps({'phone_number': 'a' * 50})  # invalid phone number
+        with self.client.post(url, data=data, headers=headers,
+                              catch_response=True) as response:
             if response.status_code == 400:
                 response.success()
             else:
@@ -62,8 +64,10 @@ class AuthenticatedPagesAPI(TaskSet):
     @task
     def test_confirm_company_email_invalid_data(self):
         url = get_relative_url('api:confirm-company-email')
-        data = {'confirmation_code': 'invalid'}
-        with self.client.post(url, data=data, catch_response=True) as response:
+        headers = {'content-type': 'application/json'}
+        data = json.dumps({'confirmation_code': 'invalid'})
+        with self.client.post(url, data=data, headers=headers,
+                              catch_response=True) as response:
             if response.status_code == 400:
                 response.success()
             else:


### PR DESCRIPTION
To make things simpler, these are load tests for cases when we give these views invalid data (easier to do this than set everything up on the api server).