### PR TITLE
ED-1727 view published profile on FAS

### DIFF
--- a/tests/functional/features/context_utils.py
+++ b/tests/functional/features/context_utils.py
@@ -145,6 +145,30 @@ def get_unregistered_company(self, alias):
     return self.scenario_data.unregistered_companies[alias]
 
 
+def set_company_description(self, alias, summary, description):
+    """Will set summary & description used when building up company's profile.
+
+    Can come handy when validating whether these values are visible.
+
+    :param self: behave `context` object
+    :type self: behave.runner.Context
+    :param alias: alias of sought Unregistered Company
+    :type alias: str
+    :param summary: Brief summary to make your company stand out to buyers
+    :type summary: str
+    :param description: Describe your business to overseas buyers
+    :type description: str
+    """
+    if alias in self.scenario_data.unregistered_companies:
+        companies = self.scenario_data.unregistered_companies
+        companies[alias] = companies[alias]._replace(summary=summary,
+                                                     description=description)
+        logging.debug("Successfully set summary & description for company %s",
+                      alias)
+    else:
+        raise KeyError("Could not find company with alias '%s'", alias)
+
+
 def patch_context(context):
     """Will patch the Behave's `context` object with some handy functions.
 
@@ -161,6 +185,7 @@ def patch_context(context):
     context.set_actor_email_confirmation_link = MethodType(
         set_actor_email_confirmation_link, context)
     context.set_company_for_actor = MethodType(set_company_for_actor, context)
+    context.set_company_description = MethodType(set_company_description, context)
     context.add_unregistered_company = MethodType(
         add_unregistered_company, context)
     context.get_unregistered_company = MethodType(

--- a/tests/functional/features/context_utils.py
+++ b/tests/functional/features/context_utils.py
@@ -22,7 +22,7 @@ Actor = namedtuple(
 UnregisteredCompany = namedtuple(
     'UnregisteredCompany',
     [
-        'alias', 'title', 'number', 'details'
+        'alias', 'title', 'number', 'details', 'summary', 'description'
     ]
 )
 

--- a/tests/functional/features/fab/profile.feature
+++ b/tests/functional/features/fab/profile.feature
@@ -66,3 +66,14 @@ Feature: Trade Profile
 
       Then "Annette Geissinger" should be on company profile page
       And "Annette Geissinger" should be told that her company is published
+
+
+    @ED-1727
+    @publish
+    @FAS
+    Scenario: Once verified Company Profile should be published on FAS
+      Given "Peter Alder" has created and verified profile for randomly selected company "Y"
+
+      When "Peter Alder" decides to view published profile
+
+      Then "Peter Alder" should be on FAS profile page of company "Y"

--- a/tests/functional/features/steps/fab_given_def.py
+++ b/tests/functional/features/steps/fab_given_def.py
@@ -7,6 +7,7 @@ from tests.functional.features.steps.fab_given_impl import (
     bp_build_company_profile,
     reg_confirm_email_address,
     reg_create_sso_account_associated_with_company,
+    reg_create_verified_profile,
     unauthenticated_supplier
 )
 from tests.functional.features.steps.fab_then_impl import (
@@ -51,3 +52,10 @@ def given_supplier_built_company_profile(context, supplier_alias):
 @given('"{supplier_alias}" set the company description')
 def given_supplier_set_company_description(context, supplier_alias):
     prof_set_company_description(context, supplier_alias)
+
+
+@given('"{supplier_alias}" has created and verified profile for randomly '
+       'selected company "{company_alias}"')
+def given_supplier_creates_verified_profile(context, supplier_alias,
+                                            company_alias):
+    reg_create_verified_profile(context, supplier_alias, company_alias)

--- a/tests/functional/features/steps/fab_given_impl.py
+++ b/tests/functional/features/steps/fab_given_impl.py
@@ -11,6 +11,7 @@ from tests.functional.features.steps.fab_then_impl import (
     bp_should_be_prompted_to_build_your_profile,
     prof_should_be_on_profile_page,
     prof_should_be_told_about_missing_description,
+    prof_should_be_told_that_company_is_published,
     reg_should_get_verification_email,
     reg_sso_account_should_be_created
 )
@@ -19,6 +20,8 @@ from tests.functional.features.steps.fab_when_impl import (
     bp_provide_company_details,
     bp_provide_full_name,
     bp_select_random_sector,
+    prof_set_company_description,
+    prof_verify_company,
     reg_confirm_company_selection,
     reg_confirm_export_status,
     reg_create_sso_account,
@@ -87,3 +90,22 @@ def bp_build_company_profile(context, supplier_alias):
     bp_confirm_registration_and_send_letter(context, supplier_alias)
     prof_should_be_on_profile_page(context, supplier_alias)
     prof_should_be_told_about_missing_description(context, supplier_alias)
+
+
+def reg_create_verified_profile(context, supplier_alias, company_alias):
+    # STEP 0 - initialize actor
+    unauthenticated_supplier(context, supplier_alias)
+
+    # STEP 1 - select company, create SSO profile & verify email address
+    reg_create_sso_account_associated_with_company(context, supplier_alias,
+                                                   company_alias)
+    reg_confirm_email_address(context, supplier_alias)
+
+    # STEP 2 - build company profile after email verification
+    bp_build_company_profile(context, supplier_alias)
+
+    # STEP 3 - verify company with the code sent by post
+    prof_set_company_description(context, supplier_alias)
+    prof_verify_company(context, supplier_alias)
+    prof_should_be_on_profile_page(context, supplier_alias)
+    prof_should_be_told_that_company_is_published(context, supplier_alias)

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -4,6 +4,7 @@ from behave import then
 
 from tests.functional.features.steps.fab_then_impl import (
     bp_should_be_prompted_to_build_your_profile,
+    fas_should_be_on_profile_page,
     prof_should_be_on_profile_page,
     prof_should_be_told_about_missing_description,
     prof_should_be_told_that_company_is_published,
@@ -41,3 +42,10 @@ def then_supplier_should_be_told_about_missing_description(context, supplier_ali
 def then_supplier_should_be_told_that_profile_is_published(context,
                                                            supplier_alias):
     prof_should_be_told_that_company_is_published(context, supplier_alias)
+
+
+@then('"{supplier_alias}" should be on FAS profile page of company '
+      '"{company_alias}"')
+def then_supplier_should_be_on_company_fas_page(context, supplier_alias,
+                                                company_alias):
+    fas_should_be_on_profile_page(context, supplier_alias, company_alias)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -114,3 +114,19 @@ def prof_should_be_told_that_company_is_published(context, supplier_alias):
     assert "View published profile" in content
     logging.debug("%s was told that the company profile is published",
                   supplier_alias)
+
+
+def fas_should_be_on_profile_page(context, supplier_alias, company_alias):
+    content = context.response.content.decode("utf-8")
+    actor = context.get_actor(supplier_alias)
+    company = context.get_unregistered_company(actor.company_alias)
+    assert "Contact" in content
+    assert "Company description" in content
+    assert "Facts &amp; details" in content
+    assert "Industries of interest" in content
+    assert "Keywords" in content
+    assert "Contact company" in content
+    assert company.number in content
+    assert company.summary in content
+    logging.debug("Supplier %s is on the %s company's FAS page",
+                  supplier_alias, company_alias)

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -8,6 +8,7 @@ from tests.functional.features.steps.fab_when_impl import (
     bp_provide_full_name,
     bp_select_random_sector,
     prof_verify_company,
+    prof_view_published_profile,
     reg_confirm_company_selection,
     reg_confirm_export_status,
     reg_create_sso_account,
@@ -83,3 +84,8 @@ def step_impl(context, supplier_alias):
       'from the letter sent after company profile was created')
 def when_supplier_verifies_company(context, supplier_alias):
     prof_verify_company(context, supplier_alias)
+
+
+@when('"{supplier_alias}" decides to view published profile')
+def when_supplier_views_published_profile(context, supplier_alias):
+    prof_view_published_profile(context, supplier_alias)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -810,7 +810,7 @@ def prof_view_published_profile(context, supplier_alias):
     new_location = "/suppliers/{}/".format(company.number)
     assert response.headers.get("Location").startswith(new_location)
 
-    # STEP 1 - go to the "View published profile" page
+    # STEP 2 - follow the redirect from last response
     actor = context.get_actor(supplier_alias)
     session = actor.session
     url = "{}{}".format(get_absolute_url("ui-supplier:landing"),

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -697,10 +697,12 @@ def prof_set_company_description(context, supplier_alias):
     fake = Factory.create()
     url = get_absolute_url("ui-buyer:company-edit-description")
     headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
+    summary = fake.sentence()
+    description = fake.sentence()
     data = {"csrfmiddlewaretoken": token,
             "supplier_company_description_edit_view-current_step": "description",
-            "description-summary": fake.sentence(),
-            "description-description": fake.sentence()
+            "description-summary": summary,
+            "description-description": description
             }
     response = make_request(Method.POST, url, session=session, headers=headers,
                             data=data, allow_redirects=False)
@@ -708,6 +710,7 @@ def prof_set_company_description(context, supplier_alias):
     assert response.status_code == 302, ("Expected 302 but got {}"
                                          .format(response.status_code))
     assert response.headers.get("Location") == "/company-profile"
+    context.set_company_description(actor.company_alias, summary, description)
 
     # STEP 3 - follow the redirect
     url = get_absolute_url("ui-buyer:company-profile")

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -14,13 +14,15 @@ from tests.functional.features.settings import NO_OF_EMPLOYEES, SECTORS
 from tests.functional.features.steps.fab_then_impl import (
     prof_should_be_on_profile_page,
     prof_should_be_told_that_company_is_not_verified_yet,
-    prof_should_be_told_that_company_is_published)
+    prof_should_be_told_that_company_is_published
+)
 from tests.functional.features.utils import (
     Method,
     extract_confirm_email_form_action,
     extract_csrf_middleware_token,
-    make_request,
-    get_verification_code)
+    get_verification_code,
+    make_request
+)
 from tests.functional.schemas.Companies import COMPANIES
 
 

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -110,8 +110,12 @@ def find_active_company_without_fas_profile(alias):
     logging.debug("It took %s attempt(s) to find an active Company without a "
                   "FAS profile: %s - %s", counter, json[0]["title"],
                   json[0]["company_number"])
-    company = UnregisteredCompany(alias, json[0]["title"].strip(),
-                                  json[0]["company_number"], json[0])
+    company = UnregisteredCompany(alias=alias,
+                                  title=json[0]["title"].strip(),
+                                  number=json[0]["company_number"],
+                                  details=json[0],
+                                  summary=None,
+                                  description=None)
     return company
 
 


### PR DESCRIPTION
This implements scenario where after verifying the company, Supplier can view the published profile on FAS

```gherkin
    @ED-1727
    @publish
    @FAS
    Scenario: Once verified Company Profile should be published on FAS
      Given "Peter Alder" has created and verified profile for randomly selected company "Y"

      When "Peter Alder" decides to view published profile

      Then "Peter Alder" should be on FAS profile page of company "Y"
```