### PR TITLE
ED-1740 Some suppliers are not appropriate to feature in the FAB service

### DIFF
--- a/tests/functional/features/fab/profile.feature
+++ b/tests/functional/features/fab/profile.feature
@@ -77,3 +77,16 @@ Feature: Trade Profile
       When "Peter Alder" decides to view published profile
 
       Then "Peter Alder" should be on FAS profile page of company "Y"
+
+
+  @ED-1740
+  @registration
+  Scenario: Some suppliers are not appropriate to feature in the FAB service
+    Given "Peter Alder" is an unauthenticated supplier
+
+    When "Peter Alder" randomly selects an active company without a profile identified by an alias "Company X"
+    And "Peter Alder" confirms that "Company X" is the correct one
+    And "Peter Alder" decides that the export status of his company is "No, we are not planning to sell overseas"
+
+    Then "Peter Alder" should be told that his company is currently not appropriate to feature in the FAB service
+

--- a/tests/functional/features/fab/profile.feature
+++ b/tests/functional/features/fab/profile.feature
@@ -79,14 +79,14 @@ Feature: Trade Profile
       Then "Peter Alder" should be on FAS profile page of company "Y"
 
 
-  @ED-1740
-  @registration
-  Scenario: Some suppliers are not appropriate to feature in the FAB service
-    Given "Peter Alder" is an unauthenticated supplier
+    @ED-1740
+    @registration
+    Scenario: Some suppliers are not appropriate to feature in the FAB service
+      Given "Peter Alder" is an unauthenticated supplier
 
-    When "Peter Alder" randomly selects an active company without a profile identified by an alias "Company X"
-    And "Peter Alder" confirms that "Company X" is the correct one
-    And "Peter Alder" decides that the export status of his company is "No, we are not planning to sell overseas"
+      When "Peter Alder" randomly selects an active company without a profile identified by an alias "Company X"
+      And "Peter Alder" confirms that "Company X" is the correct one
+      And "Peter Alder" decides that the export status of his company is "No, we are not planning to sell overseas"
 
-    Then "Peter Alder" should be told that his company is currently not appropriate to feature in the FAB service
+      Then "Peter Alder" should be told that his company is currently not appropriate to feature in the FAB service
 

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -10,6 +10,7 @@ from tests.functional.features.steps.fab_then_impl import (
     prof_should_be_told_that_company_is_published,
     reg_should_get_verification_email,
     reg_sso_account_should_be_created
+    reg_supplier_is_not_appropriate_for_fab
 )
 
 

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -9,7 +9,7 @@ from tests.functional.features.steps.fab_then_impl import (
     prof_should_be_told_about_missing_description,
     prof_should_be_told_that_company_is_published,
     reg_should_get_verification_email,
-    reg_sso_account_should_be_created
+    reg_sso_account_should_be_created,
     reg_supplier_is_not_appropriate_for_fab
 )
 
@@ -50,3 +50,9 @@ def then_supplier_should_be_told_that_profile_is_published(context,
 def then_supplier_should_be_on_company_fas_page(context, supplier_alias,
                                                 company_alias):
     fas_should_be_on_profile_page(context, supplier_alias, company_alias)
+
+
+@then('"{supplier_alias}" should be told that his company is currently not '
+      'appropriate to feature in the FAB service')
+def then_supplier_is_not_appropriate_for_fab(context, supplier_alias):
+    reg_supplier_is_not_appropriate_for_fab(context, supplier_alias)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -8,8 +8,8 @@ from tests.functional.features.utils import (
     extract_csrf_middleware_token,
     extract_email_confirmation_link,
     find_confirmation_email_msg,
-    get_s3_bucket
-)
+    get_s3_bucket,
+    check_response)
 
 
 def reg_sso_account_should_be_created(context, alias):
@@ -130,3 +130,17 @@ def fas_should_be_on_profile_page(context, supplier_alias, company_alias):
     assert company.summary in content
     logging.debug("Supplier %s is on the %s company's FAS page",
                   supplier_alias, company_alias)
+
+
+def reg_supplier_is_not_appropriate_for_fab(context, supplier_alias):
+    exp_strings = [
+        "Try our other business services",
+        "The Find a Buyer service promotes companies that are currently "
+        "exporting or looking to export in the near future. The answers you "
+        "gave suggest that your company is currently not appropriate to feature"
+        " in the Find a Buyer service.",
+        "Exporting is GREAT advice for new exporters"
+    ]
+    check_response(context.response, 200, strings=exp_strings)
+    logging.debug("%s was told that her/his business is not appropriate "
+                  "to feature in the Find a Buyer service", supplier_alias)

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -14,6 +14,7 @@ from tests.functional.features.steps.fab_when_impl import (
     reg_create_sso_account,
     reg_open_email_confirmation_link,
     reg_supplier_confirms_email_address,
+    reg_supplier_is_not_ready_to_export,
     select_random_company
 )
 
@@ -89,3 +90,9 @@ def when_supplier_verifies_company(context, supplier_alias):
 @when('"{supplier_alias}" decides to view published profile')
 def when_supplier_views_published_profile(context, supplier_alias):
     prof_view_published_profile(context, supplier_alias)
+
+
+@when('"{supplier_alias}" decides that the export status of his company is '
+      '"No, we are not planning to sell overseas"')
+def when_supplier_says_his_not_ready_to_export(context, supplier_alias):
+    reg_supplier_is_not_ready_to_export(context, supplier_alias)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -209,6 +209,32 @@ def reg_confirm_company_selection(context, supplier_alias, alias):
     context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
 
 
+def reg_supplier_is_not_ready_to_export(context, supplier_alias):
+    """Supplier decides that her/his company is not ready to export.
+
+    :param context: behave `context` object
+    :type context: behave.runner.Context
+    :param supplier_alias: alias of the Actor used in the scope of the scenario
+    :type supplier_alias: str
+    """
+    export_status = "NO_INTENTION"
+    actor = context.get_actor(supplier_alias)
+    session = actor.session
+    token = actor.csrfmiddlewaretoken
+    referer = get_absolute_url("ui-buyer:register-confirm-export-status")
+
+    # Step 1: POST /register/exports
+    url = get_absolute_url("ui-buyer:register-confirm-export-status")
+    headers = {"Referer": referer}
+    data = {"csrfmiddlewaretoken": token,
+            "enrolment_view-current_step": "exports",
+            "exports-export_status": export_status,
+            "exports-terms_agreed": "on"}
+    response = make_request(Method.POST, url, session=session, headers=headers,
+                            data=data, allow_redirects=False, context=context)
+    check_response(response, 200)
+
+
 def reg_confirm_export_status(context, supplier_alias, alias, export_status):
     """Will confirm the current export status of selected unregistered company.
 


### PR DESCRIPTION
This implements scenario:
```gherkin
  @ED-1740
  @registration
  Scenario: Some suppliers are not appropriate to feature in the FAB service
    Given "Peter Alder" is an unauthenticated supplier

    When "Peter Alder" randomly selects an active company without a profile identified by an alias "Company X"
    And "Peter Alder" confirms that "Company X" is the correct one
    And "Peter Alder" decides that the export status of his company is "No, we are not planning to sell overseas"

    Then "Peter Alder" should be told that his company is currently not appropriate to feature in the FAB service
```