### PR TITLE
ED-1743 use proper naming convention

### DIFF
--- a/tests/functional/features/fab/profile.feature
+++ b/tests/functional/features/fab/profile.feature
@@ -6,10 +6,10 @@ Feature: Trade Profile
     Scenario Outline: Supplier should receive a verification email after successful registration - export status is "<current>"
       Given "Peter Alder" is an unauthenticated supplier
 
-      When "Peter Alder" randomly selects an active company without a profile identified by an alias "Company X"
+      When "Peter Alder" randomly selects an active company without a Directory Profile identified by an alias "Company X"
       And "Peter Alder" confirms that "Company X" is the correct one
       And "Peter Alder" confirms that the export status of "Company X" is "<current>"
-      And "Peter Alder" creates a SSO account for "Company X" using valid credentials
+      And "Peter Alder" creates a SSO/great.gov.uk account for "Company X" using valid credentials
 
       Then "Peter Alder" should be told about the verification email
       And "Peter Alder" should receive an email verification msg entitled "Your great.gov.uk account: Please Confirm Your E-mail Address"
@@ -27,20 +27,20 @@ Feature: Trade Profile
     @email
     Scenario: Unauthenticated Suppliers should be able to verify their email address via confirmation link sent in an email
       Given "Annette Geissinger" is an unauthenticated supplier
-      And "Annette Geissinger" created a SSO account associated with randomly selected company "Company X"
+      And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
       And "Annette Geissinger" received the email verification message with the email confirmation link
 
       When "Annette Geissinger" decides to confirm her email address by using the email confirmation link
       And "Annette Geissinger" confirms the email address
 
-      Then "Annette Geissinger" should be prompted to Build and improve your profile
+      Then "Annette Geissinger" should be prompted to build and improve your Directory Profile
 
 
     @ED-1716
     @profile
-    Scenario: Supplier should be able to build the profile once the email address is confirmed
+    Scenario: Supplier should be able to build the Directory Profile once the email address is confirmed
       Given "Annette Geissinger" is an unauthenticated supplier
-      And "Annette Geissinger" created a SSO account associated with randomly selected company "Company X"
+      And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
       And "Annette Geissinger" confirmed her email address
 
       When "Annette Geissinger" provides valid details of selected company
@@ -48,7 +48,7 @@ Feature: Trade Profile
       And "Annette Geissinger" provides her full name which will be used to sent the verification letter
       And "Annette Geissinger" confirms the details which will be used to sent the verification letter
 
-      Then "Annette Geissinger" should be on company profile page
+      Then "Annette Geissinger" should be on edit Company's Directory Profile page
       And "Annette Geissinger" should be told that her company has no description
 
 
@@ -57,34 +57,34 @@ Feature: Trade Profile
     @letter
     Scenario: Supplier should be able to verify company using code sent in the verification letter
       Given "Annette Geissinger" is an unauthenticated supplier
-      And "Annette Geissinger" created a SSO account associated with randomly selected company "Company X"
+      And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
       And "Annette Geissinger" confirmed her email address
       And "Annette Geissinger" built the company profile
       And "Annette Geissinger" set the company description
 
-      When "Annette Geissinger" verifies the company with the verification code from the letter sent after company profile was created
+      When "Annette Geissinger" verifies the company with the verification code from the letter sent after Directory Profile was created
 
-      Then "Annette Geissinger" should be on company profile page
+      Then "Annette Geissinger" should be on edit Company's Directory Profile page
       And "Annette Geissinger" should be told that her company is published
 
 
     @ED-1727
     @publish
     @FAS
-    Scenario: Once verified Company Profile should be published on FAS
+    Scenario: Once verified Company's Directory Profile should be published on FAS
       Given "Peter Alder" has created and verified profile for randomly selected company "Y"
 
-      When "Peter Alder" decides to view published profile
+      When "Peter Alder" decides to view published Directory Profile
 
-      Then "Peter Alder" should be on FAS profile page of company "Y"
+      Then "Peter Alder" should be on FAS Directory Profile page of company "Y"
 
 
     @ED-1740
     @registration
-    Scenario: Some suppliers are not appropriate to feature in the FAB service
+    Scenario: Some suppliers are not appropriate to feature in the Find a Buyer service
       Given "Peter Alder" is an unauthenticated supplier
 
-      When "Peter Alder" randomly selects an active company without a profile identified by an alias "Company X"
+      When "Peter Alder" randomly selects an active company without a Directory Profile identified by an alias "Company X"
       And "Peter Alder" confirms that "Company X" is the correct one
       And "Peter Alder" decides that the export status of his company is "No, we are not planning to sell overseas"
 

--- a/tests/functional/features/steps/fab_given_def.py
+++ b/tests/functional/features/steps/fab_given_def.py
@@ -23,8 +23,8 @@ def given_an_unauthenticated_supplier(context, supplier_alias):
     unauthenticated_supplier(context, supplier_alias)
 
 
-@given('"{supplier_alias}" created a SSO account associated with randomly '
-       'selected company "{company_alias}"')
+@given('"{supplier_alias}" created a SSO/great.gov.uk account associated with '
+       'randomly selected company "{company_alias}"')
 def given_supplier_created_sso_account_for_company(
         context, supplier_alias, company_alias):
     reg_create_sso_account_associated_with_company(

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -24,28 +24,31 @@ def then_supplier_should_receive_verification_email(context, alias, subject):
     reg_should_get_verification_email(context, alias, subject)
 
 
-@then('"{supplier_alias}" should be prompted to Build and improve your profile')
-def then_supplier_should_be_prompted_to_build_your_profile(context, supplier_alias):
+@then('"{supplier_alias}" should be prompted to Build and improve your '
+      'Directory Profile')
+def then_supplier_should_be_prompted_to_build_your_profile(
+        context, supplier_alias):
     bp_should_be_prompted_to_build_your_profile(context, supplier_alias)
 
 
-@then('"{supplier_alias}" should be on company profile page')
+@then('"{supplier_alias}" should be on edit Company\'s Directory Profile page')
 def then_supplier_should_be_on_profile_page(context, supplier_alias):
     prof_should_be_on_profile_page(context, supplier_alias)
 
 
 @then('"{supplier_alias}" should be told that her company has no description')
-def then_supplier_should_be_told_about_missing_description(context, supplier_alias):
+def then_supplier_should_be_told_about_missing_description(
+        context, supplier_alias):
     prof_should_be_told_about_missing_description(context, supplier_alias)
 
 
 @then('"{supplier_alias}" should be told that her company is published')
-def then_supplier_should_be_told_that_profile_is_published(context,
-                                                           supplier_alias):
+def then_supplier_should_be_told_that_profile_is_published(
+        context, supplier_alias):
     prof_should_be_told_that_company_is_published(context, supplier_alias)
 
 
-@then('"{supplier_alias}" should be on FAS profile page of company '
+@then('"{supplier_alias}" should be on FAS Directory Profile page of company '
       '"{company_alias}"')
 def then_supplier_should_be_on_company_fas_page(context, supplier_alias,
                                                 company_alias):

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -19,8 +19,8 @@ from tests.functional.features.steps.fab_when_impl import (
 )
 
 
-@when('"{supplier_alias}" randomly selects an active company without a profile'
-      ' identified by an alias "{alias}"')
+@when('"{supplier_alias}" randomly selects an active company without a '
+      'Directory Profile identified by an alias "{alias}"')
 def when_supplier_selects_random_company(context, supplier_alias, alias):
     select_random_company(context, supplier_alias, alias)
 
@@ -37,8 +37,8 @@ def when_supplier_confirms_export_status(context, supplier_alias, alias,
     reg_confirm_export_status(context, supplier_alias, alias, export_status)
 
 
-@when('"{supplier_alias}" creates a SSO account for "{alias}" using '
-      'valid credentials')
+@when('"{supplier_alias}" creates a SSO/great.gov.uk account for "{alias}" '
+      'using valid credentials')
 def when_supplier_creates_sso_account_for_selected_company(context,
                                                            supplier_alias,
                                                            alias):
@@ -82,12 +82,12 @@ def step_impl(context, supplier_alias):
 
 
 @when('"{supplier_alias}" verifies the company with the verification code '
-      'from the letter sent after company profile was created')
+      'from the letter sent after Directory Profile was created')
 def when_supplier_verifies_company(context, supplier_alias):
     prof_verify_company(context, supplier_alias)
 
 
-@when('"{supplier_alias}" decides to view published profile')
+@when('"{supplier_alias}" decides to view published Directory Profile')
 def when_supplier_views_published_profile(context, supplier_alias):
     prof_view_published_profile(context, supplier_alias)
 


### PR DESCRIPTION
Our naming convention is `SSO/great.gov.uk account` and `Directory profile`.
I've updated all step definitions accordingly.

ps. best reviewed when #47 is merged.