### PR TITLE
ED-1757 verify email first before signing in

### DIFF
--- a/tests/functional/features/fab/profile.feature
+++ b/tests/functional/features/fab/profile.feature
@@ -36,6 +36,18 @@ Feature: Trade Profile
       Then "Annette Geissinger" should be prompted to build and improve your Directory Profile
 
 
+  @ED-1757
+  @verification
+  @email
+  Scenario: Suppliers without verified email should be told to verify the email address first before being able to log in
+    Given "Annette Geissinger" is an unauthenticated supplier
+    And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
+
+    When "Annette Geissinger" attempts to sign in to Find a Buyer profile
+
+    Then "Annette Geissinger" should be told that she needs to verify her email address first
+
+
     @ED-1716
     @profile
     Scenario: Supplier should be able to build the Directory Profile once the email address is confirmed

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -10,7 +10,8 @@ from tests.functional.features.steps.fab_then_impl import (
     prof_should_be_told_that_company_is_published,
     reg_should_get_verification_email,
     reg_sso_account_should_be_created,
-    reg_supplier_is_not_appropriate_for_fab
+    reg_supplier_is_not_appropriate_for_fab,
+    reg_supplier_has_to_verify_email_first
 )
 
 
@@ -59,3 +60,9 @@ def then_supplier_should_be_on_company_fas_page(context, supplier_alias,
       'appropriate to feature in the FAB service')
 def then_supplier_is_not_appropriate_for_fab(context, supplier_alias):
     reg_supplier_is_not_appropriate_for_fab(context, supplier_alias)
+
+
+@then('"{supplier_alias}" should be told that she needs to verify her email '
+      'address first')
+def then_supplier_has_to_verify_email_first(context, supplier_alias):
+    reg_supplier_has_to_verify_email_first(context, supplier_alias)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -144,3 +144,13 @@ def reg_supplier_is_not_appropriate_for_fab(context, supplier_alias):
     check_response(context.response, 200, strings=expected)
     logging.debug("%s was told that her/his business is not appropriate "
                   "to feature in the Find a Buyer service", supplier_alias)
+
+
+def reg_supplier_has_to_verify_email_first(context, supplier_alias):
+    expected = ["Verify your email address",
+                ("We have sent you a confirmation email. Please follow the link"
+                 " in the email to verify your email address."),
+                "if you do not receive an email within 10 minutes."]
+    check_response(context.response, 200, strings=expected)
+    logging.debug("%s was told that her/his email address has to be verified "
+                  "first before being able to Sign In", supplier_alias)

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -7,6 +7,7 @@ from tests.functional.features.steps.fab_when_impl import (
     bp_provide_company_details,
     bp_provide_full_name,
     bp_select_random_sector,
+    prof_attempt_to_sign_in_to_fab,
     prof_verify_company,
     prof_view_published_profile,
     reg_confirm_company_selection,
@@ -96,3 +97,8 @@ def when_supplier_views_published_profile(context, supplier_alias):
       '"No, we are not planning to sell overseas"')
 def when_supplier_says_his_not_ready_to_export(context, supplier_alias):
     reg_supplier_is_not_ready_to_export(context, supplier_alias)
+
+
+@when('"{supplier_alias}" attempts to sign in to Find a Buyer profile')
+def when_supplier_attempts_to_sign_in_to_fab(context, supplier_alias):
+    prof_attempt_to_sign_in_to_fab(context, supplier_alias)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -784,3 +784,59 @@ def prof_view_published_profile(context, supplier_alias):
                             allow_redirects=False, context=context)
     check_response(response, 200, strings=[company.number])
     logging.debug("Supplier is on the company's FAS page")
+
+
+def prof_attempt_to_sign_in_to_fab(context, supplier_alias):
+    """Try to sign in to FAB as a Supplier without verified email address.
+
+    :param context: behave `context` object
+    :type context: behave.runner.Context
+    :param supplier_alias: alias of the Actor used in the scope of the scenario
+    :type supplier_alias: str
+    """
+    actor = context.get_actor(supplier_alias)
+    session = actor.session
+    fab_landing = get_absolute_url("ui-buyer:landing")
+
+    # Step 1 - Get to the Sign In page
+    url = get_absolute_url("sso:login")
+    params = {"next": fab_landing}
+    headers = {"Referer": fab_landing}
+    response = make_request(Method.GET, url, session=session, params=params,
+                            headers=headers, allow_redirects=False,
+                            context=context)
+    expected = []
+    check_response(response, 200, strings=expected)
+    assert response.cookies.get("sso_display_logged_in") == "false"
+    token = extract_csrf_middleware_token(response)
+    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+
+    # Step 2 - submit the login form
+    url = get_absolute_url("sso:login")
+    data = {"next": fab_landing,
+            "csrfmiddlewaretoken": token,
+            "login": actor.email,
+            "password": actor.password,
+            "remember": "on"}
+    # Referer is the same as the final URL from the previous request
+    referer = response.request.url
+    headers = {"Referer": referer}
+    response = make_request(Method.POST, url, session=session, data=data,
+                            headers=headers, allow_redirects=False,
+                            context=context)
+    location = "/accounts/confirm-email/"
+    check_response(response, 302, location=location)
+    cookies = response.cookies
+    assert cookies.get("sso_display_logged_in") == "false"
+    assert cookies.get("directory_sso_dev_session") is not None
+    # extra check - validate the cookie Domain
+    assert "sso_display_logged_in" in cookies.get_dict(domain='.uktrade.io')
+    assert "directory_sso_dev_session" in cookies.get_dict(domain='.uktrade.io')
+
+    # Step 3 - follow the redirect
+    url = get_absolute_url("sso:email_confirm")
+    # Referer is the same as in the previous request
+    headers = {"Referer": referer}
+    response = make_request(Method.GET, url, session=session, headers=headers,
+                            allow_redirects=False, context=context)
+    check_response(response, 200)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -764,11 +764,10 @@ def prof_view_published_profile(context, supplier_alias):
     :type supplier_alias: str
     """
     actor = context.get_actor(supplier_alias)
+    session = actor.session
     company = context.get_unregistered_company(actor.company_alias)
 
     # STEP 1 - go to the "View published profile" page
-    actor = context.get_actor(supplier_alias)
-    session = actor.session
     url = "{}/{}".format(get_absolute_url("ui-supplier:suppliers"), company.number)
     response = make_request(Method.GET, url, session=session,
                             allow_redirects=False, context=context)
@@ -776,8 +775,6 @@ def prof_view_published_profile(context, supplier_alias):
     check_response(response, 301, location_starts_with=location)
 
     # STEP 2 - follow the redirect from last response
-    actor = context.get_actor(supplier_alias)
-    session = actor.session
     url = "{}{}".format(get_absolute_url("ui-supplier:landing"),
                         response.headers.get("Location"))
     response = make_request(Method.GET, url, session=session,


### PR DESCRIPTION
This implements:

```gherkin
  @ED-1757
  @verification
  @email
  Scenario: Suppliers without verified email should be told to verify the email address first before being able to log in
    Given "Annette Geissinger" is an unauthenticated supplier
    And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"

    When "Annette Geissinger" attempts to sign in to Find a Buyer profile

    Then "Annette Geissinger" should be told that she needs to verify her email address first
```