### PR TITLE
ED-1769 log out and log back in

### DIFF
--- a/tests/functional/features/fab/profile.feature
+++ b/tests/functional/features/fab/profile.feature
@@ -102,3 +102,16 @@ Feature: Trade Profile
 
       Then "Peter Alder" should be told that his company is currently not appropriate to feature in the FAB service
 
+
+    @ED-1769
+    @login
+    Scenario: Suppliers with unverified company profile should be able to logout and log back in
+      Given "Annette Geissinger" is an unauthenticated supplier
+      And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
+      And "Annette Geissinger" confirmed her email address
+      And "Annette Geissinger" signed out from Find a Buyer service
+
+      When "Annette Geissinger" signs in to Find a Buyer profile
+
+      Then "Annette Geissinger" should be on edit Company's Directory Profile page
+      And "Annette Geissinger" should be told that her company has no description

--- a/tests/functional/features/fab/profile.feature
+++ b/tests/functional/features/fab/profile.feature
@@ -38,7 +38,7 @@ Feature: Trade Profile
 
   @ED-1757
   @verification
-  @email
+  @login
   Scenario: Suppliers without verified email should be told to verify the email address first before being able to log in
     Given "Annette Geissinger" is an unauthenticated supplier
     And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"

--- a/tests/functional/features/steps/fab_given_def.py
+++ b/tests/functional/features/steps/fab_given_def.py
@@ -13,7 +13,8 @@ from tests.functional.features.steps.fab_then_impl import (
     reg_should_get_verification_email
 )
 from tests.functional.features.steps.fab_when_impl import (
-    prof_set_company_description
+    prof_set_company_description,
+    prof_sign_out_from_fab
 )
 from tests.settings import EMAIL_VERIFICATION_MSG_SUBJECT
 
@@ -59,3 +60,8 @@ def given_supplier_set_company_description(context, supplier_alias):
 def given_supplier_creates_verified_profile(context, supplier_alias,
                                             company_alias):
     reg_create_verified_profile(context, supplier_alias, company_alias)
+
+
+@given('"{supplier_alias}" signed out from Find a Buyer service')
+def given_supplier_signed_out_from_fab(context, supplier_alias):
+    prof_sign_out_from_fab(context, supplier_alias)

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -8,6 +8,7 @@ from tests.functional.features.steps.fab_when_impl import (
     bp_provide_full_name,
     bp_select_random_sector,
     prof_attempt_to_sign_in_to_fab,
+    prof_sign_in_to_fab,
     prof_verify_company,
     prof_view_published_profile,
     reg_confirm_company_selection,
@@ -102,3 +103,8 @@ def when_supplier_says_his_not_ready_to_export(context, supplier_alias):
 @when('"{supplier_alias}" attempts to sign in to Find a Buyer profile')
 def when_supplier_attempts_to_sign_in_to_fab(context, supplier_alias):
     prof_attempt_to_sign_in_to_fab(context, supplier_alias)
+
+
+@when('"{supplier_alias}" signs in to Find a Buyer profile')
+def when_supplier_signs_in_to_fab(context, supplier_alias):
+    prof_sign_in_to_fab(context, supplier_alias)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -837,3 +837,60 @@ def prof_attempt_to_sign_in_to_fab(context, supplier_alias):
     response = make_request(Method.GET, url, session=session, headers=headers,
                             allow_redirects=False, context=context)
     check_response(response, 200)
+
+
+def prof_sign_out_from_fab(context, supplier_alias):
+    """Sign out from Find a Buyer.
+
+    :param context: behave `context` object
+    :type context: behave.runner.Context
+    :param supplier_alias: alias of the Actor used in the scope of the scenario
+    :type supplier_alias: str
+    """
+    actor = context.get_actor(supplier_alias)
+    session = actor.session
+    fab_landing = get_absolute_url("ui-buyer:landing")
+
+    # Step 1 - Get to the Sign Out confirmation page
+    url = get_absolute_url("sso:logout")
+    params = {"next": fab_landing}
+    headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
+    response = make_request(Method.GET, url, session=session, params=params,
+                            headers=headers, allow_redirects=False,
+                            context=context)
+    expected = ["Sign out", "Are you sure you want to sign out?"]
+    check_response(response, 200, strings=expected)
+    assert response.cookies.get("sso_display_logged_in") == "true"
+    token = extract_csrf_middleware_token(response)
+    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+
+    # Step 2 - log out
+    url = get_absolute_url("sso:logout")
+    data = {"csrfmiddlewaretoken": token,
+            "next": fab_landing}
+    # Referer header is the final URL of the previous request
+    referer = response.request.url
+    headers = {"Referer": referer}
+    response = make_request(Method.POST, url, session=session, headers=headers,
+                            data=data, allow_redirects=False, context=context)
+    check_response(response, 302, location=fab_landing)
+    assert response.cookies.get("sso_display_logged_in") == "false"
+    # It looks like `requests` is ignoring empty cookies, so to check whether
+    # `directory_sso_dev_session` was unset, we have to check
+    # the "Set-Cookie" header
+    cookies_hdr = response.headers.get("Set-Cookie")
+    assert 'directory_sso_dev_session="\\"\\"";' in cookies_hdr
+
+    # Step 3 - follow the redirect to FAB's landing page
+    url = response.headers.get("Location")
+    # Referer header is the same one as in the previous request
+    headers = {"Referer": referer}
+    response = make_request(Method.GET, url, session=session,
+                            headers=headers, allow_redirects=False,
+                            context=context)
+    expected = ["Find a Buyer - GREAT.gov.uk", "Get promoted internationally",
+                "with a great.gov.uk trade profile",
+                "Enter your Companies House number"]
+    check_response(response, 200, strings=expected)
+    assert "sso_display_logged_in" not in response.cookies
+    assert "directory_sso_dev_session" not in response.cookies


### PR DESCRIPTION
BEST REVIEWED WHEN #49 is merged.
-------------------------------------------------------

This implements:
```gherkin
    @ED-1769
    @login
    Scenario: Suppliers with unverified company profile should be able to logout and log back in
      Given "Annette Geissinger" is an unauthenticated supplier
      And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
      And "Annette Geissinger" confirmed her email address
      And "Annette Geissinger" signed out from Find a Buyer service

      When "Annette Geissinger" signs in to Find a Buyer profile

      Then "Annette Geissinger" should be on edit Company's Directory Profile page
      And "Annette Geissinger" should be told that her company has no description
```