### PR TITLE
ED-1770 create dir profile after creating sso account - 2nd scenario

### DIFF
--- a/tests/functional/features/fab/profile.feature
+++ b/tests/functional/features/fab/profile.feature
@@ -140,7 +140,6 @@ Feature: Trade Profile
         | No, but we are preparing to    |
 
 
-    @wip
     @ED-1770
     @sso
     @fab
@@ -148,7 +147,7 @@ Feature: Trade Profile
     Scenario: Suppliers with a standalone SSO/great.gov.uk account should be able to create a Directory profile
       Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
       And "Peter Alder" is signed in to SSO/great.gov.uk account
-      And "Peter Alder" selected his company for Directory Profile creation
+      And "Peter Alder" selected an active company without a Directory Profile identified by an alias "Company X"
 
       When "Peter Alder" provides valid details of selected company
       And "Peter Alder" selects random sector the company is interested in working in

--- a/tests/functional/features/steps/fab_given_def.py
+++ b/tests/functional/features/steps/fab_given_def.py
@@ -7,6 +7,7 @@ from tests.functional.features.steps.fab_given_impl import (
     reg_confirm_email_address,
     reg_create_sso_account_associated_with_company,
     reg_create_verified_profile,
+    reg_select_random_company_and_confirm_export_status,
     sso_create_standalone_unverified_sso_account,
     sso_create_standalone_verified_sso_account,
     unauthenticated_supplier
@@ -84,3 +85,10 @@ def given_verified_standalone_sso_account(context, supplier_alias):
 @given('"{supplier_alias}" is signed in to SSO/great.gov.uk account')
 def step_impl(context, supplier_alias):
     sso_should_be_signed_in_to_sso_account(context, supplier_alias)
+
+
+@given('"{supplier_alias}" selected an active company without a Directory '
+       'Profile identified by an alias "{company_alias}"')
+def given_supplier_selects_random_company(context, supplier_alias, company_alias):
+    reg_select_random_company_and_confirm_export_status(
+        context, supplier_alias, company_alias)

--- a/tests/functional/features/steps/fab_given_def.py
+++ b/tests/functional/features/steps/fab_given_def.py
@@ -14,7 +14,8 @@ from tests.functional.features.steps.fab_given_impl import (
 )
 from tests.functional.features.steps.fab_then_impl import (
     reg_should_get_verification_email,
-    sso_should_be_signed_in_to_sso_account)
+    sso_should_be_signed_in_to_sso_account
+)
 from tests.functional.features.steps.fab_when_impl import (
     prof_set_company_description,
     prof_sign_out_from_fab

--- a/tests/functional/features/steps/fab_given_impl.py
+++ b/tests/functional/features/steps/fab_given_impl.py
@@ -31,6 +31,7 @@ from tests.functional.features.steps.fab_when_impl import (
     select_random_company,
     reg_create_standalone_sso_account,
     sso_supplier_confirms_email_address,
+from tests.functional.features.utils import get_positive_exporting_status
 from tests.settings import EMAIL_VERIFICATION_MSG_SUBJECT
 
 
@@ -67,14 +68,10 @@ def unauthenticated_supplier(context, supplier_alias):
 
 def reg_create_sso_account_associated_with_company(context, supplier_alias,
                                                    company_alias):
-    export_status = ["Yes, in the last year",
-                     "Yes, 1 to 2 years ago",
-                     "Yes, but more than 2 years ago",
-                     "No, but we are preparing to"]
+    export = get_positive_exporting_status()
     select_random_company(context, supplier_alias, company_alias)
     reg_confirm_company_selection(context, supplier_alias, company_alias)
-    reg_confirm_export_status(context, supplier_alias, company_alias,
-                              random.choice(export_status))
+    reg_confirm_export_status(context, supplier_alias, company_alias, export)
     reg_create_sso_account(context, supplier_alias, company_alias)
     reg_sso_account_should_be_created(context, supplier_alias)
 

--- a/tests/functional/features/steps/fab_given_impl.py
+++ b/tests/functional/features/steps/fab_given_impl.py
@@ -31,6 +31,7 @@ from tests.functional.features.steps.fab_when_impl import (
     select_random_company,
     reg_create_standalone_sso_account,
     sso_supplier_confirms_email_address,
+    sso_go_to_create_trade_profile)
 from tests.functional.features.utils import get_positive_exporting_status
 from tests.settings import EMAIL_VERIFICATION_MSG_SUBJECT
 
@@ -126,3 +127,15 @@ def sso_create_standalone_verified_sso_account(context, supplier_alias):
     sso_supplier_confirms_email_address(context, supplier_alias)
     sso_should_be_on_landing_page(context, supplier_alias)
     sso_should_be_signed_in_to_sso_account(context, supplier_alias)
+
+
+def reg_select_random_company_and_confirm_export_status(
+        context, supplier_alias, company_alias):
+    export = get_positive_exporting_status()
+    sso_create_standalone_verified_sso_account(context, supplier_alias)
+    sso_should_be_signed_in_to_sso_account(context, supplier_alias)
+    sso_go_to_create_trade_profile(context, supplier_alias)
+    select_random_company(context, supplier_alias, company_alias)
+    reg_confirm_company_selection(context, supplier_alias, company_alias)
+    reg_confirm_export_status(context, supplier_alias, company_alias, export)
+    bp_should_be_prompted_to_build_your_profile(context, supplier_alias)

--- a/tests/functional/features/steps/fab_given_impl.py
+++ b/tests/functional/features/steps/fab_given_impl.py
@@ -15,7 +15,8 @@ from tests.functional.features.steps.fab_then_impl import (
     reg_should_get_verification_email,
     reg_sso_account_should_be_created,
     sso_should_be_on_landing_page,
-    sso_should_be_signed_in_to_sso_account)
+    sso_should_be_signed_in_to_sso_account
+)
 from tests.functional.features.steps.fab_when_impl import (
     bp_confirm_registration_and_send_letter,
     bp_provide_company_details,
@@ -26,12 +27,12 @@ from tests.functional.features.steps.fab_when_impl import (
     reg_confirm_company_selection,
     reg_confirm_export_status,
     reg_create_sso_account,
+    reg_create_standalone_sso_account,
     reg_open_email_confirmation_link,
     reg_supplier_confirms_email_address,
     select_random_company,
-    reg_create_standalone_sso_account,
-    sso_supplier_confirms_email_address,
-    sso_go_to_create_trade_profile
+    sso_go_to_create_trade_profile,
+    sso_supplier_confirms_email_address
 )
 from tests.functional.features.utils import get_positive_exporting_status
 from tests.settings import EMAIL_VERIFICATION_MSG_SUBJECT

--- a/tests/functional/features/steps/fab_given_impl.py
+++ b/tests/functional/features/steps/fab_given_impl.py
@@ -133,11 +133,11 @@ def sso_create_standalone_verified_sso_account(context, supplier_alias):
 
 def reg_select_random_company_and_confirm_export_status(
         context, supplier_alias, company_alias):
-    export = get_positive_exporting_status()
+    export_status = get_positive_exporting_status()
     sso_create_standalone_verified_sso_account(context, supplier_alias)
     sso_should_be_signed_in_to_sso_account(context, supplier_alias)
     sso_go_to_create_trade_profile(context, supplier_alias)
     select_random_company(context, supplier_alias, company_alias)
     reg_confirm_company_selection(context, supplier_alias, company_alias)
-    reg_confirm_export_status(context, supplier_alias, company_alias, export)
+    reg_confirm_export_status(context, supplier_alias, export_status)
     bp_should_be_prompted_to_build_your_profile(context, supplier_alias)

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -10,8 +10,8 @@ from tests.functional.features.steps.fab_then_impl import (
     prof_should_be_told_that_company_is_published,
     reg_should_get_verification_email,
     reg_sso_account_should_be_created,
-    reg_supplier_is_not_appropriate_for_fab,
     reg_supplier_has_to_verify_email_first,
+    reg_supplier_is_not_appropriate_for_fab,
     sso_should_be_on_landing_page,
     sso_should_be_signed_in_to_sso_account
 )

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -5,11 +5,12 @@ import logging
 from retrying import retry
 
 from tests.functional.features.utils import (
+    check_response,
     extract_csrf_middleware_token,
     extract_email_confirmation_link,
     find_confirmation_email_msg,
-    get_s3_bucket,
-    check_response)
+    get_s3_bucket
+)
 
 
 def reg_sso_account_should_be_created(context, alias):

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -19,8 +19,8 @@ from tests.functional.features.steps.fab_when_impl import (
     reg_supplier_confirms_email_address,
     reg_supplier_is_not_ready_to_export,
     select_random_company,
-    sso_supplier_confirms_email_address,
-    sso_go_to_create_trade_profile
+    sso_go_to_create_trade_profile,
+    sso_supplier_confirms_email_address
 )
 
 

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -25,7 +25,7 @@ from tests.functional.features.utils import (
     make_request
 )
 from tests.functional.schemas.Companies import COMPANIES
-from tests.settings import NO_OF_EMPLOYEES, SECTORS, EXPORT_STATUSES
+from tests.settings import EXPORT_STATUSES, NO_OF_EMPLOYEES, SECTORS
 
 
 def has_fas_profile(company_number):

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -781,7 +781,8 @@ def prof_view_published_profile(context, supplier_alias):
     company = context.get_unregistered_company(actor.company_alias)
 
     # STEP 1 - go to the "View published profile" page
-    url = "{}/{}".format(get_absolute_url("ui-supplier:suppliers"), company.number)
+    url = "{}/{}".format(get_absolute_url("ui-supplier:suppliers"),
+                         company.number)
     response = make_request(Method.GET, url, session=session,
                             allow_redirects=False, context=context)
     location = "/suppliers/{}/".format(company.number)

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -15,11 +15,12 @@ from requests.models import Response
 
 from tests.functional.features.db_cleanup import get_dir_db_connection
 from tests.settings import (
+    EXPORT_STATUSES,
     S3_ACCESS_KEY_ID,
     S3_BUCKET,
     S3_REGION,
-    S3_SECRET_ACCESS_KEY,
-    EXPORT_STATUSES)
+    S3_SECRET_ACCESS_KEY
+)
 
 
 def get_file_log_handler(log_formatter,

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -4,6 +4,7 @@
 import email
 import logging
 import os
+import random
 from enum import Enum
 
 import requests
@@ -16,8 +17,8 @@ from tests.settings import (
     S3_ACCESS_KEY_ID,
     S3_BUCKET,
     S3_REGION,
-    S3_SECRET_ACCESS_KEY
-)
+    S3_SECRET_ACCESS_KEY,
+    EXPORT_STATUSES)
 
 
 def get_file_log_handler(log_formatter,
@@ -438,3 +439,19 @@ def check_response(response: Response, status_code: int, *,
         assert new_location.startswith(location_starts_with), (
             "Expected Location header to start with: '{}' but got '{}' instead."
             .format(location_starts_with, response.headers.get("Location")))
+
+
+def get_positive_exporting_status():
+    """Select random Exporting Status that allows you to register with
+    Find a Buyer service.
+
+    :return: an exporting status accepted by Find a Buyer service
+    :rtype: str
+    """
+    return random.choice(
+        list(
+            filter(lambda x: x != "No, we are not planning to sell overseas",
+                   EXPORT_STATUSES
+                   )
+        )
+    )

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -8,6 +8,7 @@ import random
 from enum import Enum
 
 import requests
+from boto.exception import S3ResponseError
 from boto.s3 import connect_to_region
 from boto.s3.connection import OrdinaryCallingFormat
 from requests.models import Response
@@ -329,28 +330,33 @@ def find_confirmation_email_msg(bucket, actor, subject):
         logging.debug("Processing email file: %s", key.key)
         try:
             msg_contents = key.get_contents_as_string().decode("utf-8")
-            msg = email.message_from_string(msg_contents)
-            if msg['To'].strip().lower() == actor.email.lower():
-                logging.debug("Found an email addressed at: %s", msg['To'])
-                if msg['Subject'] == subject:
-                    logging.debug("Found email confirmation message entitled: "
-                                  "%s", subject)
-                    res = extract_plain_text_payload(msg)
-                    found = True
-                    logging.debug("Deleting message %s", key.key)
+        except S3ResponseError as s3ex:
+            logging.error("Something went wrong when getting an email msg "
+                          "from S3: %s", s3ex)
+            raise
+        msg = email.message_from_string(msg_contents)
+        if msg['To'].strip().lower() == actor.email.lower():
+            logging.debug("Found an email addressed at: %s", msg['To'])
+            if msg['Subject'] == subject:
+                logging.debug("Found email confirmation message entitled: "
+                              "%s", subject)
+                res = extract_plain_text_payload(msg)
+                found = True
+                logging.debug("Deleting message %s", key.key)
+                try:
                     bucket.delete_key(key.key)
                     logging.debug("Successfully deleted message %s from S3",
                                   key.key)
-                else:
-                    logging.debug("Message from %s to %s had a non-matching"
-                                  "subject: '%s'", msg['From'], msg['To'],
-                                  msg['Subject'])
+                except S3ResponseError as s3ex:
+                    logging.error("Something went wrong when deleting msg: "
+                                  "%s - %s", key.key, s3ex)
             else:
-                logging.debug("Message %s was addressed at: %s", key.key,
-                              msg['To'])
-        except Exception as ex:
-            logging.error("Something went wrong when getting an email msg "
-                          "from S3: %s", ex)
+                logging.debug("Message from %s to %s had a non-matching"
+                              "subject: '%s'", msg['From'], msg['To'],
+                              msg['Subject'])
+        else:
+            logging.debug("Message %s was addressed at: %s", key.key,
+                          msg['To'])
 
     assert found, ("Could not find email confirmation message for {}"
                    .format(actor.email))

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -16,6 +16,7 @@ from requests.models import Response
 from tests.functional.features.db_cleanup import get_dir_db_connection
 from tests.settings import (
     EXPORT_STATUSES,
+    NO_EXPORT_INTENT_LABEL,
     S3_ACCESS_KEY_ID,
     S3_BUCKET,
     S3_REGION,
@@ -455,10 +456,5 @@ def get_positive_exporting_status():
     :return: an exporting status accepted by Find a Buyer service
     :rtype: str
     """
-    return random.choice(
-        list(
-            filter(lambda x: x != "No, we are not planning to sell overseas",
-                   EXPORT_STATUSES
-                   )
-        )
-    )
+    EXPORT_STATUSES.pop(NO_EXPORT_INTENT_LABEL, 0)
+    return random.choice(list(EXPORT_STATUSES))

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -64,10 +64,12 @@ SECTORS = [
     "WATER"
 ]
 
+NO_EXPORT_INTENT_LABEL = "No, we are not planning to sell overseas"
+
 EXPORT_STATUSES = {
     "Yes, in the last year": "YES",
     "Yes, 1 to 2 years ago": "ONE_TWO_YEARS_AGO",
     "Yes, but more than 2 years ago": "OVER_TWO_YEARS_AGO",
     "No, but we are preparing to": "NOT_YET",
-    "No, we are not planning to sell overseas": "NO_INTENTION"
+    NO_EXPORT_INTENT_LABEL: "NO_INTENTION"
 }


### PR DESCRIPTION
This implements 2nd out 2 scenarios defined in https://uktrade.atlassian.net/browse/ED-1770

```gherkin
    @ED-1770
    @sso
    @fab
    @account
    Scenario: Suppliers with a standalone SSO/great.gov.uk account should be able to create a Directory profile
      Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
      And "Peter Alder" is signed in to SSO/great.gov.uk account
      And "Peter Alder" selected an active company without a Directory Profile identified by an alias "Company X"

      When "Peter Alder" provides valid details of selected company
      And "Peter Alder" selects random sector the company is interested in working in
      And "Peter Alder" provides her full name which will be used to sent the verification letter
      And "Peter Alder" confirms the details which will be used to sent the verification letter

      Then "Peter Alder" should be on edit Company's Directory Profile page
      And "Peter Alder" should be told that her company has no description
```