### PR TITLE
ED-1787 improve fetching & deleting emails messages from S3

### DIFF
--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -334,7 +334,7 @@ def get_email_from_s3(key):
     try:
         message_contents = key.get_contents_as_string().decode("utf-8")
     except S3ResponseError as s3_exception:
-        logging.error("Something went wrong when getting an email message "
+        logging.debug("Something went wrong when getting an email message "
                       "from S3: %s", s3_exception)
         raise
     return email.message_from_string(message_contents)
@@ -360,8 +360,9 @@ def delete_message_from_s3(bucket, key):
         logging.debug("Successfully deleted message %s from S3",
                       key.key)
     except S3ResponseError as s3ex:
-        logging.error("Something went wrong when deleting msg: "
+        logging.debug("Something went wrong when deleting msg: "
                       "%s - %s", key.key, s3ex)
+        raise
 
 
 def find_confirmation_email_msg(bucket, actor, subject):

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -385,7 +385,7 @@ def find_confirmation_email_msg(bucket, actor, subject):
                               "%s", subject)
                 result = extract_plain_text_payload(msg)
                 found = True
-                delete_message_from_s3(key)
+                delete_message_from_s3(bucket, key)
             else:
                 logging.debug("Message from %s to %s had a non-matching"
                               "subject: '%s'", msg['From'], msg['To'],

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -12,6 +12,7 @@ from boto.exception import S3ResponseError
 from boto.s3 import connect_to_region
 from boto.s3.connection import OrdinaryCallingFormat
 from requests.models import Response
+from retrying import retry
 
 from tests.functional.features.db_cleanup import get_dir_db_connection
 from tests.settings import (
@@ -317,6 +318,52 @@ def get_s3_bucket():
     return conn.get_bucket(S3_BUCKET)
 
 
+@retry(wait_fixed=2000, stop_max_attempt_number=3)
+def get_email_from_s3(key):
+    """Fetch Email message from S3 and parse it into Python Email object.
+
+    NOTE:
+    This will retry few times to fetch the contents of the message due to fact
+    that it take a while for the changes (e.g.: saving email message)
+    to replicate across Amazon S3.
+    More on it here: https://stackoverflow.com/a/13602018
+
+    :param key: a Key that identifies email message stored in S3 bucket
+    :return: standard Python Email object
+    """
+    try:
+        message_contents = key.get_contents_as_string().decode("utf-8")
+    except S3ResponseError as s3_exception:
+        logging.error("Something went wrong when getting an email message "
+                      "from S3: %s", s3_exception)
+        raise
+    return email.message_from_string(message_contents)
+
+
+@retry(wait_fixed=2000, stop_max_attempt_number=3)
+def delete_message_from_s3(bucket, key):
+    """Delete Email message from S3.
+
+    NOTE:
+    This will retry few times to fetch the contents of the message due to fact
+    that it take a while for the changes (e.g.: saving email message)
+    to replicate across Amazon S3.
+    More on it here: https://stackoverflow.com/a/13602018
+
+    :param bucket: S3 bucket connection
+    :param key: a Key that identifies email message stored in S3 bucket
+    :return: standard Python Email object
+    """
+    logging.debug("Deleting message %s", key.key)
+    try:
+        bucket.delete_key(key.key)
+        logging.debug("Successfully deleted message %s from S3",
+                      key.key)
+    except S3ResponseError as s3ex:
+        logging.error("Something went wrong when deleting msg: "
+                      "%s - %s", key.key, s3ex)
+
+
 def find_confirmation_email_msg(bucket, actor, subject):
     """Will search for an email confirmation message stored in AWS S3.
 
@@ -325,32 +372,20 @@ def find_confirmation_email_msg(bucket, actor, subject):
     :param subject: expected subject of sought message
     :return: a plain text message payload
     """
-    res = None
+    result = None
     found = False
+
     for key in bucket.list():
         logging.debug("Processing email file: %s", key.key)
-        try:
-            msg_contents = key.get_contents_as_string().decode("utf-8")
-        except S3ResponseError as s3ex:
-            logging.error("Something went wrong when getting an email msg "
-                          "from S3: %s", s3ex)
-            raise
-        msg = email.message_from_string(msg_contents)
+        msg = get_email_from_s3(key)
         if msg['To'].strip().lower() == actor.email.lower():
             logging.debug("Found an email addressed at: %s", msg['To'])
             if msg['Subject'] == subject:
                 logging.debug("Found email confirmation message entitled: "
                               "%s", subject)
-                res = extract_plain_text_payload(msg)
+                result = extract_plain_text_payload(msg)
                 found = True
-                logging.debug("Deleting message %s", key.key)
-                try:
-                    bucket.delete_key(key.key)
-                    logging.debug("Successfully deleted message %s from S3",
-                                  key.key)
-                except S3ResponseError as s3ex:
-                    logging.error("Something went wrong when deleting msg: "
-                                  "%s - %s", key.key, s3ex)
+                delete_message_from_s3(key)
             else:
                 logging.debug("Message from %s to %s had a non-matching"
                               "subject: '%s'", msg['From'], msg['To'],
@@ -361,7 +396,7 @@ def find_confirmation_email_msg(bucket, actor, subject):
 
     assert found, ("Could not find email confirmation message for {}"
                    .format(actor.email))
-    return res
+    return result
 
 
 def get_verification_code(company_number):


### PR DESCRIPTION
This should improve handling of fetching & deleting email messages from S3 by simply retrying to access the file few times before the test will fail.
The reason behind this workaround stems from the issue described here: https://stackoverflow.com/questions/13580335/amazon-s3-the-specified-key-does-not-exist-after-get-key-success