### PR TITLE
ED-1759 upload invalid logos

### DIFF
--- a/tests/functional/features/fab/profile.feature
+++ b/tests/functional/features/fab/profile.feature
@@ -212,15 +212,11 @@ Feature: Trade Profile
     @ED-1759
     @profile
     @logo
-    Scenario Outline: Supplier should not be able to upload files other than images as company’s logo
+    Scenario: Supplier should not be able to upload files other than images as company’s logo
       Given "Peter Alder" has created and verified profile for randomly selected company "Y"
 
-      When "Peter Alder" attempts to upload "<unsupported_file>" as company's logo
-
-      Then "Peter Alder" should be told that only images can be uploaded and set as company's logo
-
-      Examples:
-        | unsupported_file      | comment                 |
+      When "Peter Alder" attempts to upload a file of unsupported type as company's logo
+        | file                  | type                    |
         | Anfiteatro_El_Jem.bmp | Bitmap                  |
         | Anfiteatro_El_Jem.jp2 | JPEG 2000               |
         | Kobe_Port_Tower.webp  | Web P                   |
@@ -229,4 +225,6 @@ Feature: Trade Profile
         | example.sh            | Linux shell script      |
         | example.bat           | Windows shell script    |
         | example.txt           | text file               |
-        | example.psd           | Photoshop file          |
+
+      Then for every uploaded unsupported file "Peter Alder" should be told that only certain image types can be used as company's logo
+

--- a/tests/functional/features/fab/profile.feature
+++ b/tests/functional/features/fab/profile.feature
@@ -208,7 +208,6 @@ Feature: Trade Profile
         | Anfiteatro_El_Jem.jpeg | Kobe_Port_Tower.jpg |
 
 
-    @wip
     @ED-1759
     @profile
     @logo

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -6,6 +6,7 @@ from tests.functional.features.steps.fab_then_impl import (
     bp_should_be_prompted_to_build_your_profile,
     fas_should_be_on_profile_page,
     fas_should_see_logo_picture,
+    prof_all_unsupported_files_should_be_rejected,
     prof_should_be_on_profile_page,
     prof_should_be_told_about_missing_description,
     prof_should_be_told_that_company_is_published,
@@ -93,3 +94,9 @@ def then_supplier_should_see_logo_picture_on_fab(context, supplier_alias):
       'Directory Profile page')
 def then_supplier_should_see_logo_picture_on_fas(context, supplier_alias):
     fas_should_see_logo_picture(context, supplier_alias)
+
+
+@then('for every uploaded unsupported file "{supplier_alias}" should be told '
+      'that only certain image types can be used as company\'s logo')
+def then_every_invalid_logo_should_be_rejected(context, supplier_alias):
+    prof_all_unsupported_files_should_be_rejected(context, supplier_alias)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -241,3 +241,23 @@ def fas_should_see_logo_picture(context, supplier_alias):
     check_hash_of_remote_file(logo_hash, logo_url)
     logging.debug("The Logo visible on the %s's FAS profile page is the same "
                   "as uploaded %s", company.title, logo_picture)
+
+
+def prof_all_unsupported_files_should_be_rejected(context, supplier_alias):
+    """Check if all unsupported files were rejected upon upload as company logo.
+
+    NOTE:
+    This require `context.rejections` to be set.
+    It should be a list of bool values.
+
+    :param context: behave `context` object
+    :type context: behave.runner.Context
+    :param supplier_alias: alias of the Actor used in the scope of the scenario
+    :type supplier_alias: str
+    """
+    assert hasattr(context, "rejections")
+    assert all(context.rejections), (
+        "Some of the uploaded files that should be marked as unsupported were "
+        "actually accepted. Please check the logs for more details")
+    logging.debug("All files of unsupported types uploaded by %s were rejected"
+                  .format(supplier_alias))

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -8,6 +8,7 @@ from tests.functional.features.steps.fab_when_impl import (
     bp_provide_full_name,
     bp_select_random_sector,
     prof_attempt_to_sign_in_to_fab,
+    prof_to_upload_unsupported_logos,
     prof_sign_in_to_fab,
     prof_supplier_uploads_logo,
     prof_verify_company,
@@ -131,3 +132,9 @@ def when_supplier_decide_to_create_trade_profile(context, supplier_alias):
 @when('"{supplier_alias}" uploads "{picture}" as company\'s logo')
 def when_supplier_uploads_logo(context, supplier_alias, picture):
     prof_supplier_uploads_logo(context, supplier_alias, picture)
+
+
+@when('"{supplier_alias}" attempts to upload a file of unsupported type as '
+      'company\'s logo')
+def when_supplier_attempts_to_upload_unsupported_file(context, supplier_alias):
+    prof_to_upload_unsupported_logos(context, supplier_alias, context.table)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1308,9 +1308,9 @@ def prof_upload_unsupported_file_as_logo(context, supplier_alias, file):
     has_error = any([message in content for message in error_messages])
     is_200 = response.status_code == 200
     if is_200 and has_error:
-        logging.debug("%s was rejected", file)
+        logging.debug("%s was rejected", filename)
     else:
-        logging.error("%s was accepted", file)
+        logging.error("%s was accepted", filename)
 
     return is_200 and has_error
 

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1290,7 +1290,8 @@ def prof_upload_unsupported_file_as_logo(context, supplier_alias, file):
     data = {"csrfmiddlewaretoken": actor.csrfmiddlewaretoken,
             "supplier_company_profile_logo_edit_view-current_step": "logo",
             }
-    files = {"logo-logo": open(filename, "rb")}
+    with open(filename, "rb") as picture:
+        files = {"logo-logo": picture}
     response = make_request(Method.POST, url, session=session, headers=headers,
                             data=data, files=files,
                             allow_redirects=False, context=context)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1277,8 +1277,8 @@ def prof_upload_unsupported_file_as_logo(context, supplier_alias, file):
     :type  context: behave.runner.Context
     :param supplier_alias: alias of the Actor used in the scope of the scenario
     :type  supplier_alias: str
-    :param filename: name of the file stored in ./tests/functional/files
-    :type  filename: str
+    :param file: name of the file stored in ./tests/functional/files
+    :type  file: str
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
@@ -1308,9 +1308,9 @@ def prof_upload_unsupported_file_as_logo(context, supplier_alias, file):
     has_error = any([message in content for message in error_messages])
     is_200 = response.status_code == 200
     if is_200 and has_error:
-        logging.debug("%s was rejected", filename)
+        logging.debug("%s was rejected", file)
     else:
-        logging.error("%s was accepted", filename)
+        logging.error("%s was accepted", file)
 
     return is_200 and has_error
 

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1291,8 +1291,9 @@ def prof_upload_unsupported_file_as_logo(context, supplier_alias, file):
     data = {"csrfmiddlewaretoken": actor.csrfmiddlewaretoken,
             "supplier_company_profile_logo_edit_view-current_step": "logo",
             }
-    with open(filename, "rb") as picture:
-        files = {"logo-logo": picture}
+    with open(filename, "rb") as f:
+        picture = f.read()
+    files = {"logo-logo": picture}
     response = make_request(Method.POST, url, session=session, headers=headers,
                             data=data, files=files,
                             allow_redirects=False, context=context)


### PR DESCRIPTION
This implements:
```gherkin
    @ED-1759
    @profile
    @logo
    Scenario: Supplier should not be able to upload files other than images as company’s logo
      Given "Peter Alder" has created and verified profile for randomly selected company "Y"

      When "Peter Alder" attempts to upload a file of unsupported type as company's logo
        | file                  | type                    |
        | Anfiteatro_El_Jem.bmp | Bitmap                  |
        | Anfiteatro_El_Jem.jp2 | JPEG 2000               |
        | Kobe_Port_Tower.webp  | Web P                   |
        | example.exe           | Windows executable file |
        | example.com           | Windows executable file |
        | example.sh            | Linux shell script      |
        | example.bat           | Windows shell script    |
        | example.txt           | text file               |

      Then for every uploaded unsupported file "Peter Alder" should be told that only certain image types can be used as company's logo
```