### PR TITLE
ED-1807 improve helpers

### DIFF
--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -396,7 +396,8 @@ def reg_confirm_export_status(context, supplier_alias, export_status):
     :param export_status: current Export Status of selected company
     :type export_status: str
     """
-    export_status = EXPORT_STATUSES[export_status]
+    if export_status in EXPORT_STATUSES:
+        export_status = EXPORT_STATUSES[export_status]
     context.export_status = export_status
     has_sso_account = context.get_actor(supplier_alias).has_sso_account
 

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -166,7 +166,7 @@ def select_random_company(context, supplier_alias, alias):
                             allow_redirects=True, context=context)
     html_escape_table = {"&": "&amp;", "'": "&#39;"}
     escaped_company_title = "".join(html_escape_table.get(c, c) for c in
-                                    company.title.upper())
+                                    company.title).upper().strip()
     expected = ["Create your company’s profile", escaped_company_title,
                 company.number]
     check_response(response, 200, body_contains=expected)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -166,7 +166,7 @@ def select_random_company(context, supplier_alias, alias):
                             allow_redirects=True, context=context)
     html_escape_table = {"&": "&amp;", "'": "&#39;"}
     escaped_company_title = "".join(html_escape_table.get(c, c) for c in
-                                    company.title).upper().strip()
+                                    company.title.upper()).strip()
     expected = ["Create your company’s profile", escaped_company_title,
                 company.number]
     check_response(response, 200, body_contains=expected)

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -349,24 +349,19 @@ def check_response(response: Response, status_code: int, *,
                                present in the response content
     :type  unexpected_strings: list
     """
-    assert response.status_code == status_code, (
-        "Expected {} but got {}".format(status_code, response.status_code))
+    assert response.status_code == status_code
 
     if body_contains:
         assert response.content, "Response has no content!"
         content = response.content.decode("utf-8")
-        assert all(s in content for s in body_contains), (
-            "Could not find all expected string in the response: {}"
-            .format(", ".join(body_contains))
-        )
+        for string in body_contains:
+            assert string in content
 
     if unexpected_strings:
         assert response.content, "Response has no content!"
         content = response.content.decode("utf-8")
-        assert all(s not in content for s in unexpected_strings), (
-            "Some of the unexpected strings were found in the response: {}"
-            .format(", ".join(unexpected_strings))
-        )
+        for string in unexpected_strings:
+            assert string in content
 
     if location:
         assert response.headers.get("Location") == location, (

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -407,8 +407,8 @@ def get_positive_exporting_status():
     :return: an exporting status accepted by Find a Buyer service
     :rtype: str
     """
-    with_export_intent = [EXPORT_STATUSES[s] for s in EXPORT_STATUSES if
-                          s != NO_EXPORT_INTENT_LABEL]
+    with_export_intent = [EXPORT_STATUSES[key] for key in EXPORT_STATUSES if
+                          key != NO_EXPORT_INTENT_LABEL]
     return random.choice(with_export_intent)
 
 

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -16,7 +16,7 @@ from tests.settings import (
     EXPORT_STATUSES,
     MAILGUN_EVENTS_URL,
     MAILGUN_SECRET_API_KEY,
-    NO_EXPORT_INTENT_LABEL,
+    NO_EXPORT_INTENT_LABEL
 )
 
 
@@ -388,8 +388,9 @@ def get_positive_exporting_status():
     :return: an exporting status accepted by Find a Buyer service
     :rtype: str
     """
-    EXPORT_STATUSES.pop(NO_EXPORT_INTENT_LABEL, 0)
-    return random.choice(list(EXPORT_STATUSES))
+    with_export_intent = [EXPORT_STATUSES[s] for s in EXPORT_STATUSES if
+                          s != NO_EXPORT_INTENT_LABEL]
+    return random.choice(with_export_intent)
 
 
 def get_absolute_path_of_file(filename):


### PR DESCRIPTION
Includes minor improvements to the common test code.

FYI: These `try, except` clauses around assertions, despite being a pretty ugly solution, they allow to nicely print out a custom assertion failure message and the traceback when we run the tests with  `--no-logcapture` mode on `CI`.