### PR TITLE
ED-1807 Final refactoring PR - use PO actions and assertions

### DIFF
--- a/tests/functional/features/fab/profile.feature
+++ b/tests/functional/features/fab/profile.feature
@@ -173,6 +173,7 @@ Feature: Trade Profile
         | keywords                    |
         | number of employees         |
         | sector of interest          |
+        | countries to export to      |
 
       Then "Annette Geissinger" should see new details on FAB Company's Directory Profile page
         | detail                      |
@@ -280,10 +281,10 @@ Feature: Trade Profile
       Given "Peter Alder" has created and verified profile for randomly selected company "Y"
 
       When "Peter Alder" attempts to use invalid links to online profiles
-        | online profile  |
-        | Facebook        |
-        | LinkedIn        |
-        | Twitter         |
+        | online profile  | invalid link           |
+        | Facebook        | http://notfacebook.com |
+        | LinkedIn        | http://notlinkedin.com |
+        | Twitter         | http://nottwitter.com  |
 
       Then "Peter Alder" should be told to provide valid links to all online profiles
 

--- a/tests/functional/features/pages/fab_ui_confirm_export_status.py
+++ b/tests/functional/features/pages/fab_ui_confirm_export_status.py
@@ -6,13 +6,11 @@ from requests import Response, Session
 
 from tests import get_absolute_url
 from tests.functional.features.utils import Method, check_response, make_request
-from tests.settings import EXPORT_STATUSES, NO_EXPORT_INTENT_LABEL
 
 EXPECTED_STRINGS = [
     "Your company's previous exports", "Confirm company", "Export status",
     "Have you exported before?",
     "Yes", "No", "I accept the", "Find a Buyer terms and conditions",
-    "To confirm that this is your company you must create a great.gov.uk account",
     "< Back to previous step", "Continue"
 ]
 
@@ -34,44 +32,22 @@ def should_be_here(response: Response):
     logging.debug("Supplier is on Confirm Export Status page")
 
 
-def submit_no_export_intent(session: Session, token: str) -> Response:
-    """Supplier decides that the company has no export intent.
+def submit(session: Session, token: str, exported: bool) -> Response:
+    """Submit the Export Status form.
 
     :param session: Supplier session object
     :param token: a CSRF token required to submit the form
+    :param exported: True is exported in the past, False if not
     :return: response object
     """
-    export_status = EXPORT_STATUSES[NO_EXPORT_INTENT_LABEL]
-
-    # Step 1: POST /register/exports
     url = get_absolute_url("ui-buyer:register-confirm-export-status")
     headers = {"Referer": url}
     data = {
         "csrfmiddlewaretoken": token,
         "enrolment_view-current_step": "exports",
-        "exports-export_status": export_status,
+        "exports-has_exported_before": exported,
         "exports-terms_agreed": "on"
     }
-    response = make_request(
-        Method.POST, url, session=session, headers=headers, data=data)
-    return response
-
-
-def submit(session: Session, token: str, export_status: str) -> Response:
-    """Submit the Export Status form.
-
-    :param session: Supplier session object
-    :param token: a CSRF token required to submit the form
-    :param export_status: any export status that allows Suppliers to create
-                          a Directory profile.
-    :return: response object
-    """
-    url = get_absolute_url("ui-buyer:register-confirm-export-status")
-    headers = {"Referer": url}
-    data = {"csrfmiddlewaretoken": token,
-            "enrolment_view-current_step": "exports",
-            "exports-export_status": export_status,
-            "exports-terms_agreed": "on"}
 
     response = make_request(
         Method.POST, url, session=session, headers=headers, data=data)

--- a/tests/functional/features/pages/fab_ui_edit_online_profiles.py
+++ b/tests/functional/features/pages/fab_ui_edit_online_profiles.py
@@ -4,11 +4,10 @@ import logging
 import random
 
 from faker import Factory
+from requests import Response, Session
 
 from tests import get_absolute_url
-from tests.functional.features.pages.utils import (
-    extract_and_set_csrf_middleware_token
-)
+from tests.functional.features.context_utils import Actor, Company
 from tests.functional.features.utils import Method, check_response, make_request
 
 URL = get_absolute_url("ui-buyer:company-edit-social-media")
@@ -25,53 +24,47 @@ EXPECTED_STRINGS = [
 FAKE = Factory.create()
 
 
-def should_be_here(response):
+def should_be_here(response: Response):
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on the Edit Online Profiles page")
 
 
-def go_to(context, supplier_alias):
+def go_to(session: Session) -> Response:
     """Go to "Edit Company's Online Profiles" page.
 
     This requires:
      * Supplier to be logged in
 
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
+    :param session: Supplier session object
+    :return: response object
     """
-    actor = context.get_actor(supplier_alias)
-    session = actor.session
-
     headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
-    response = make_request(Method.GET, URL, session=session, headers=headers,
-                            allow_redirects=False, context=context)
-
+    response = make_request(Method.GET, URL, session=session, headers=headers)
     should_be_here(response)
-    extract_and_set_csrf_middleware_token(context, response, supplier_alias)
-    logging.debug("%s is on the Edit Company's Online Profiles page",
-                  supplier_alias)
+    return response
 
 
 def update_profiles(
-        context, supplier_alias, *, facebook=True, linkedin=True, twitter=True,
-        specific_facebook=None, specific_linkedin=None, specific_twitter=None):
+        actor: Actor, company: Company, *, facebook=True, linkedin=True,
+        twitter=True, specific_facebook=None, specific_linkedin=None,
+        specific_twitter=None) -> (Response, Company):
     """Change Company's Sector of Interest.
 
     NOTE:
     If any of `specific_*` arguments is set to an empty string, then this will
     remove existing link.
 
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
+    :param actor: a namedtuple with Actor details
+    :param company: a namedtuple with Company details
     :param facebook: change Facebook URL if True, or use the current one if False
     :param linkedin: change LinkedIn URL if True, or use the current one if False
     :param twitter: change Twitter URL if True, or use the current one if False
     :param specific_facebook: use specific Facebook URL
     :param specific_linkedin: use specific LinkedIn URL
     :param specific_twitter: use specific Twitter URL
+    :return: a tuple consisting of a Response object & a namedtuple with Company
+             details used in the update request.
     """
-    actor = context.get_actor(supplier_alias)
-    company = context.get_company(actor.company_alias)
     session = actor.session
     token = actor.csrfmiddlewaretoken
 
@@ -95,96 +88,54 @@ def update_profiles(
         new_tw = company.twitter
 
     headers = {"Referer": URL}
-    data = {"csrfmiddlewaretoken": token,
-            "company_social_links_edit_view-current_step": "social",
-            "social-facebook_url": new_fb,
-            "social-linkedin_url": new_li,
-            "social-twitter_url": new_tw
-            }
+    data = {
+        "csrfmiddlewaretoken": token,
+        "company_social_links_edit_view-current_step": "social",
+        "social-facebook_url": new_fb,
+        "social-linkedin_url": new_li,
+        "social-twitter_url": new_tw
+    }
 
-    make_request(Method.POST, URL, session=session, headers=headers, data=data,
-                 allow_redirects=True, context=context)
+    new_details = Company(facebook=new_fb, linkedin=new_li, twitter=new_tw)
 
-    context.set_company_details(
-        company.alias, facebook=new_fb, linkedin=new_li, twitter=new_tw)
-    logging.debug(
-        "%s set Company's Online Profile links to: Facebook=%s, LinkedId=%s, "
-        "Twitter=%s", supplier_alias, new_fb, new_li, new_tw)
+    response = make_request(
+        Method.POST, URL, session=session, headers=headers, data=data)
 
-
-def update_profiles_w_invalid_urls(
-        context, supplier_alias, *, facebook=True, linkedin=True, twitter=True,
-        specific_facebook=None, specific_linkedin=None, specific_twitter=None):
-    """Try to change Company's Online profiled using invalid URLs.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :param facebook: change Facebook URL if True, or use the current one if False
-    :param linkedin: change LinkedIn URL if True, or use the current one if False
-    :param twitter: change Twitter URL if True, or use the current one if False
-    :param specific_facebook: use specific Facebook URL
-    :param specific_linkedin: use specific LinkedIn URL
-    :param specific_twitter: use specific Twitter URL
-    """
-    actor = context.get_actor(supplier_alias)
-    company = context.get_company(actor.company_alias)
-    session = actor.session
-    token = actor.csrfmiddlewaretoken
-
-    fake = "http://{}".format(FAKE.domain_name())
-    new_facebook = specific_facebook or fake if facebook else company.facebook
-    new_linkedin = specific_linkedin or fake if linkedin else company.linkedin
-    new_twitter = specific_twitter or fake if twitter else company.twitter
-
-    headers = {"Referer": URL}
-    data = {"csrfmiddlewaretoken": token,
-            "supplier_company_social_links_edit_view-current_step": "social",
-            "social-facebook_url": new_facebook,
-            "social-linkedin_url": new_linkedin,
-            "social-twitter_url": new_twitter
-            }
-
-    response = make_request(Method.POST, URL, session=session, headers=headers,
-                            data=data, allow_redirects=True, context=context)
-    # check whether we're still on the same page
-    should_be_here(response)
+    return response, new_details
 
 
-def should_see_errors(context, supplier_alias, *, facebook=True, linkedin=True,
-                      twitter=True):
+def should_see_errors(
+        response: Response, *, facebook=True, linkedin=True, twitter=True):
     """Check if all required errors are visible.
 
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
+    :param response: a Response object
     :param facebook: check for a Facebook URL error if True, or not if False
     :param linkedin: check for a LinkedIn URL error if True, or not if False
     :param twitter: check for a Twitter URL error if True, or not if False
     """
-    content = context.response.content.decode("utf-8")
+    content = response.content.decode("utf-8")
     if facebook:
         assert "Please provide a link to Facebook." in content
     if linkedin:
         assert "Please provide a link to LinkedIn." in content
     if twitter:
         assert "Please provide a link to Twitter." in content
-    logging.debug(
-        "%s was not able to set Company's Online Profile links using invalid "
-        "URLs to: %s %s %s", supplier_alias, "Facebook" if facebook else "",
-        "LinkedIn" if linkedin else "", "Twitter" if twitter else "")
 
 
 def remove_links(
-        context, supplier_alias, *, facebook=False, linkedin=False,
-        twitter=False):
+        actor: Actor, company: Company, *, facebook=False, linkedin=False,
+        twitter=False) -> Response:
     """Remove links to all existing Online Profiles.
 
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
+    :param actor: a namedtuple with Actor details
+    :param company: a namedtuple with Company details
     :param facebook: remove link to Facebook profile if True, or not if False
     :param linkedin: remove link to LinkedIn profile if True, or not if False
     :param twitter: remove link to Twitter profile if True, or not if False
+    :return: a Response object
     """
-    update_profiles(
-        context, supplier_alias, facebook=facebook, linkedin=linkedin,
+    response, _ = update_profiles(
+        actor, company, facebook=facebook, linkedin=linkedin,
         twitter=twitter, specific_facebook="", specific_linkedin="",
         specific_twitter="")
+    return response

--- a/tests/functional/features/steps/fab_given_def.py
+++ b/tests/functional/features/steps/fab_given_def.py
@@ -18,12 +18,11 @@ from tests.functional.features.steps.fab_then_impl import (
     sso_should_be_signed_in_to_sso_account
 )
 from tests.functional.features.steps.fab_when_impl import (
-    prof_add_invalid_online_profiles,
+    prof_add_online_profiles,
     prof_set_company_description,
     prof_sign_out_from_fab,
     prof_supplier_uploads_logo
 )
-from tests.settings import EMAIL_VERIFICATION_MSG_SUBJECT
 
 
 @given('"{supplier_alias}" is an unauthenticated supplier')
@@ -42,8 +41,7 @@ def given_supplier_created_sso_account_for_company(
 @given('"{alias}" received the email verification message with the email '
        'confirmation link')
 def given_supplier_received_verification_email(context, alias):
-    subject = EMAIL_VERIFICATION_MSG_SUBJECT
-    reg_should_get_verification_email(context, alias, subject)
+    reg_should_get_verification_email(context, alias)
 
 
 @given('"{supplier_alias}" confirmed her email address')
@@ -100,7 +98,7 @@ def given_supplier_selects_random_company(context, supplier_alias, company_alias
 
 @given('"{supplier_alias}" has added links to online profiles')
 def given_supplier_adds_valid_links_to_online_profiles(context, supplier_alias):
-    prof_add_invalid_online_profiles(context, supplier_alias, context.table)
+    prof_add_online_profiles(context, supplier_alias, context.table)
 
 
 @given('"{supplier_alias}" created an unverified profile for randomly selected '

--- a/tests/functional/features/steps/fab_given_impl.py
+++ b/tests/functional/features/steps/fab_given_impl.py
@@ -4,24 +4,24 @@ import random
 import string
 import uuid
 
+from behave.runner import Context
 from requests import Session
 
 from tests.functional.features.context_utils import Actor
+from tests.functional.features.pages import fab_ui_profile, profile_ui_landing
 from tests.functional.features.steps.fab_then_impl import (
     bp_should_be_prompted_to_build_your_profile,
     prof_should_be_on_profile_page,
     prof_should_be_told_about_missing_description,
-    prof_should_be_told_that_company_is_published,
     reg_should_get_verification_email,
     reg_sso_account_should_be_created,
-    sso_should_be_on_landing_page,
     sso_should_be_signed_in_to_sso_account
 )
 from tests.functional.features.steps.fab_when_impl import (
     bp_confirm_registration_and_send_letter,
     bp_provide_company_details,
     bp_provide_full_name,
-    bp_select_random_sector,
+    bp_select_random_sector_and_export_to_country,
     prof_set_company_description,
     prof_verify_company,
     reg_confirm_company_selection,
@@ -34,10 +34,9 @@ from tests.functional.features.steps.fab_when_impl import (
     sso_go_to_create_trade_profile,
     sso_supplier_confirms_email_address
 )
-from tests.settings import EMAIL_VERIFICATION_MSG_SUBJECT
 
 
-def unauthenticated_supplier(context, supplier_alias):
+def unauthenticated_supplier(context: Context, supplier_alias: str):
     """Create an instance of an unauthenticated Supplier Actor.
 
     Will:
@@ -51,9 +50,7 @@ def unauthenticated_supplier(context, supplier_alias):
     on AWS SES to store all incoming emails in plain text in S3.
 
     :param context: behave `context` object
-    :type context: behave.runner.Context
     :param supplier_alias: alias of the Actor used within the scenario's scope
-    :type supplier_alias: str
     """
     session = Session()
     email = ("test+{}{}@directory.uktrade.io"
@@ -62,46 +59,47 @@ def unauthenticated_supplier(context, supplier_alias):
     password_length = 10
     password = ''.join(random.choice(string.ascii_letters)
                        for _ in range(password_length))
-    actor = Actor(alias=supplier_alias, email=email, password=password,
-                  session=session, csrfmiddlewaretoken=None,
-                  email_confirmation_link=None, company_alias=None,
-                  has_sso_account=False)
+    actor = Actor(
+        alias=supplier_alias, email=email, password=password, session=session,
+        csrfmiddlewaretoken=None, email_confirmation_link=None,
+        company_alias=None, has_sso_account=False)
     context.add_actor(actor)
 
 
-def reg_create_sso_account_associated_with_company(context, supplier_alias,
-                                                   company_alias):
+def reg_create_sso_account_associated_with_company(
+        context: Context, supplier_alias: str, company_alias: str):
     select_random_company(context, supplier_alias, company_alias)
     reg_confirm_company_selection(context, supplier_alias, company_alias)
     reg_confirm_export_status(context, supplier_alias, exported=True)
     reg_create_sso_account(context, supplier_alias, company_alias)
-    reg_sso_account_should_be_created(context, supplier_alias)
+    reg_sso_account_should_be_created(context.response, supplier_alias)
+    context.set_actor_has_sso_account(supplier_alias, True)
 
 
-def reg_confirm_email_address(context, supplier_alias):
-    subject = EMAIL_VERIFICATION_MSG_SUBJECT
-    reg_should_get_verification_email(context, supplier_alias, subject)
+def reg_confirm_email_address(context: Context, supplier_alias: str):
+    reg_should_get_verification_email(context, supplier_alias)
     reg_open_email_confirmation_link(context, supplier_alias)
     reg_supplier_confirms_email_address(context, supplier_alias)
     bp_should_be_prompted_to_build_your_profile(context, supplier_alias)
 
 
-def bp_build_company_profile(context, supplier_alias):
+def bp_build_company_profile(context: Context, supplier_alias: str):
     bp_provide_company_details(context, supplier_alias)
-    bp_select_random_sector(context, supplier_alias)
+    bp_select_random_sector_and_export_to_country(context, supplier_alias)
     bp_provide_full_name(context, supplier_alias)
-    bp_confirm_registration_and_send_letter(context, supplier_alias)
-    prof_should_be_on_profile_page(context, supplier_alias)
-    prof_should_be_told_about_missing_description(context, supplier_alias)
+    response = bp_confirm_registration_and_send_letter(context, supplier_alias)
+    prof_should_be_on_profile_page(response, supplier_alias)
+    prof_should_be_told_about_missing_description(response, supplier_alias)
 
 
-def reg_create_verified_profile(context, supplier_alias, company_alias):
+def reg_create_verified_profile(
+        context: Context, supplier_alias: str, company_alias: str):
     # STEP 0 - initialize actor
     unauthenticated_supplier(context, supplier_alias)
 
     # STEP 1 - select company, create SSO profile & verify email address
-    reg_create_sso_account_associated_with_company(context, supplier_alias,
-                                                   company_alias)
+    reg_create_sso_account_associated_with_company(
+        context, supplier_alias, company_alias)
     reg_confirm_email_address(context, supplier_alias)
 
     # STEP 2 - build company profile after email verification
@@ -110,28 +108,29 @@ def reg_create_verified_profile(context, supplier_alias, company_alias):
     # STEP 3 - verify company with the code sent by post
     prof_set_company_description(context, supplier_alias)
     prof_verify_company(context, supplier_alias)
-    prof_should_be_on_profile_page(context, supplier_alias)
-    prof_should_be_told_that_company_is_published(context, supplier_alias)
+    prof_should_be_on_profile_page(context.response, supplier_alias)
+    fab_ui_profile.should_see_profile_is_verified(context.response)
 
 
-def sso_create_standalone_unverified_sso_account(context, supplier_alias):
-    subject = EMAIL_VERIFICATION_MSG_SUBJECT
+def sso_create_standalone_unverified_sso_account(
+        context: Context, supplier_alias: str):
     unauthenticated_supplier(context, supplier_alias)
     reg_create_standalone_sso_account(context, supplier_alias)
-    reg_sso_account_should_be_created(context, supplier_alias)
-    reg_should_get_verification_email(context, supplier_alias, subject)
+    reg_sso_account_should_be_created(context.response, supplier_alias)
+    reg_should_get_verification_email(context, supplier_alias)
 
 
-def sso_create_standalone_verified_sso_account(context, supplier_alias):
+def sso_create_standalone_verified_sso_account(
+        context: Context, supplier_alias: str):
     sso_create_standalone_unverified_sso_account(context, supplier_alias)
     reg_open_email_confirmation_link(context, supplier_alias)
     sso_supplier_confirms_email_address(context, supplier_alias)
-    sso_should_be_on_landing_page(context, supplier_alias)
+    profile_ui_landing.should_be_here(context.response)
     sso_should_be_signed_in_to_sso_account(context, supplier_alias)
 
 
 def reg_select_random_company_and_confirm_export_status(
-        context, supplier_alias, company_alias):
+        context: Context, supplier_alias: str, company_alias: str):
     sso_create_standalone_verified_sso_account(context, supplier_alias)
     sso_should_be_signed_in_to_sso_account(context, supplier_alias)
     sso_go_to_create_trade_profile(context, supplier_alias)

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -2,10 +2,15 @@
 """FAB Given step definitions."""
 from behave import then
 
-from tests.functional.features.pages import fab_ui_profile, fas_ui_profile
 from tests.functional.features.steps.fab_then_impl import (
     bp_should_be_prompted_to_build_your_profile,
+    fab_no_links_to_online_profiles_are_visible,
+    fab_profile_is_verified,
     fab_should_see_all_case_studies,
+    fab_should_see_company_details,
+    fab_should_see_online_profiles,
+    fas_check_profiles,
+    fas_no_links_to_online_profiles_are_visible,
     fas_should_be_on_profile_page,
     fas_should_see_all_case_studies,
     fas_should_see_logo_picture,
@@ -13,25 +18,24 @@ from tests.functional.features.steps.fab_then_impl import (
     prof_should_be_on_profile_page,
     prof_should_be_told_about_invalid_links,
     prof_should_be_told_about_missing_description,
-    prof_should_be_told_that_company_is_published,
     prof_should_see_logo_picture,
+    profile_supplier_should_be_on_landing_page,
     reg_should_get_verification_email,
     reg_sso_account_should_be_created,
     reg_supplier_has_to_verify_email_first,
     reg_supplier_is_not_appropriate_for_fab,
-    sso_should_be_on_landing_page,
     sso_should_be_signed_in_to_sso_account
 )
 
 
 @then('"{alias}" should be told about the verification email')
 def then_sso_account_was_created(context, alias):
-    reg_sso_account_should_be_created(context, alias)
+    reg_sso_account_should_be_created(context.response, alias)
 
 
 @then('"{alias}" should receive an email verification msg entitled "{subject}"')
 def then_supplier_should_receive_verification_email(context, alias, subject):
-    reg_should_get_verification_email(context, alias, subject)
+    reg_should_get_verification_email(context, alias)
 
 
 @then('"{supplier_alias}" should be prompted to Build and improve your '
@@ -43,19 +47,20 @@ def then_supplier_should_be_prompted_to_build_your_profile(
 
 @then('"{supplier_alias}" should be on edit Company\'s Directory Profile page')
 def then_supplier_should_be_on_profile_page(context, supplier_alias):
-    prof_should_be_on_profile_page(context, supplier_alias)
+    prof_should_be_on_profile_page(context.response, supplier_alias)
 
 
 @then('"{supplier_alias}" should be told that her company has no description')
 def then_supplier_should_be_told_about_missing_description(
         context, supplier_alias):
-    prof_should_be_told_about_missing_description(context, supplier_alias)
+    response = context.response
+    prof_should_be_told_about_missing_description(response, supplier_alias)
 
 
 @then('"{supplier_alias}" should be told that her company is published')
 def then_supplier_should_be_told_that_profile_is_published(
         context, supplier_alias):
-    prof_should_be_told_that_company_is_published(context, supplier_alias)
+    fab_profile_is_verified(context, supplier_alias)
 
 
 @then('"{supplier_alias}" should be on FAS Directory Profile page of company '
@@ -80,7 +85,7 @@ def then_supplier_has_to_verify_email_first(context, supplier_alias):
 @then('"{supplier_alias}" should be on Welcome to your great.gov.uk profile '
       'page')
 def then_supplier_should_be_on_profile_landing_page(context, supplier_alias):
-    sso_should_be_on_landing_page(context, supplier_alias)
+    profile_supplier_should_be_on_landing_page(context, supplier_alias)
 
 
 @then('"{supplier_alias}" should be signed in to SSO/great.gov.uk account')
@@ -91,20 +96,19 @@ def then_supplier_should_be_signed_in_to_sso_account(context, supplier_alias):
 @then('"{supplier_alias}" should see new details on FAB Company\'s Directory '
       'Profile page')
 def then_supplier_should_see_new_details(context, supplier_alias):
-    fab_ui_profile.should_see_details(context, supplier_alias, context.table)
+    fab_should_see_company_details(context, supplier_alias)
 
 
 @then('"{supplier_alias}" should see links to all online profiles on FAB '
       'Company\'s Directory Profile page')
 def then_supplier_should_see_online_profiles_on_fab(context, supplier_alias):
-    fab_ui_profile.should_see_online_profiles(context, supplier_alias)
+    fab_should_see_online_profiles(context, supplier_alias)
 
 
 @then('"{supplier_alias}" should see links to all online profiles on FAS '
       'Company\'s Directory Profile page')
 def then_supplier_should_see_online_profiles_on_fas(context, supplier_alias):
-    fas_ui_profile.go_to(context, supplier_alias)
-    fas_ui_profile.should_see_online_profiles(context, supplier_alias)
+    fas_check_profiles(context, supplier_alias)
 
 
 @then('"{supplier_alias}" should be told to provide valid links to all online '
@@ -116,13 +120,13 @@ def then_supplier_should_be_told_to_use_valid_links(context, supplier_alias):
 @then('"{supplier_alias}" should not see any links to online profiles on FAB '
       'Company\'s Directory Profile page')
 def then_no_online_profiles_are_visible_on_fab(context, supplier_alias):
-    fab_ui_profile.should_not_see_online_profiles(context, supplier_alias)
+    fab_no_links_to_online_profiles_are_visible(context, supplier_alias)
 
 
 @then('"{supplier_alias}" should not see any links to online profiles on FAS '
       'Company\'s Directory Profile page')
 def then_no_online_profiles_are_visible_on_fas(context, supplier_alias):
-    fas_ui_profile.should_not_see_online_profiles(context, supplier_alias)
+    fas_no_links_to_online_profiles_are_visible(context, supplier_alias)
 
 
 @then('"{supplier_alias}" should see all case studies on the FAB Company\'s '

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -2,61 +2,50 @@
 """FAB Given step definitions."""
 import logging
 
+from behave.runner import Context
+from requests import Response
 from retrying import retry
 
 from tests.functional.features.pages import (
+    fab_ui_build_profile_basic,
     fab_ui_edit_online_profiles,
     fab_ui_profile,
-    fas_ui_profile
+    fab_ui_try_other_services,
+    fas_ui_profile,
+    profile_ui_landing,
+    sso_ui_verify_your_email
 )
 from tests.functional.features.utils import (
     check_hash_of_remote_file,
-    check_response,
     extract_csrf_middleware_token,
     extract_logo_url,
     get_verification_link
 )
 
 
-def reg_sso_account_should_be_created(context, alias):
+def reg_sso_account_should_be_created(response: Response, supplier_alias: str):
     """Will verify if SSO account was successfully created.
 
+    Note:
     It's a very crude check, as it will only check if the response body
     contains selected phrases.
 
-    NOTE:
-    It expects that create SSO account response is stored in `context.response`
-
-    :param context: behave `context` object
-    :type context: behave.runner.Context
-    :param alias: alias of the Actor used in the scope of the scenario
-    :type alias: str
+    :param response: response object
+    :param supplier_alias: alias of the Actor used in the scope of the scenario
     """
-    response = context.response
-    msgs = ["Verify your email address",
-            "if you do not receive an email within 10 minutes",
-            ("We have sent you a confirmation email. Please follow the link"
-             " in the email to verify your email address.")]
-    content = response.content.decode("utf-8")
-    for msg in msgs:
-        err_msg = ("Could not find '{}' in the response".format(msg))
-        assert msg in content, err_msg
-    logging.debug("Successfully created new SSO account for %s", alias)
+    sso_ui_verify_your_email.should_be_here(response)
+    logging.debug("Successfully created new SSO account for %s", supplier_alias)
 
 
 @retry(wait_fixed=5000, stop_max_attempt_number=18)
-def reg_should_get_verification_email(context, alias, subject):
+def reg_should_get_verification_email(context: Context, alias: str):
     """Will check if the Supplier received an email verification message.
 
     NOTE:
     The check is done by attempting to find a file with the email is Amazon S3.
 
     :param context: behave `context` object
-    :type context: behave.runner.Context
     :param alias: alias of the Actor used in the scope of the scenario
-    :type alias: str
-    :param subject: expected subject of the email verification message
-    :type  subject: str
     """
     logging.debug("Searching for an email verification message...")
     actor = context.get_actor(alias)
@@ -64,132 +53,70 @@ def reg_should_get_verification_email(context, alias, subject):
     context.set_actor_email_confirmation_link(alias, link)
 
 
-def bp_should_be_prompted_to_build_your_profile(context, supplier_alias):
-    content = context.response.content.decode("utf-8")
-    assert "Build and improve your profile" in content
-    assert "To set up your Find a Buyer profile" in content
-    assert "Your company details" in content
-    assert "Company name" in content
-    assert "Website (optional)" in content
-    assert "Enter up to 10 keywords that describe your company" in content
-    assert "How many employees are in your company" in content
-    logging.debug("%s is on the 'Build and improve your profile' page",
-                  supplier_alias)
+def bp_should_be_prompted_to_build_your_profile(
+        context: Context, supplier_alias: str):
+    fab_ui_build_profile_basic.should_be_here(context.response)
+    logging.debug(
+        "%s is on the 'Build and improve your profile' page", supplier_alias)
     token = extract_csrf_middleware_token(context.response)
     context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
 
 
-def prof_should_be_on_profile_page(context, supplier_alias):
-    content = context.response.content.decode("utf-8")
-    assert "Facts &amp; details" in content
-    assert "Number of employees" in content
-    assert "Registration number" in content
-    assert "Company description" in content
-    assert "Online profiles" in content
-    assert "Recent projects" in content
-    assert "+ Add a case study" in content
-    assert "Sectors of interest" in content
-    assert "Keywords" in content
+def prof_should_be_on_profile_page(response: Response, supplier_alias: str):
+    fab_ui_profile.should_be_here(response)
     logging.debug("%s is on the company profile page", supplier_alias)
 
 
-def prof_should_be_told_about_missing_description(context, supplier_alias):
-    content = context.response.content.decode("utf-8")
-    assert "Your company has no description." in content
-    assert "Your profile can't be published until your company has a" in content
-    assert "Set your description" in content
-    logging.debug("%s was told that the company profile has no description",
-                  supplier_alias)
-
-
-def prof_should_be_told_that_company_is_not_verified_yet(context, supplier_alias):
-    content = context.response.content.decode("utf-8")
-    assert "Your company has not yet been verified." in content
-    assert "Your profile can't be published until your company is verified" in content
-    assert "Verify your company" in content
-    logging.debug("%s was told that the company is not verified yet",
-                  supplier_alias)
-
-
-def prof_should_be_told_that_company_is_published(context, supplier_alias):
-    content = context.response.content.decode("utf-8")
-    assert "Your company is published" in content
-    assert "Your profile is visible to international buyers" in content
-    assert "View published profile" in content
-    logging.debug("%s was told that the company profile is published",
-                  supplier_alias)
+def prof_should_be_told_about_missing_description(
+        response: Response, supplier_alias: str):
+    fab_ui_profile.should_see_missing_description(response)
+    logging.debug("%s was told about missing description", supplier_alias)
 
 
 def fas_should_be_on_profile_page(context, supplier_alias, company_alias):
-    content = context.response.content.decode("utf-8")
     actor = context.get_actor(supplier_alias)
     company = context.get_company(actor.company_alias)
-    assert "Contact" in content
-    assert "Company description" in content
-    assert "Facts &amp; details" in content
-    assert "Industries of interest" in content
-    assert "Keywords" in content
-    assert "Contact company" in content
-    assert company.number in content
-    assert company.summary in content
-    logging.debug("Supplier %s is on the %s company's FAS page",
-                  supplier_alias, company_alias)
+    fas_ui_profile.should_be_here(context.response, number=company.number)
+    logging.debug(
+        "%s is on the %s company's FAS page", supplier_alias, company_alias)
 
 
-def reg_supplier_is_not_appropriate_for_fab(context, supplier_alias):
-    expected = [
-        "Try our other business services",
-        "The Find a Buyer service promotes companies that are currently "
-        "exporting or looking to export in the near future. The answers you "
-        "gave suggest that your company is currently not appropriate to feature"
-        " in the Find a Buyer service.",
-        "Exporting is GREAT advice for new exporters"
-    ]
-    check_response(context.response, 200, body_contains=expected)
+def fas_check_profiles(context: Context, supplier_alias: str):
+    actor = context.get_actor(supplier_alias)
+    company = context.get_company(actor.company_alias)
+    # Step 1 - go to company's profile page on FAS
+    response = fas_ui_profile.go_to(actor.session, company.number)
+    context.response = response
+    # Step 2 - check if links to online profile are visible
+    fas_ui_profile.should_see_online_profiles(company, response)
+    logging.debug("%s can see all expected links to Online Profiles on "
+                  "FAS Company's Directory Profile Page", supplier_alias)
+
+
+def reg_supplier_is_not_appropriate_for_fab(
+        context: Context, supplier_alias: str):
+    fab_ui_try_other_services.should_be_here(context.response)
     logging.debug("%s was told that her/his business is not appropriate "
                   "to feature in the Find a Buyer service", supplier_alias)
 
 
-def reg_supplier_has_to_verify_email_first(context, supplier_alias):
-    expected = ["Verify your email address",
-                ("We have sent you a confirmation email. Please follow the link"
-                 " in the email to verify your email address."),
-                "if you do not receive an email within 10 minutes."]
-    check_response(context.response, 200, body_contains=expected)
+def reg_supplier_has_to_verify_email_first(
+        context: Context, supplier_alias: str):
+    sso_ui_verify_your_email.should_be_here(context.response)
     logging.debug("%s was told that her/his email address has to be verified "
                   "first before being able to Sign In", supplier_alias)
 
 
-def sso_should_be_on_landing_page(context, supplier_alias):
-    expected = ["Welcome to your great.gov.uk profile",
-                ("From now on, every time you sign in you’ll be able to quickly"
-                 " access all of our exporting tools in one place. The tools "
-                 "are here to help your business succeed internationally."),
-                ("You can start using any of our exporting tools by clicking "
-                 "on the tabs on your profile."), "Export opportunities",
-                "Find a buyer", "Selling online overseas",
-                ("Find thousands of exporting opportunities, search and apply "
-                 "within your industry or a specific country, and sign up for "
-                 "email alerts so you’re the first to know of new "
-                 "opportunities."),
-                ("Promote your business to overseas buyers with your own trade "
-                 "profile, add case studies of your company’s best work, and "
-                 "let buyers contact your sales team directly."),
-                ("Join major online marketplaces in other countries and access"
-                 " special offers negotiated by the Department for "
-                 "International Trade.")]
-    check_response(context.response, 200, body_contains=expected)
-    logging.debug("%s is on the SSO Profile landing page", supplier_alias)
-
-
-def sso_should_be_signed_in_to_sso_account(context, supplier_alias):
+def sso_should_be_signed_in_to_sso_account(
+        context: Context, supplier_alias: str):
     response = context.response
     assert response.cookies.get("sessionid") is not None
     assert "Sign out" in response.content.decode("utf-8")
     logging.debug("%s is logged in to the SSO account".format(supplier_alias))
 
 
-def prof_should_be_told_about_invalid_links(context, supplier_alias):
+def prof_should_be_told_about_invalid_links(
+        context: Context, supplier_alias: str):
     actor = context.get_actor(supplier_alias)
     company = context.get_company(actor.company_alias)
 
@@ -198,30 +125,44 @@ def prof_should_be_told_about_invalid_links(context, supplier_alias):
     twitter = True if company.twitter else False
 
     fab_ui_edit_online_profiles.should_see_errors(
-        context, supplier_alias, facebook=facebook, linkedin=linkedin,
+        context.response, facebook=facebook, linkedin=linkedin,
         twitter=twitter)
+    logging.debug(
+        "%s was not able to set Company's Online Profile links using invalid "
+        "URLs to: %s %s %s", supplier_alias, "Facebook" if facebook else "",
+        "LinkedIn" if linkedin else "", "Twitter" if twitter else "")
 
 
-def fab_should_see_all_case_studies(context, supplier_alias):
+def fab_should_see_all_case_studies(context: Context, supplier_alias: str):
+    """Check if Supplier can see all case studies on FAB profile page.
+
+    :param context: behave `context` object
+    :param supplier_alias: alias of the Actor used in the scope of the scenario
+    """
     actor = context.get_actor(supplier_alias)
     case_studies = context.get_company(actor.company_alias).case_studies
     fab_ui_profile.should_see_case_studies(case_studies, context.response)
 
 
-def fas_should_see_all_case_studies(context, supplier_alias):
+def fas_should_see_all_case_studies(context: Context, supplier_alias: str):
+    """Check if Supplier can see all case studies on FAS profile page.
+
+    :param context: behave `context` object
+    :param supplier_alias: alias of the Actor used in the scope of the scenario
+    """
     actor = context.get_actor(supplier_alias)
     case_studies = context.get_company(actor.company_alias).case_studies
     fas_ui_profile.should_see_case_studies(case_studies, context.response)
+    logging.debug("%s can see all %d Case Studies on FAS Company's "
+                  "Directory Profile Page", supplier_alias, len(case_studies))
 
 
-def prof_should_see_logo_picture(context, supplier_alias):
+def prof_should_see_logo_picture(context: Context, supplier_alias: str):
     """Will check if Company's Logo visible on FAB profile page is the same as
     the uploaded one.
 
     :param context: behave `context` object
-    :type context: behave.runner.Context
     :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
     """
     actor = context.get_actor(supplier_alias)
     company = context.get_company(actor.company_alias)
@@ -236,28 +177,23 @@ def prof_should_see_logo_picture(context, supplier_alias):
                   "as uploaded %s", company.title, logo_picture)
 
 
-def fas_should_see_logo_picture(context, supplier_alias):
+def fas_should_see_logo_picture(context: Context, supplier_alias: str):
     """Will check if Company's Logo visible on FAS profile page is the same as
     the one uploaded on FAB.
 
     :param context: behave `context` object
-    :type context: behave.runner.Context
     :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
     """
     actor = context.get_actor(supplier_alias)
+    session = actor.session
     company = context.get_company(actor.company_alias)
     logo_hash = company.logo_hash
     logo_url = company.logo_url
     logo_picture = company.logo_picture
 
-    # had to do an inline import as there was a problem with circular imports
-    from tests.functional.features.steps.fab_when_impl import (
-        prof_view_published_profile
-    )
-    # Go to the FAS profile page & extract the URL of visible logo image
-    prof_view_published_profile(context, supplier_alias)
-    response = context.response
+    # Step 1 - Go to the FAS profile page & extract URL of visible logo image
+    response = fas_ui_profile.go_to(session, company.number)
+    context.response = response
     visible_logo_url = extract_logo_url(response)
 
     # Check if FAS shows the correct Logo image
@@ -269,7 +205,8 @@ def fas_should_see_logo_picture(context, supplier_alias):
                   "as uploaded %s", company.title, logo_picture)
 
 
-def prof_all_unsupported_files_should_be_rejected(context, supplier_alias):
+def prof_all_unsupported_files_should_be_rejected(
+        context: Context, supplier_alias: str):
     """Check if all unsupported files were rejected upon upload as company logo.
 
     NOTE:
@@ -277,9 +214,7 @@ def prof_all_unsupported_files_should_be_rejected(context, supplier_alias):
     It should be a list of bool values.
 
     :param context: behave `context` object
-    :type context: behave.runner.Context
     :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
     """
     assert hasattr(context, "rejections")
     assert all(context.rejections), (
@@ -287,3 +222,80 @@ def prof_all_unsupported_files_should_be_rejected(context, supplier_alias):
         "actually accepted. Please check the logs for more details")
     logging.debug("All files of unsupported types uploaded by %s were rejected"
                   .format(supplier_alias))
+
+
+def fab_should_see_online_profiles(context: Context, supplier_alias: str):
+    """Check if Supplier can see all online Profiles on FAB Profile page.
+
+    :param context: behave `context` object
+    :param supplier_alias: alias of the Actor used in the scope of the scenario
+    """
+    actor = context.get_actor(supplier_alias)
+    company = context.get_company(actor.company_alias)
+    response = context.response
+    fab_ui_profile.should_see_online_profiles(company, response)
+
+
+def fab_no_links_to_online_profiles_are_visible(
+        context: Context, supplier_alias: str):
+    """Supplier should't see any links to Online Profiles on FAB Profile page.
+
+    :param context: behave `context` object
+    :param supplier_alias: alias of the Actor used in the scope of the scenario
+    """
+    response = context.response
+    fab_ui_profile.should_not_see_online_profiles(response)
+    logging.debug(
+        "%s cannot see links to Online Profiles on FAB Profile page",
+        supplier_alias)
+
+
+def fas_no_links_to_online_profiles_are_visible(
+        context: Context, supplier_alias: str):
+    """Supplier should't see any links to Online Profiles on FAS Profile page.
+
+    :param context: behave `context` object
+    :param supplier_alias: alias of the Actor used in the scope of the scenario
+    """
+    response = context.response
+    fas_ui_profile.should_not_see_online_profiles(response)
+    logging.debug(
+        "%s cannot see links to Online Profiles on FAS Profile page",
+        supplier_alias)
+
+
+def fab_profile_is_verified(context: Context, supplier_alias: str):
+    """Check if Supplier was told that Company's profile is verified.
+
+    :param context: behave `context` object
+    :param supplier_alias: alias of the Actor used in the scope of the scenario
+    """
+    response = context.response
+    fab_ui_profile.should_see_profile_is_verified(response)
+    logging.debug("%s was told that the profile is verified.", supplier_alias)
+
+
+def fab_should_see_company_details(context: Context, supplier_alias: str):
+    """Supplier should see all expected Company details of FAB profile page.
+
+    :param context: behave `context` object
+    :param supplier_alias: alias of the Actor used in the scope of the scenario
+    """
+    actor = context.get_actor(supplier_alias)
+    company = context.get_company(actor.company_alias)
+    response = context.response
+    fab_ui_profile.should_see_details(company, response, context.table)
+    logging.debug("%s can see all expected details are visible of FAB "
+                  "Company's Directory Profile Page", supplier_alias)
+
+
+def profile_supplier_should_be_on_landing_page(
+        context: Context, supplier_alias: str):
+    """Check if Supplier is on Profile Landing page.
+
+    :param context: behave `context` object
+    :param supplier_alias: alias of the Actor used in the scope of the scenario
+    """
+    response = context.response
+    profile_ui_landing.should_be_here(response)
+    logging.debug("%s got to the SSO landing page.", supplier_alias)

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -6,16 +6,16 @@ from tests.functional.features.steps.fab_when_impl import (
     bp_confirm_registration_and_send_letter,
     bp_provide_company_details,
     bp_provide_full_name,
-    bp_select_random_sector,
+    bp_select_random_sector_and_export_to_country,
     prof_add_case_study,
     prof_add_invalid_online_profiles,
     prof_add_online_profiles,
     prof_attempt_to_sign_in_to_fab,
     prof_remove_links_to_online_profiles,
-    prof_to_upload_unsupported_logos,
     prof_sign_in_to_fab,
-    prof_update_company_details,
     prof_supplier_uploads_logo,
+    prof_to_upload_unsupported_logos,
+    prof_update_company_details,
     prof_verify_company,
     prof_view_published_profile,
     reg_confirm_company_selection,
@@ -84,7 +84,7 @@ def when_supplier_provides_company_details(context, supplier_alias):
 @when('"{supplier_alias}" selects sector the company is in and preferred '
       'country of export')
 def when_supplier_selects_random_sector(context, supplier_alias):
-    bp_select_random_sector(context, supplier_alias)
+    bp_select_random_sector_and_export_to_country(context, supplier_alias)
 
 
 @when('"{supplier_alias}" provides her full name which will be used to sent '

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -2,141 +2,61 @@
 """FAB Given step implementations."""
 import logging
 import random
-from urllib.parse import quote, unquote
 
-from behave.runner import Context
 from behave.model import Table
+from behave.runner import Context
 from faker import Factory
-from jsonschema import validate
-from requests.models import Response
-from scrapy.selector import Selector
+from requests import Response
 
-from tests import get_absolute_url
-from tests.functional.features.context_utils import Company
 from tests.functional.features.pages import (
+    fab_ui_build_profile_address,
+    fab_ui_build_profile_basic,
+    fab_ui_build_profile_confirm,
+    fab_ui_build_profile_sector,
+    fab_ui_build_profile_verification_letter,
     fab_ui_case_study_basic,
     fab_ui_case_study_images,
+    fab_ui_confirm_company,
+    fab_ui_confirm_export_status,
+    fab_ui_edit_description,
     fab_ui_edit_details,
     fab_ui_edit_online_profiles,
     fab_ui_edit_sector,
-    fab_ui_profile
+    fab_ui_landing,
+    fab_ui_profile,
+    fab_ui_upload_logo,
+    fab_ui_verify_company,
+    fas_ui_profile,
+    profile_ui_find_a_buyer,
+    profile_ui_landing,
+    sso_ui_confim_your_email,
+    sso_ui_login,
+    sso_ui_logout,
+    sso_ui_register,
+    sso_ui_verify_your_email
 )
 from tests.functional.features.pages.common import DETAILS, PROFILES
-from tests.functional.features.pages.utils import random_case_study_data
-from tests.functional.features.steps.fab_then_impl import (
-    prof_should_be_on_profile_page,
-    prof_should_be_told_that_company_is_not_verified_yet,
-    prof_should_be_told_that_company_is_published
+from tests.functional.features.pages.utils import (
+    extract_and_set_csrf_middleware_token,
+    find_active_company_without_fas_profile,
+    random_case_study_data
 )
 from tests.functional.features.utils import (
-    Method,
     check_response,
     extract_confirm_email_form_action,
     extract_csrf_middleware_token,
     extract_logo_url,
     get_absolute_path_of_file,
     get_md5_hash_of_file,
-    get_verification_code,
-    make_request
+    get_verification_code
 )
-from tests.functional.schemas.Companies import COMPANIES
 from tests.settings import NO_OF_EMPLOYEES, SECTORS, COUNTRIES
 
-
-def has_fas_profile(company_number):
-    """Will check if company has an active FAS profile.
-
-    It will do it by calling FAS /suppliers/{} UI endpoint. This endpoint
-    returns:
-     - 404 Not Found when there's no profile for selected company
-     - and 301 with Location header pointing at the profile page
-
-    :param company_number: Companies House number (8 digit long number padded
-                                                   with zeroes)
-    :type: str
-    :return: True/False based on the presence of FAS profile
-    :rtype bool
-    """
-    endpoint = get_absolute_url('ui-supplier:suppliers')
-    url = "{}/{}".format(endpoint, company_number)
-    response = make_request(Method.GET, url, allow_redirects=False)
-    return response.status_code == 301
+FAKE = Factory.create()
 
 
-def search_company_house(term):
-    """Will search for companies using provided term.
-
-    NOTE:
-    This will validate the response data against appropriate JSON Schema.
-
-    :param term: search term, can be: company name or number, keywords etc.
-    :type term: str
-    :return: a tuple consisting of raw Requests response & response JSON
-    :rtype: tuple
-    """
-    url = get_absolute_url('internal-api:companies-house-search')
-    params = {"term": term}
-    response = make_request(Method.GET, url, params=params,
-                            allow_redirects=False)
-    assert response.status_code == 200, (
-        "Expected 200 but got {}. In case you're getting 301 Redirect then "
-        "check if you're using correct protocol https or http"
-        .format(response.status_code))
-    json = response.json()
-    logging.debug("Company House Search result: %s", json)
-    validate(json, COMPANIES)
-    return response, response.json()
-
-
-def find_active_company_without_fas_profile(alias):
-    """Will find an active company without a FAS profile.
-
-    :param alias: alias that will be given to the found company
-    :return: an Company named tuple
-    :rtype: test.functional.features.ScenarioData.Company
-    """
-    has_profile = True
-    exists = False
-    active = False
-    counter = 1
-    while has_profile and not exists and not active:
-        random_company_number = str(random.randint(0, 9999999)).zfill(8)
-        has_profile = has_fas_profile(random_company_number)
-        logging.debug("Found a company without a FAS profile: %s. Getting "
-                      "it details...", random_company_number)
-
-        _, json = search_company_house(random_company_number)
-
-        if len(json) == 1:
-            exists = True
-            if json[0]["company_status"] == "active":
-                active = True
-                assert json[0]["company_number"] == random_company_number, (
-                    "Expected to get details of company no.: %s but got %s",
-                    random_company_number, json[0]["company_number"])
-            else:
-                counter += 1
-                has_profile, exists, active = True, False, False
-                logging.debug("Company with number %s is not active. It's %s. "
-                              "Trying a different one...",
-                              random_company_number, json[0]["company_status"])
-        else:
-            counter += 1
-            has_profile, exists, active = True, False, False
-            logging.debug("Company with number %s does not exist. Trying a "
-                          "different one...", random_company_number)
-
-    logging.debug("It took %s attempt(s) to find an active Company without a "
-                  "FAS profile: %s - %s", counter, json[0]["title"],
-                  json[0]["company_number"])
-    company = Company(
-        alias=alias, title=json[0]["title"].strip(),
-        number=json[0]["company_number"], companies_house_details=json[0],
-        case_studies={})
-    return company
-
-
-def select_random_company(context, supplier_alias, alias):
+def select_random_company(
+        context: Context, supplier_alias: str, company_alias: str):
     """Will try to find an active company that doesn't have a FAS profile.
 
     Steps (repeat until successful):
@@ -148,139 +68,62 @@ def select_random_company(context, supplier_alias, alias):
         context.scenario_data.unregistered_companies[]
 
     :param context: behave `context` object
-    :type context: behave.runner.Context
     :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
-    :param alias: alias of the company used in the scope of the scenario
-    :type alias: str
+    :param company_alias: alias of the company used in the scope of the scenario
     """
-    company = find_active_company_without_fas_profile(alias)
+    actor = context.get_actor(supplier_alias)
+    session = actor.session
+
+    # Step 1 - find an active company without a FAS profile
+    company = find_active_company_without_fas_profile(company_alias)
+
+    # Step 2 - Go to the Confirm Company page
+    response = fab_ui_confirm_company.go_to(session, company)
+    context.response = response
+
+    # Step 3 - check if we're on the Confirm Company page
+    fab_ui_confirm_company.should_be_here(response, company)
+
+    # Step 4 - store Company, CSRF token & associate Actor with Company
     context.add_company(company)
-
-    # Once we have company's details, we can select it for registration
-    session = context.get_actor(supplier_alias).session
-    url = get_absolute_url('ui-buyer:landing')
-    data = {"company_name": company.title, "company_number": company.number}
-    response = make_request(Method.POST, url, session=session,
-                            headers={"Referer": url}, data=data,
-                            allow_redirects=True, context=context)
-    html_escape_table = {"&": "&amp;", "'": "&#39;"}
-    escaped_company_title = "".join(html_escape_table.get(c, c) for c in
-                                    company.title.upper()).strip()
-    expected = ["Create your company’s profile", escaped_company_title,
-                company.number]
-    check_response(response, 200, body_contains=expected)
-    logging.debug("Successfully got to the Confirm your Company page")
-
     token = extract_csrf_middleware_token(response)
     context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
-    context.set_company_for_actor(supplier_alias, alias)
+    context.set_company_for_actor(supplier_alias, company_alias)
 
 
-def reg_confirm_company_selection(context, supplier_alias, alias):
+def reg_confirm_company_selection(
+        context: Context, supplier_alias: str, company_alias: str):
     """Will confirm that the selected company is the right one.
 
     :param context: behave `context` object
-    :type context: behave.runner.Context
     :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
-    :param alias: alias of the company used in the scope of the scenario
-    :type alias: str
+    :param company_alias: alias of the company used in the scope of the scenario
     """
     actor = context.get_actor(supplier_alias)
     token = actor.csrfmiddlewaretoken
+    has_sso_account = actor.has_sso_account
     session = actor.session
-    company = context.get_company(alias)
-    url = ("{}?company_number={}"
-           .format(get_absolute_url('ui-buyer:register-confirm-company'),
-                   company.number))
-    headers = {"Referer": url}
-    data = {"csrfmiddlewaretoken": token,
-            "enrolment_view-current_step": "company",
-            "company-company_name": company.title,
-            "company-company_number": company.number,
-            "company-company_address":
-                company.companies_house_details["address_snippet"]}
+    company = context.get_company(company_alias)
 
-    response = make_request(Method.POST, url, session=session, headers=headers,
-                            data=data, allow_redirects=False, context=context)
-    check_response(response, 302, location="/register/exports")
+    # Step 1 - confirm the selection of the company
+    response = fab_ui_confirm_company.confirm_company_selection(
+        session, company, token)
+    context.response = response
+
+    # Step 2 - check if we're on the Confirm Export Status page
+    fab_ui_confirm_export_status.should_be_here(response)
+    if not has_sso_account:
+        fab_ui_confirm_export_status.should_see_info_about_sso_account(response)
+
     logging.debug("Confirmed selection of Company: %s", company.number)
 
-    # Once on the "Confirm Company" page, we have to go to the
-    # "Confirm Export Status" page with "Referer" header set to this page
-    url_export = get_absolute_url('ui-buyer:register-confirm-export-status')
-    headers = {"Referer": url}
-    response = make_request(Method.GET, url_export, session=session,
-                            headers=headers, context=context)
-    expected = ["Your company's previous exports"]
-    check_response(response, 200, body_contains=expected)
-    logging.debug("Confirmed selection of Company: %s", company.number)
-
-    # Now, we've landed on the Export Status page, so we have extract the
-    # csrfmiddlewaretoken from the response content
+    # Step 3 - extract & store CSRF token
     token = extract_csrf_middleware_token(response)
     context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
 
 
-def submit_export_status_form(context, supplier_alias, exported):
-    """Submit the Export Status form.
-
-    NOTE:
-    This won't run any assertions once the last request is made, it's because
-    that there are 2 possible results depending whether Supplier already has
-    a SSO/great.gov.uk account or not.
-    Moreover the last response will be stored in `context.response`, which can
-    be used in further verification.
-
-    :param context: behave `context` object
-    :type  context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type  supplier_alias: str
-    :param exported: has the company exported or not in the past
-    :type  exported: bool
-    """
-    actor = context.get_actor(supplier_alias)
-    company = context.get_company(actor.company_alias)
-    session = actor.session
-    token = actor.csrfmiddlewaretoken
-    referer = get_absolute_url("ui-buyer:register-confirm-export-status")
-
-    # Step 1: POST /register/exports
-    url = get_absolute_url("ui-buyer:register-confirm-export-status")
-    headers = {"Referer": referer}
-    data = {"csrfmiddlewaretoken": token,
-            "enrolment_view-current_step": "exports",
-            "exports-has_exported_before": exported,
-            "exports-terms_agreed": "on"}
-    response = make_request(Method.POST, url, session=session, headers=headers,
-                            data=data, allow_redirects=False, context=context)
-    check_response(response, 302, location="/register/finished")
-
-    # Step 2: GET /register/finished
-    url = get_absolute_url("ui-buyer:register-finish")
-    headers = {"Referer": referer}
-    response = make_request(Method.GET, url, session=session, headers=headers,
-                            allow_redirects=False, context=context)
-    location = ("/register-submit?company_number={}&has_exported_before={}"
-                .format(company.number, exported))
-    check_response(response, 302, location=location)
-
-    # Step 3: GET /register-submit?company_number={}&has_exported_before={}
-    url = get_absolute_url("ui-buyer:register-submit-account-details")
-    params = {"company_number": company.number,
-              "has_exported_before": exported}
-    headers = {"Referer": referer}
-    make_request(Method.GET, url, session=session, params=params,
-                 headers=headers, allow_redirects=False, context=context)
-
-
-def supplier_should_get_to_build_your_profile(context, supplier_alias):
-    """Assert last response based on the fact that Supplier has
-    a SSO/great.gov.uk account
-
-    NOTE:
-    Will use `context.response` to assert the contents of last response.
+def reg_supplier_is_not_ready_to_export(context, supplier_alias):
+    """Supplier decides that her/his company is not ready to export.
 
     :param context: behave `context` object
     :type context: behave.runner.Context
@@ -288,98 +131,41 @@ def supplier_should_get_to_build_your_profile(context, supplier_alias):
     :type supplier_alias: str
     """
     actor = context.get_actor(supplier_alias)
-    company_alias = actor.company_alias
     session = actor.session
-    response = context.response
-    check_response(response, 302, location="/company-profile/edit")
-    assert response.cookies.get("sessionid") is not None
-    logging.debug("Confirmed Export Status of '%s'. We're now going to the "
-                  "FAB edit company profile page.", company_alias)
+    token = actor.csrfmiddlewaretoken
 
-    # GET FAB /company-profile/edit
-    url = get_absolute_url("ui-buyer:company-edit")
-    headers = {
-        "Referer":
-            get_absolute_url("ui-buyer:register-confirm-export-status")
-    }
-    response = make_request(Method.GET, url, session=session,
-                            headers=headers, context=context)
-    expected = ["Build and improve your profile"]
-    check_response(response, 200, body_contains=expected)
-    logging.debug("Successfully got to Build your Profile page")
+    # Step 1 - Submit the form with No Intention to Export
+    response = fab_ui_confirm_export_status.submit(session, token, exported=False)
+
+    # Step 2 - store response & check it
+    context.response = response
+    check_response(response, 200)
 
 
-def supplier_should_get_to_sso_registration_page(
-        context, supplier_alias, exported):
-    """Assert last response based on the fact that Supplier doesn't have
-    a SSO/great.gov.uk account
-
-    NOTE:
-    Will use `context.response` to assert the contents of last response.
-
-    :param context: behave `context` object
-    :type  context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type  supplier_alias: str
-    :param exported: True if company has exported in the past and False if not
-    :type  exported: bool
-    """
-    actor = context.get_actor(supplier_alias)
-    company = context.get_company(actor.company_alias)
-    company_alias = actor.company_alias
-    session = actor.session
-    response = context.response
-    referer = get_absolute_url("ui-buyer:register-confirm-export-status")
-    url = get_absolute_url("ui-buyer:register-submit-account-details")
-    # assert last response based on the fact that Supplier doesn't have
-    # a SSO account
-    next_1 = quote("{}?has_exported_before={}&company_number={}"
-                   .format(url, exported, company.number))
-    location_1 = "{}?next={}".format(get_absolute_url("sso:signup"), next_1)
-    next_2 = quote("{}?company_number={}&has_exported_before={}"
-                   .format(url, company.number, exported))
-    location_2 = "{}?next={}".format(get_absolute_url("sso:signup"), next_2)
-    locations = [location_1, location_2]
-    check_response(response, 302, locations=locations)
-    logging.debug("Confirmed Export Status of '%s'. We're now going to the "
-                  "SSO signup page.", company_alias)
-
-    # GET SSO /accounts/signup/?next=...
-    url = get_absolute_url("sso:signup")
-    params = {"next": next_1}
-    headers = {"Referer": referer}
-    response = make_request(Method.GET, url, session=session, params=params,
-                            headers=headers, context=context)
-    expected = ["Create a great.gov.uk account and you can"]
-    check_response(response, 200, body_contains=expected)
-    logging.debug("Successfully landed on SSO signup page")
-
-    token = extract_csrf_middleware_token(response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
-
-
-def reg_confirm_export_status(context, supplier_alias, exported):
+def reg_confirm_export_status(context: Context, supplier_alias: str, exported: bool):
     """Will confirm the current export status of selected unregistered company.
 
     :param context: behave `context` object
-    :type context: behave.runner.Context
     :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
-    :param exported: current Export Status of selected company
-    :type exported: bool
+    :param exported: True is exported in the past, False if not
     """
+    actor = context.get_actor(supplier_alias)
+    has_sso_account = actor.has_sso_account
+    session = actor.session
+    token = actor.csrfmiddlewaretoken
     context.exported = exported
-    has_sso_account = context.get_actor(supplier_alias).has_sso_account
 
-    submit_export_status_form(context, supplier_alias, exported)
+    response = fab_ui_confirm_export_status.submit(session, token, exported)
+    context.response = response
 
     if has_sso_account:
         logging.debug("Supplier already has a SSO account")
-        supplier_should_get_to_build_your_profile(context, supplier_alias)
+        fab_ui_build_profile_basic.should_be_here(response)
     else:
         logging.debug("Supplier doesn't have a SSO account")
-        supplier_should_get_to_sso_registration_page(
-            context, supplier_alias, exported)
+        sso_ui_register.should_be_here(response)
+        token = extract_csrf_middleware_token(response)
+        context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
 
 
 def reg_create_sso_account(context, supplier_alias, alias):
@@ -397,34 +183,11 @@ def reg_create_sso_account(context, supplier_alias, alias):
     :type alias: str
     """
     actor = context.get_actor(supplier_alias)
-    session = actor.session
     company = context.get_company(alias)
     exported = context.exported
-    # Step 1: POST SSO accounts/signup/
-    next_url = get_absolute_url("ui-buyer:register-submit-account-details")
-    next_link = quote("{}?company_number={}&has_exported_before={}"
-                      .format(next_url, company.number, exported))
-    url_signup = get_absolute_url("sso:signup")
-    headers = {"Referer": "{}?next={}".format(url_signup,
-                                              next_link)}
-    data = {"csrfmiddlewaretoken": actor.csrfmiddlewaretoken,
-            "email": actor.email,
-            "email2": actor.email,
-            "password1": actor.password,
-            "password2": actor.password,
-            "terms_agreed": "on",
-            "next": next_link}
-    response = make_request(Method.POST, url_signup, session=session,
-                            headers=headers, data=data,
-                            allow_redirects=False, context=context)
-    check_response(response, 302, location="/accounts/confirm-email/")
 
-    # Steps 2: GET SSO /accounts/confirm-email/
-    url = get_absolute_url("sso:email_confirm")
-    response = make_request(Method.GET, url, session=session,
-                            headers=headers, allow_redirects=False,
-                            context=context)
-    check_response(response, 200)
+    # Submit SSO Registration form with Supplier's & Company's required details
+    context.response = sso_ui_register.submit(actor, company, exported)
 
 
 def reg_open_email_confirmation_link(context, supplier_alias):
@@ -438,16 +201,18 @@ def reg_open_email_confirmation_link(context, supplier_alias):
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
-    confirmation_link = actor.email_confirmation_link
-    assert confirmation_link, "Expected a non-empty email confirmation link"
-    response = make_request(Method.GET, confirmation_link, session=session,
-                            context=context)
-    expected = ["Confirm email Address"]
-    unexpected = ["This e-mail confirmation link expired or is invalid"]
-    check_response(response, 200, body_contains=expected,
-                   unexpected_strings=unexpected)
-    logging.debug("Supplier is on the Confirm your email address page")
+    link = actor.email_confirmation_link
 
+    # Step 1 - open confirmation link
+    response = sso_ui_confim_your_email.open_confirmation_link(session, link)
+    context.response = response
+
+    # Step 3 - confirm that Supplier is on SSO Confirm Your Email page
+    sso_ui_confim_your_email.should_be_here(response)
+    logging.debug("Supplier is on the SSO Confirm your email address page")
+
+    # Step 4 - extract & store CSRF token & form action value
+    # Form Action Value is required to successfully confirm email
     token = extract_csrf_middleware_token(response)
     context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
     form_action_value = extract_confirm_email_form_action(response)
@@ -463,46 +228,11 @@ def reg_supplier_confirms_email_address(context, supplier_alias):
     :param supplier_alias: alias of the Actor used in the scope of the scenario
     :type supplier_alias: str
     """
-    # STEP 1 - Submit "Confirm your email address" form
     actor = context.get_actor(supplier_alias)
-    session = actor.session
-    csrfmiddlewaretoken = actor.csrfmiddlewaretoken
     form_action_value = context.form_action_value
-    url = "{}{}".format(get_absolute_url("sso:landing"), form_action_value)
-    referer = actor.email_confirmation_link
-    headers = {"Referer": referer}
-    data = {"csrfmiddlewaretoken": csrfmiddlewaretoken}
-    response = make_request(Method.POST, url, session=session, headers=headers,
-                            data=data, allow_redirects=False, context=context)
-    new_location = response.headers.get("Location")
-    assert new_location.startswith("/accounts/login/?next=")
-    assert "register-submit%253Fcompany_number%253D" in new_location
-    check_response(response, 302)
 
-    # Step 2 - Follow redirect - go to SSO /accounts/login/
-    # use the same Referer as in previous request
-    headers = {"Referer": referer}
-    url = "{}{}".format(get_absolute_url("sso:landing"), new_location)
-    response = make_request(Method.GET, url, session=session, headers=headers,
-                            allow_redirects=False, context=context)
-    new_location = response.headers.get("Location")
-    register_submit = get_absolute_url("ui-buyer:register-submit-account-details")
-    assert new_location.startswith(quote(register_submit)), (
-        "Expected new Location to start with: '{}' but got '{}'"
-        .format(register_submit, new_location))
-    assert "company_number" in new_location
-    assert "has_exported_before" in new_location
-    check_response(response, 302)
-
-    # Step 3 - Follow redirect - go to DIR /company-profile/edit
-    # use the same Referer as in previous request
-    headers = {"Referer": referer}
-    url = unquote(new_location)
-    response = make_request(Method.GET, url, session=session, headers=headers,
-                            context=context)
-    expected = ["Build and improve your profile"]
-    check_response(response, 200, body_contains=expected)
-    context.set_actor_has_sso_account(supplier_alias, True)
+    response = sso_ui_confim_your_email.confirm(actor, form_action_value)
+    context.response = response
 
 
 def bp_provide_company_details(context, supplier_alias):
@@ -514,68 +244,34 @@ def bp_provide_company_details(context, supplier_alias):
     :param supplier_alias: alias of the Actor used in the scope of the scenario
     :type supplier_alias: str
     """
-    fake = Factory.create()
     actor = context.get_actor(supplier_alias)
     company = context.get_company(actor.company_alias)
-    session = actor.session
-    csrfmiddlewaretoken = actor.csrfmiddlewaretoken
-    url = get_absolute_url("ui-buyer:company-edit")
-    headers = {"Referer": url}
-    employees = random.choice(NO_OF_EMPLOYEES)
-    website = "https://{}".format(fake.domain_name())
-    keywords = ", ".join(fake.sentence().replace(".", "").split())
-    data = {"csrfmiddlewaretoken": csrfmiddlewaretoken,
-            "company_profile_edit_view-current_step": "basic",
-            "basic-name": company.title,
-            "basic-website": website,
-            "basic-keywords": keywords,
-            "basic-employees": employees}
-    response = make_request(Method.POST, url, session=session, headers=headers,
-                            data=data, allow_redirects=False, context=context)
-    expected = ["Your company sector", "What industry is your company in?"]
-    expected += SECTORS
-    check_response(response, 200, body_contains=expected)
+    company_alias = company.alias
+
+    # Step 0 - generate random details & update Company matching details
+    # Need to get Company details after updating it in the Scenario Data
+    size = random.choice(NO_OF_EMPLOYEES)
+    website = "https://{}".format(FAKE.domain_name())
+    keywords = ", ".join(FAKE.sentence().replace(".", "").split())
+    context.set_company_details(
+        company_alias, no_employees=size, website=website, keywords=keywords
+    )
+    company = context.get_company(actor.company_alias)
+
+    # Step 1 - submit the Basic details form
+    response = fab_ui_build_profile_basic.submit(actor, company)
+    context.response = response
+
+    # Step 2 - check if Supplier is on Select Your Sector page
+    fab_ui_build_profile_sector.should_be_here(response)
+
+    # Step 3 - extract CSRF token
     logging.debug("Supplier is on the Select Sector page")
     token = extract_csrf_middleware_token(response)
     context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
 
 
-def bp_extract_company_address_details(response: Response):
-    """Build Profile - extract company details from Your company address page
-
-    :param response: requests response
-    :type  response: requests.models.Response
-    :return: named tuple containing all extracted company details
-    """
-    assert response.content, "Response has no content"
-    content = response.content.decode("utf-8")
-
-    from collections import namedtuple
-
-    Details = namedtuple("Details", ["address_signature", "address_line_1",
-                                     "address_line_2", "locality", "country",
-                                     "postal_code", "po_box"])
-
-    def extract(selector):
-        res = Selector(text=content).css(selector).extract()
-        return res[0] if len(res) > 0 else ""
-
-    address_signature = extract("#id_address-signature::attr(value)")
-    address_line_1 = extract("#id_address-address_line_1::attr(value)")
-    address_line_2 = extract("#id_address-address_line_2::attr(value)")
-    locality = extract("#id_address-locality::attr(value)")
-    country = extract("#id_address-country::attr(value)")
-    postal_code = extract("#id_address-postal_code::attr(value)")
-    po_box = extract("#id_address-po_box::attr(value)")
-
-    details = Details(address_signature, address_line_1, address_line_2,
-                      locality, country, postal_code, po_box)
-
-    logging.debug("Extracted company details: %s", details)
-    return details
-
-
-def bp_select_random_sector(context, supplier_alias):
+def bp_select_random_sector_and_export_to_country(context, supplier_alias):
     """Build Profile - Randomly select one of available sectors our company is
     interested in working in.
 
@@ -589,32 +285,25 @@ def bp_select_random_sector(context, supplier_alias):
     :type supplier_alias: str
     """
     actor = context.get_actor(supplier_alias)
-    session = actor.session
-    csrfmiddlewaretoken = actor.csrfmiddlewaretoken
-    url = get_absolute_url("ui-buyer:company-edit")
-    headers = {"Referer": url}
     sector = random.choice(SECTORS)
     country = COUNTRIES[random.choice(list(COUNTRIES))]
     other = ""
-    data = {"csrfmiddlewaretoken": csrfmiddlewaretoken,
-            "company_profile_edit_view-current_step": "classification",
-            "classification-sectors": sector,
-            "classification-export_destinations": country,
-            "classification-export_destinations_other": other
-            }
-    response = make_request(Method.POST, url, session=session, headers=headers,
-                            data=data, allow_redirects=False, context=context)
-    expected = [
-        "We need to send a letter containing a verification code ",
-        "Your company address", "Full name", "Address line 1", "Address line 2",
-        "City", "Country", "Postcode", "PO box"
-    ]
-    check_response(response, 200, body_contains=expected)
+
+    # Step 1 - Submit the Choose Your Sector form
+    response = fab_ui_build_profile_sector.submit(actor, sector, country, other)
+    context.response = response
+
+    # Step 2 - check if Supplier is on Confirm Address page
+    fab_ui_build_profile_address.should_be_here(response)
     logging.debug("Supplier is on the Your company address page")
+
+    # Step 3 - extract & store CSRF token and company's address details
     token = extract_csrf_middleware_token(response)
     context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
-    details = bp_extract_company_address_details(response)
-    context.set_company_details(actor.company_alias, address_details=details)
+    details = fab_ui_build_profile_address.extract_address_details(response)
+    context.set_company_details(
+        actor.company_alias, address_details=details,
+        export_to_countries=country)
 
 
 def bp_provide_full_name(context, supplier_alias):
@@ -627,37 +316,23 @@ def bp_provide_full_name(context, supplier_alias):
     :type supplier_alias: str
     """
     actor = context.get_actor(supplier_alias)
-    company = context.get_company(actor.company_alias)
-    details = company.address_details
-    session = actor.session
-    csrfmiddlewaretoken = actor.csrfmiddlewaretoken
-    url = get_absolute_url("ui-buyer:company-edit")
-    headers = {"Referer": url}
-    data = {"csrfmiddlewaretoken": csrfmiddlewaretoken,
-            "company_profile_edit_view-current_step": "address",
-            "address-signature": details.address_signature,
-            "address-postal_full_name": actor.alias,
-            "address-address_line_1": details.address_line_1,
-            "address-address_line_2": details.address_line_2,
-            "address-locality": details.locality,
-            "address-country": details.country,
-            "address-postal_code": details.postal_code,
-            "address-po_box": details.po_box
-            }
-    response = make_request(Method.POST, url, session=session, headers=headers,
-                            data=data, allow_redirects=False, context=context)
-    expected = [
-        actor.alias, "Thank you",
-        "The letter will be sent to your registered business address",
-        "You can change the name of the person who will receive this letter",
-    ]
-    check_response(response, 200, body_contains=expected)
+    details = context.get_company(actor.company_alias).address_details
+
+    # Step 1 - Submit Supplier's Full Name
+    response = fab_ui_build_profile_address.submit(actor, details)
+    context.response = response
+
+    # Step 2 - check if Supplier is on Confirm page
+    fab_ui_build_profile_confirm.should_be_here(response)
     logging.debug("Supplier is on the Thank You page")
+
+    # Steps 3 - extract CSRF token
     token = extract_csrf_middleware_token(response)
     context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
 
 
-def bp_confirm_registration_and_send_letter(context, supplier_alias):
+def bp_confirm_registration_and_send_letter(
+        context: Context, supplier_alias: str) -> Response:
     """Build Profile - Supplier has to finally confirm registration and is
     informed about verification letter.
 
@@ -665,38 +340,30 @@ def bp_confirm_registration_and_send_letter(context, supplier_alias):
     :type context: behave.runner.Context
     :param supplier_alias: alias of the Actor used in the scope of the scenario
     :type supplier_alias: str
+    :return last response object -> FAB Profile page
     """
     # STEP 1 - Confirm registration
     actor = context.get_actor(supplier_alias)
     session = actor.session
-    csrfmiddlewaretoken = actor.csrfmiddlewaretoken
-    url = get_absolute_url("ui-buyer:company-edit")
-    headers = {"Referer": url}
-    data = {"csrfmiddlewaretoken": csrfmiddlewaretoken,
-            "company_profile_edit_view-current_step": "confirm"
-            }
-    response = make_request(Method.POST, url, session=session, headers=headers,
-                            data=data, allow_redirects=False, context=context)
-    msg = ("You should receive your verification letter within a week. When you"
-           " receive the letter, please log in to GREAT.gov.uk to enter your "
-           "verification profile to publish your company profile.")
-    expected = [msg, "We've sent your verification letter"]
-    check_response(response, 200, body_contains=expected)
-    logging.debug("Supplier is on the We've sent your verification letter page")
+    token = actor.csrfmiddlewaretoken
 
-    # STEP 2 - Click on the "View or amend your company profile" link
+    # Step 1 - Submit the Confirm form
+    response = fab_ui_build_profile_confirm.submit(session, token)
+    context.response = response
+
+    # Step 2 - check if Supplier is on the We've sent you a verification letter
+    fab_ui_build_profile_verification_letter.should_be_here(response)
+    logging.debug("Supplier is on the We've sent you verification letter page")
+
+    # STEP 3 - Click on the "View or amend your company profile" link
     # use previous url as the referer link
-    referer = url
-    url = get_absolute_url("ui-buyer:company-profile")
-    headers = {"Referer": referer}
-    response = make_request(Method.GET, url, session=session, headers=headers,
-                            allow_redirects=False, context=context)
-    expected = [
-        "Your company has no description.", "Set your description",
-        "Your profile can't be published until your company has a",
-    ]
-    check_response(response, 200, body_contains=expected)
-    logging.debug("Supplier is on the Edit Company Profile page")
+    response = fab_ui_build_profile_verification_letter.go_to_profile(session)
+    context.response = response
+
+    # Step 4 - check if Supplier is on the FAB profile page
+    fab_ui_profile.should_see_missing_description(response)
+
+    return response
 
 
 def prof_set_company_description(context, supplier_alias):
@@ -714,47 +381,29 @@ def prof_set_company_description(context, supplier_alias):
     :param supplier_alias: alias of the Actor used in the scope of the scenario
     :type supplier_alias: str
     """
-    # STEP 1 - go to the "Set Company Description" page
     actor = context.get_actor(supplier_alias)
     session = actor.session
-    url = get_absolute_url("ui-buyer:company-edit-description")
-    headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
-    response = make_request(Method.GET, url, session=session, headers=headers,
-                            allow_redirects=False, context=context)
-    expected = [
-        "About your company", "Describe your business to overseas buyers",
-        "Brief summary to make your company stand out to buyers"
-    ]
-    check_response(response, 200, body_contains=expected)
+
+    # Step 1 - go to the "Set Company Description" page
+    response = fab_ui_edit_description.go_to(session)
+
     token = extract_csrf_middleware_token(response)
     context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
     logging.debug("Supplier is on the Set Company Description page")
 
-    # STEP 2 - Submit company description
-    fake = Factory.create()
-    url = get_absolute_url("ui-buyer:company-edit-description")
-    headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
-    summary = fake.sentence()
-    description = fake.sentence()
-    data = {"csrfmiddlewaretoken": token,
-            "company_description_edit_view-current_step": "description",
-            "description-summary": summary,
-            "description-description": description
-            }
-    response = make_request(Method.POST, url, session=session, headers=headers,
-                            data=data, allow_redirects=False, context=context)
-    check_response(response, 302, location="/company-profile")
+    # Step 2 - Submit company description
+    summary = FAKE.sentence()
+    description = FAKE.sentence()
+    response = fab_ui_edit_description.submit(
+        session, token, summary, description)
+    context.response = response
+
+    # Step 3 - check if Supplier is on Profile page
+    fab_ui_profile.should_see_profile_is_not_verified(response)
+
+    # Step 4 - update company details in Scenario Data
     context.set_company_details(
         actor.company_alias, summary=summary, description=description)
-
-    # STEP 3 - follow the redirect
-    url = get_absolute_url("ui-buyer:company-profile")
-    headers = {"Referer": get_absolute_url("ui-buyer:company-edit-description")}
-    response = make_request(Method.GET, url, session=session, headers=headers,
-                            allow_redirects=False, context=context)
-    check_response(response, 200)
-    prof_should_be_on_profile_page(context, supplier_alias)
-    prof_should_be_told_that_company_is_not_verified_yet(context, supplier_alias)
     logging.debug("Supplier is back to the Profile Page")
 
 
@@ -769,55 +418,32 @@ def prof_verify_company(context, supplier_alias):
     """
     actor = context.get_actor(supplier_alias)
     company = context.get_company(actor.company_alias)
+    session = actor.session
 
     # STEP 0 - get the verification code from DB
     verification_code = get_verification_code(company.number)
 
-    # STEP 1 - go to the "Set Company Description" page
-    actor = context.get_actor(supplier_alias)
-    session = actor.session
-    url = get_absolute_url("ui-buyer:confirm-company-address")
-    headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
-    response = make_request(Method.GET, url, session=session, headers=headers,
-                            allow_redirects=False, context=context)
-    expected = [
-        "Verify your company",
-        ("Enter the verification code from the letter we sent to you after  "
-         "you created your company profile"),
-        ("We sent you a letter through the mail containing a twelve digit "
-         "code.")]
-    check_response(response, 200, body_contains=expected)
+    # STEP 1 - go to the "Verify your company" page
+    response = fab_ui_verify_company.go_to(session)
+    context.response = response
+
+    # STEP 2 - extract CSRF token
     token = extract_csrf_middleware_token(response)
     context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
-    logging.debug("Supplier is on the Verify Company page")
 
-    # STEP 2 - Submit the verification code
-    url = get_absolute_url("ui-buyer:confirm-company-address")
-    headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
-    data = {"csrfmiddlewaretoken": token,
-            "company_address_verification_view-current_step": "address",
-            "address-code": verification_code
-            }
-    response = make_request(Method.POST, url, session=session, headers=headers,
-                            data=data, allow_redirects=False, context=context)
-    expected = [
-        "Your company has been verified",
-        "View or amend your company profile"
-    ]
-    check_response(response, 200, body_contains=expected)
+    # STEP 3 - Submit the verification code
+    response = fab_ui_verify_company.submit(session, token, verification_code)
+    context.response = response
 
-    # STEP 3 - click on the "View or amend your company profile" link
-    actor = context.get_actor(supplier_alias)
-    session = actor.session
-    url = get_absolute_url("ui-buyer:company-profile")
-    headers = {"Referer": get_absolute_url("ui-buyer:confirm-company-address")}
-    response = make_request(Method.GET, url, session=session, headers=headers,
-                            allow_redirects=False, context=context)
-    check_response(response, 200)
-    prof_should_be_on_profile_page(context, supplier_alias)
-    prof_should_be_told_that_company_is_published(context, supplier_alias)
-    logging.debug("%s is on the Verified & Published Company Profile page",
-                  supplier_alias)
+    # STEP 4 - check if code was accepted
+    fab_ui_verify_company.should_see_company_is_verified(response)
+
+    # STEP 5 - click on the "View or amend your company profile" link
+    response = fab_ui_verify_company.view_or_amend_profile(session)
+    context.response = response
+
+    # STEP 6 - check if Supplier is on Verified Profile Page
+    fab_ui_profile.should_see_profile_is_verified(response)
 
 
 def prof_view_published_profile(context, supplier_alias):
@@ -834,19 +460,8 @@ def prof_view_published_profile(context, supplier_alias):
     company = context.get_company(actor.company_alias)
 
     # STEP 1 - go to the "View published profile" page
-    url = "{}/{}".format(get_absolute_url("ui-supplier:suppliers"),
-                         company.number)
-    response = make_request(Method.GET, url, session=session,
-                            allow_redirects=False, context=context)
-    location = "/suppliers/{}/".format(company.number)
-    check_response(response, 301, location_starts_with=location)
-
-    # STEP 2 - follow the redirect from last response
-    url = "{}{}".format(get_absolute_url("ui-supplier:landing"),
-                        response.headers.get("Location"))
-    response = make_request(Method.GET, url, session=session,
-                            allow_redirects=False, context=context)
-    check_response(response, 200, body_contains=[company.number])
+    response = fas_ui_profile.go_to(session, company.number)
+    context.response = response
     logging.debug("Supplier is on the company's FAS page")
 
 
@@ -860,50 +475,20 @@ def prof_attempt_to_sign_in_to_fab(context, supplier_alias):
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
-    fab_landing = get_absolute_url("ui-buyer:landing")
 
     # Step 1 - Get to the Sign In page
-    url = get_absolute_url("sso:login")
-    params = {"next": fab_landing}
-    headers = {"Referer": fab_landing}
-    response = make_request(Method.GET, url, session=session, params=params,
-                            headers=headers, allow_redirects=False,
-                            context=context)
-    expected = []
-    check_response(response, 200, body_contains=expected)
+    response = sso_ui_login.go_to(session)
+    context.response = response
+
+    # Step 2 - check if Supplier is on SSO Login page & extract CSRF token
+    sso_ui_login.should_be_here(response)
     assert response.cookies.get("sso_display_logged_in") == "false"
     token = extract_csrf_middleware_token(response)
     context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
 
-    # Step 2 - submit the login form
-    url = get_absolute_url("sso:login")
-    data = {"next": fab_landing,
-            "csrfmiddlewaretoken": token,
-            "login": actor.email,
-            "password": actor.password,
-            "remember": "on"}
-    # Referer is the same as the final URL from the previous request
-    referer = response.request.url
-    headers = {"Referer": referer}
-    response = make_request(Method.POST, url, session=session, data=data,
-                            headers=headers, allow_redirects=False,
-                            context=context)
-    location = "/accounts/confirm-email/"
-    check_response(response, 302, location=location)
-    cookies = response.cookies
-    assert cookies.get("sso_display_logged_in") == "false"
-    assert cookies.get("directory_sso_dev_session") is not None
-    # extra check - validate the cookie Domain
-    assert "sso_display_logged_in" in cookies.get_dict(domain='.uktrade.io')
-    assert "directory_sso_dev_session" in cookies.get_dict(domain='.uktrade.io')
-
-    # Step 3 - follow the redirect
-    url = get_absolute_url("sso:email_confirm")
-    # Referer is the same as in the previous request
-    headers = {"Referer": referer}
-    response = make_request(Method.GET, url, session=session, headers=headers,
-                            allow_redirects=False, context=context)
-    check_response(response, 200)
+    # Step 3 - submit the login form
+    response = sso_ui_login.login(actor, token)
+    context.response = response
 
 
 def prof_sign_out_from_fab(context, supplier_alias):
@@ -916,51 +501,23 @@ def prof_sign_out_from_fab(context, supplier_alias):
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
-    fab_landing = get_absolute_url("ui-buyer:landing")
 
     # Step 1 - Get to the Sign Out confirmation page
-    url = get_absolute_url("sso:logout")
-    params = {"next": fab_landing}
-    headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
-    response = make_request(Method.GET, url, session=session, params=params,
-                            headers=headers, allow_redirects=False,
-                            context=context)
-    expected = ["Sign out", "Are you sure you want to sign out?"]
-    check_response(response, 200, body_contains=expected)
-    assert response.cookies.get("sso_display_logged_in") == "true"
+    response = sso_ui_logout.go_to(session)
+    context.response = response
+
+    # Step 2 - check if Supplier is on Log Out page & extract CSRF token
+    sso_ui_logout.should_be_here(response)
     token = extract_csrf_middleware_token(response)
     context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
 
-    # Step 2 - log out
-    url = get_absolute_url("sso:logout")
-    data = {"csrfmiddlewaretoken": token,
-            "next": fab_landing}
-    # Referer header is the final URL of the previous request
-    referer = response.request.url
-    headers = {"Referer": referer}
-    response = make_request(Method.POST, url, session=session, headers=headers,
-                            data=data, allow_redirects=False, context=context)
-    check_response(response, 302, location=fab_landing)
-    assert response.cookies.get("sso_display_logged_in") == "false"
-    # It looks like `requests` is ignoring empty cookies, so to check whether
-    # `directory_sso_dev_session` was unset, we have to check
-    # the "Set-Cookie" header
-    cookies_hdr = response.headers.get("Set-Cookie")
-    assert 'directory_sso_dev_session="\\"\\"";' in cookies_hdr
+    # Step 3 - log out
+    response = sso_ui_logout.logout(session, token)
+    context.response = response
 
-    # Step 3 - follow the redirect to FAB's landing page
-    url = response.headers.get("Location")
-    # Referer header is the same one as in the previous request
-    headers = {"Referer": referer}
-    response = make_request(Method.GET, url, session=session,
-                            headers=headers, allow_redirects=False,
-                            context=context)
-    expected = ["Find a Buyer - GREAT.gov.uk", "Get promoted internationally",
-                "with a great.gov.uk trade profile",
-                "Enter your Companies House number"]
-    check_response(response, 200, body_contains=expected)
-    assert "sso_display_logged_in" not in response.cookies
-    assert "directory_sso_dev_session" not in response.cookies
+    # Step 4 - check if Supplier is on FAB Landing page & is logged out
+    fab_ui_landing.should_be_here(response)
+    fab_ui_landing.should_be_logged_out(response)
 
 
 def prof_sign_in_to_fab(context, supplier_alias):
@@ -973,116 +530,54 @@ def prof_sign_in_to_fab(context, supplier_alias):
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
-    fab_landing = get_absolute_url("ui-buyer:landing")
 
     # Step 1 - Get to the Sign In page
-    url = get_absolute_url("sso:login")
-    params = {"next": fab_landing}
-    headers = {"Referer": fab_landing}
-    response = make_request(Method.GET, url, session=session, params=params,
-                            headers=headers, allow_redirects=False,
-                            context=context)
-    expected = []
-    check_response(response, 200, body_contains=expected)
+    response = sso_ui_login.go_to(session)
+    context.response = response
+
+    # Step 2 - check if Supplier is on the SSO Login page
+    sso_ui_login.should_be_here(response)
     assert response.cookies.get("sso_display_logged_in") == "false"
+
+    # Step 3 - extract CSRF token
     token = extract_csrf_middleware_token(response)
     context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
 
-    # Step 2 - submit the login form
-    url = get_absolute_url("sso:login")
-    data = {"next": fab_landing,
-            "csrfmiddlewaretoken": token,
-            "login": actor.email,
-            "password": actor.password,
-            "remember": "on"}
-    # Referer is the same as the final URL from the previous request
-    referer = response.request.url
-    headers = {"Referer": referer}
-    response = make_request(Method.POST, url, session=session, data=data,
-                            headers=headers, allow_redirects=False,
-                            context=context)
-    check_response(response, 302, location=fab_landing)
-    cookies = response.cookies
-    assert cookies.get("sso_display_logged_in") == "true"
-    assert cookies.get("directory_sso_dev_session") is not None
-    # extra check - validate the cookie Domain
-    assert "sso_display_logged_in" in cookies.get_dict(domain='.uktrade.io')
-    assert "directory_sso_dev_session" in cookies.get_dict(domain='.uktrade.io')
+    # Step 4 - submit the login form
+    response = sso_ui_login.login(actor, token)
+    context.response = response
 
-    # Step 3 - follow the redirect
-    url = fab_landing
-    # Referer is the same as in the previous request
-    headers = {"Referer": referer}
-    response = make_request(Method.GET, url, session=session, headers=headers,
-                            allow_redirects=False, context=context)
-    check_response(response, 302, location="/company-profile")
-    assert "sso_display_logged_in" not in response.cookies
-    assert "directory_sso_dev_session" not in response.cookies
-
-    # Step 4 - go the company profile page
-    url = get_absolute_url("ui-buyer:company-profile")
-    # Referer is the same as the final URL from the previous request
-    referer = response.request.url
-    headers = {"Referer": referer}
-    response = make_request(Method.GET, url, session=session, headers=headers,
-                            allow_redirects=False, context=context)
-    check_response(response, 200)
+    # Step 5 - check if Supplier is on the FAB profile page
+    fab_ui_profile.should_be_here(response)
     assert "sso_display_logged_in" not in response.cookies
     assert "directory_sso_dev_session" not in response.cookies
 
 
-def reg_create_standalone_sso_account(context, supplier_alias):
+def reg_create_standalone_sso_account(context: Context, supplier_alias: str):
     """Will create a standalone SSO/great.gov.uk account.
 
     NOTE:
     There will be no association between this account and any company.
 
     :param context: behave `context` object
-    :type context: behave.runner.Context
     :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
 
     # Step 1: Go to the SSO/great.gov.uk registration page
-    url = get_absolute_url("sso:signup")
-    headers = {"Referer": get_absolute_url("ui-buyer:landing")}
-    response = make_request(Method.GET, url, session=session,
-                            headers=headers, allow_redirects=False,
-                            context=context)
-    expected = ["Register", "Create a great.gov.uk account and you can",
-                "gain access to worldwide exporting opportunities",
-                "promote your business to international buyers",
-                "Email:", "Confirm email:", "Password:", "Confirm password:",
-                "Tick this box to accept the", "of the great.gov.uk service."]
-    check_response(response, 200, body_contains=expected)
+    response = sso_ui_register.go_to(session)
+    context.response = response
+
+    # Step 2: Check if User is not logged in
     assert response.cookies.get("sso_display_logged_in") == "false"
 
-    # Step 2: POST SSO accounts/signup/
-    url = get_absolute_url("sso:signup")
-    headers = {"Referer": url}
-    data = {"csrfmiddlewaretoken": actor.csrfmiddlewaretoken,
-            "email": actor.email,
-            "email2": actor.email,
-            "password1": actor.password,
-            "password2": actor.password,
-            "terms_agreed": "on"
-            }
-    response = make_request(Method.POST, url, session=session,
-                            headers=headers, data=data,
-                            allow_redirects=False, context=context)
-    check_response(response, 302, location="/accounts/confirm-email/")
-    assert response.cookies.get("sso_display_logged_in") == "false"
-    assert response.cookies.get("directory_sso_dev_session") is not None
+    # Step 3: POST SSO accounts/signup/
+    response = sso_ui_register.submit_no_company(actor)
+    context.response = response
 
-    # Steps 3: GET SSO /accounts/confirm-email/
-    url = get_absolute_url("sso:email_confirm")
-    response = make_request(Method.GET, url, session=session,
-                            headers=headers, allow_redirects=False,
-                            context=context)
-    expected = ["Verify your email address"]
-    check_response(response, 200, body_contains=expected)
+    # Step 3: Check if Supplier is on Verify your email page & is not logged in
+    sso_ui_verify_your_email.should_be_here(response)
     assert response.cookies.get("sso_display_logged_in") == "false"
 
 
@@ -1095,44 +590,17 @@ def sso_supplier_confirms_email_address(context, supplier_alias):
     :param supplier_alias: alias of the Actor used in the scope of the scenario
     :type supplier_alias: str
     """
-    # STEP 1 - Submit "Confirm your email address" form
     actor = context.get_actor(supplier_alias)
-    session = actor.session
-    csrfmiddlewaretoken = actor.csrfmiddlewaretoken
     form_action_value = context.form_action_value
-    url = "{}{}".format(get_absolute_url("sso:landing"), form_action_value)
-    referer = actor.email_confirmation_link
-    headers = {"Referer": referer}
-    data = {"csrfmiddlewaretoken": csrfmiddlewaretoken}
-    response = make_request(Method.POST, url, session=session, headers=headers,
-                            data=data, allow_redirects=False, context=context)
-    new_location = response.headers.get("Location")
-    assert new_location.startswith("/accounts/login/?next=")
-    assert "%2Fabout%2F" in new_location
-    check_response(response, 302)
 
-    # Step 2 - Follow redirect - go to
-    # SSO_HOST/accounts/login/?next=https://SSO_HOST/about/
-    # use the same Referer as in previous request
-    headers = {"Referer": referer}
-    url = "{}{}".format(get_absolute_url("sso:landing"), new_location)
-    response = make_request(Method.GET, url, session=session, headers=headers,
-                            allow_redirects=False, context=context)
-    new_location = response.headers.get("Location")
-    expected_locations = [get_absolute_url("profile:about"),
-                          get_absolute_url("profile:about")
-                          .replace("http://", "https://")]
-    check_response(response, 302, locations=expected_locations)
-    assert response.cookies.get("sso_display_logged_in") == "true"
+    # STEP 1 - Submit "Confirm your email address" form
+    response = sso_ui_confim_your_email.confirm(actor, form_action_value)
+    context.response = response
 
-    # Step 3 - Follow the redirect - go to PROFILE /about
-    # use the same Referer as in previous request
-    headers = {"Referer": referer}
-    url = unquote(new_location)
-    response = make_request(Method.GET, url, session=session, headers=headers,
-                            context=context)
-    expected = ["Welcome to your great.gov.uk profile"]
-    check_response(response, 200, body_contains=expected)
+    # STEP 2 - Check if Supplier if on SSO Profile Landing page
+    profile_ui_landing.should_be_here(response)
+
+    # STEP 3 - Update Actor's data
     context.set_actor_has_sso_account(supplier_alias, True)
 
 
@@ -1151,55 +619,14 @@ def sso_go_to_create_trade_profile(context, supplier_alias):
     session = actor.session
 
     # Step 1 - Go to "Find a Buyer" tab
-    headers = {"Referer": get_absolute_url("profile:about")}
-    url = get_absolute_url("profile:fab")
-    response = make_request(Method.GET, url, session=session, headers=headers,
-                            allow_redirects=False, context=context)
-    expected = ["Get a trade profile", "Create a trade profile",
-                "Get a trade profile for your company and you can:",
-                "generate new sales leads",
-                "promote your business to thousands of overseas buyers",
-                ("add case studies of your best work to make your company "
-                 "stand out"),
-                ("have buyers contact your sales team directly to get deals "
-                 "moving"),
-                ]
-    check_response(response, 200, body_contains=expected)
+    response = profile_ui_find_a_buyer.go_to(session)
+    context.response = response
+    profile_ui_find_a_buyer.should_see_get_a_trade_profile(response)
 
     # Step 2 - Click on "Create a trade profile" button
-    url = get_absolute_url("ui-buyer:landing")
-    response = make_request(Method.GET, url, session=session,
-                            allow_redirects=False, context=context)
-    expected = ["Get promoted internationally",
-                "with a great.gov.uk trade profile",
-                "Connect directly with international buyers"
-                ]
-    check_response(response, 200, body_contains=expected)
-
-
-def prof_go_to_edit_logo_page(context, supplier_alias):
-    """Go to the 'Upload your company's logo' page & extract CSRF token.
-
-    :param context: behave `context` object
-    :type  context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type  supplier_alias: str
-    """
-    actor = context.get_actor(supplier_alias)
-    session = actor.session
-
-    # Go to "Upload your company's logo" page
-    headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
-    url = get_absolute_url("ui-buyer:upload-logo")
-    response = make_request(Method.GET, url, session=session, headers=headers,
-                            allow_redirects=False, context=context)
-    expected = ["Upload your company's logo", "Logo:", "Upload file",
-                ("For best results this should be a transparent PNG file of "
-                 "600 x 600 pixels and no more than 2MB")
-                ]
-    check_response(response, 200, body_contains=expected)
-    token = extract_csrf_middleware_token(response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+    response = profile_ui_find_a_buyer.go_to_create_a_trade_profile(session)
+    context.response = response
+    fab_ui_landing.should_be_here(response)
 
 
 def prof_upload_logo(context, supplier_alias, picture: str):
@@ -1217,39 +644,22 @@ def prof_upload_logo(context, supplier_alias, picture: str):
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
-    company = context.get_company(actor.company_alias)
-    filename = get_absolute_path_of_file(picture)
+    token = actor.csrfmiddlewaretoken
+    file_path = get_absolute_path_of_file(picture)
 
-    # Upload company's logo
-    headers = {"Referer": get_absolute_url("ui-buyer:upload-logo")}
-    url = get_absolute_url("ui-buyer:upload-logo")
-    data = {"csrfmiddlewaretoken": actor.csrfmiddlewaretoken,
-            "company_profile_logo_edit_view-current_step": "logo",
-            }
-    with open(filename, "rb") as f:
-        picture = f.read()
-    files = {"logo-logo": picture}
-    response = make_request(
-        Method.POST, url, session=session, headers=headers, data=data,
-        files=files, allow_redirects=False, context=context)
-    check_response(response, 302, location="/company-profile")
-    assert response.cookies.get("sessionid") is not None
+    # Step 1 - Upload company's logo
+    response = fab_ui_upload_logo.upload(session, token, file_path)
+    context.response = response
 
-    # Follow the redirect
-    headers = {"Referer": get_absolute_url("ui-buyer:upload-logo")}
-    url = get_absolute_url("ui-buyer:company-profile")
-    response = make_request(Method.GET, url, session=session, headers=headers,
-                            allow_redirects=False, context=context)
-    expected = ["Your company is published"]
-    check_response(response, 200, body_contains=expected)
-
+    # Step 2 - check if Supplier is on the FAB profile page
+    fab_ui_profile.should_be_here(response)
     logging.debug("Successfully uploaded logo picture: %s", picture)
 
-    # Keep logo details in Company's scenario data
+    # Step 3 - Keep logo details in Company's scenario data
     logo_url = extract_logo_url(response)
-    md5_hash = get_md5_hash_of_file(filename)
+    md5_hash = get_md5_hash_of_file(file_path)
     context.set_company_logo_detail(
-        company.alias, picture=picture, hash=md5_hash, url=logo_url)
+        actor.company_alias, picture=picture, hash=md5_hash, url=logo_url)
 
 
 def prof_upload_unsupported_file_as_logo(context, supplier_alias, file):
@@ -1267,37 +677,25 @@ def prof_upload_unsupported_file_as_logo(context, supplier_alias, file):
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
-    filename = get_absolute_path_of_file(file)
+    token = actor.csrfmiddlewaretoken
+    file_path = get_absolute_path_of_file(file)
 
-    logging.debug("Attempting to upload %s as company logo", filename)
-    # Try to upload a file of unsupported type as company's logo
-    headers = {"Referer": get_absolute_url("ui-buyer:upload-logo")}
-    url = get_absolute_url("ui-buyer:upload-logo")
-    data = {"csrfmiddlewaretoken": actor.csrfmiddlewaretoken,
-            "company_profile_logo_edit_view-current_step": "logo",
-            }
-    with open(filename, "rb") as f:
-        picture = f.read()
-    files = {"logo-logo": picture}
-    response = make_request(Method.POST, url, session=session, headers=headers,
-                            data=data, files=files,
-                            allow_redirects=False, context=context)
+    logging.debug("Attempting to upload %s as company logo", file)
+    # Step 1 - Try to upload a file of unsupported type as company's logo
+    response = fab_ui_upload_logo.upload(session, token, file_path)
+    context.response = response
 
-    content = response.content.decode("utf-8")
+    # Step 2 - check if upload was rejected
+    rejected = fab_ui_upload_logo.was_upload_rejected(response)
+
     # There are 2 different error message that you can get, depending of the
     # type of uploaded file.
     # Here, we're checking if `any` of these 2 message is visible.
-    error_messages = ["Invalid image format, allowed formats: PNG, JPG, JPEG",
-                      ("Upload a valid image. The file you uploaded was either "
-                       "not an image or a corrupted image.")]
-    has_error = any([message in content for message in error_messages])
-    is_200 = response.status_code == 200
-    if is_200 and has_error:
+    if rejected:
         logging.debug("%s was rejected", file)
     else:
         logging.error("%s was accepted", file)
-
-    return is_200 and has_error
+    return rejected
 
 
 def prof_supplier_uploads_logo(context, supplier_alias, picture):
@@ -1309,7 +707,18 @@ def prof_supplier_uploads_logo(context, supplier_alias, picture):
     :type supplier_alias: str
     :param picture: name of the picture file stored in ./tests/functional/files
     """
-    prof_go_to_edit_logo_page(context, supplier_alias)
+    actor = context.get_actor(supplier_alias)
+    session = actor.session
+
+    # Step 1 - go to Upload Logo page
+    response = fab_ui_upload_logo.go_to(session)
+    context.response = response
+
+    # Step 2 - extract CSRF token
+    token = extract_csrf_middleware_token(response)
+    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+
+    # Step 3 - upload the logo
     prof_upload_logo(context, supplier_alias, picture)
 
 
@@ -1323,16 +732,20 @@ def prof_to_upload_unsupported_logos(context, supplier_alias, table):
     :param table: context.table containing data table
                   see: https://pythonhosted.org/behave/gherkin.html#table
     """
+    actor = context.get_actor(supplier_alias)
+    session = actor.session
     files = [row['file'] for row in table]
     rejections = []
     for file in files:
-        prof_go_to_edit_logo_page(context, supplier_alias)
-        rejected = prof_upload_unsupported_file_as_logo(context, supplier_alias, file)
+        fab_ui_upload_logo.go_to(session)
+        rejected = prof_upload_unsupported_file_as_logo(
+            context, supplier_alias, file)
         rejections.append(rejected)
     context.rejections = rejections
 
 
-def prof_update_company_details(context, supplier_alias, table_of_details):
+def prof_update_company_details(
+        context: Context, supplier_alias: str, table_of_details: Table):
     """Update selected Company's details.
 
     NOTE:
@@ -1341,23 +754,69 @@ def prof_update_company_details(context, supplier_alias, table_of_details):
     `context` object, yet in order to be more explicit, we're making it
     a mandatory argument.
 
+    :param context: behave `context` object
+    :param supplier_alias: alias of the Actor used in the scope of the scenario
     :param table_of_details: context.table containing data table
             see: https://pythonhosted.org/behave/gherkin.html#table
     """
-    details_to_update = [row["detail"] for row in table_of_details]
+    actor = context.get_actor(supplier_alias)
+    session = actor.session
+    company = context.get_company(actor.company_alias)
 
+    # Step 0 - prepare company's details to update
+    details_to_update = [row["detail"] for row in table_of_details]
     title = DETAILS["TITLE"] in details_to_update
     keywords = DETAILS["KEYWORDS"] in details_to_update
     website = DETAILS["WEBSITE"] in details_to_update
     size = DETAILS["SIZE"] in details_to_update
     sector = DETAILS["SECTOR"] in details_to_update
+    countries = DETAILS["COUNTRIES"] in details_to_update
 
-    fab_ui_edit_details.go_to(context, supplier_alias)
-    fab_ui_edit_details.update_details(context, supplier_alias,
-                                       title=title, keywords=keywords,
-                                       website=website, size=size)
-    fab_ui_edit_sector.go_to(context, supplier_alias)
-    fab_ui_edit_sector.update_sector_and_countries(context, supplier_alias, update=sector)
+    # Steps 1 - Go to the FAB Edit Company's details page
+    response = fab_ui_edit_details.go_to(session)
+    context.response = response
+
+    # Step 2 - extract CSRF token
+    token = extract_csrf_middleware_token(response)
+    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+
+    # Step 3 - Update company's details
+    response, new_details = fab_ui_edit_details.update_details(
+        actor, company, title=title, keywords=keywords,
+        website=website, size=size)
+    context.response = response
+
+    # Step 4 - Supplier should be on Edit Profile page
+    fab_ui_profile.should_be_here(response)
+
+    # Step 5 - Go to the Edit Sector page
+    fab_ui_edit_sector.go_to(session)
+    context.response = response
+
+    # Step 5 - extract CSRF token
+    token = extract_csrf_middleware_token(response)
+    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+
+    # Step 6 - Update company's sector
+    response, new_sector, new_countries = fab_ui_edit_sector.update(
+        actor, company, update_sector=sector, update_countries=countries)
+    context.response = response
+
+    # Step 7 - Check if Supplier is on FAB Profile page
+    fab_ui_profile.should_be_here(response)
+
+    # Step 7 - update company's details stored in context.scenario_data
+    context.set_company_details(
+        actor.company_alias, title=new_details.title,
+        website=new_details.website, keywords=new_details.keywords,
+        no_employees=new_details.no_employees, sector=new_sector,
+        export_to_countries=new_countries)
+    logging.debug(
+        "%s successfully updated basic Company's details: title=%s, website=%s,"
+        " keywords=%s, number of employees=%s, sector=%s, countries=%s",
+        supplier_alias, new_details.title, new_details.website,
+        new_details.keywords, new_details.no_employees, new_sector,
+        new_countries)
 
 
 def prof_add_online_profiles(context, supplier_alias, online_profiles):
@@ -1370,14 +829,36 @@ def prof_add_online_profiles(context, supplier_alias, online_profiles):
     :param online_profiles: context.table containing data table
             see: https://pythonhosted.org/behave/gherkin.html#table
     """
+    actor = context.get_actor(supplier_alias)
+    session = actor.session
+    company = context.get_company(actor.company_alias)
     profiles = [row["online profile"] for row in online_profiles]
     facebook = PROFILES["FACEBOOK"] in profiles
     linkedin = PROFILES["LINKEDIN"] in profiles
     twitter = PROFILES["TWITTER"] in profiles
-    fab_ui_edit_online_profiles.go_to(context, supplier_alias)
-    fab_ui_edit_online_profiles.update_profiles(
-        context, supplier_alias, facebook=facebook, linkedin=linkedin,
-        twitter=twitter)
+
+    # Step 1 - Go to the FAB Edit Online Profiles page
+    response = fab_ui_edit_online_profiles.go_to(session)
+
+    # Step 2 - Extract CSRF token
+    extract_and_set_csrf_middleware_token(context, response, supplier_alias)
+
+    # Step 3 - Update links to Online Profiles
+    response, new_details = fab_ui_edit_online_profiles.update_profiles(
+        actor, company, facebook=facebook, linkedin=linkedin, twitter=twitter)
+    context.response = response
+
+    # Step 4 - Check if Supplier is on FAB Profile page
+    fab_ui_profile.should_be_here(response)
+
+    # Step 5 - Update company's details stored in context.scenario_data
+    context.set_company_details(
+        company.alias, facebook=new_details.facebook,
+        linkedin=new_details.linkedin, twitter=new_details.twitter)
+    logging.debug(
+        "%s set Company's Online Profile links to: Facebook=%s, LinkedId=%s, "
+        "Twitter=%s", supplier_alias, new_details.facebook,
+        new_details.linkedin, new_details.twitter)
 
 
 def prof_add_invalid_online_profiles(
@@ -1391,6 +872,9 @@ def prof_add_invalid_online_profiles(
     :param online_profiles: context.table containing data table
             see: https://pythonhosted.org/behave/gherkin.html#table
     """
+    actor = context.get_actor(supplier_alias)
+    session = actor.session
+    company = context.get_company(actor.company_alias)
     facebook = False
     linkedin = False
     twitter = False
@@ -1407,15 +891,24 @@ def prof_add_invalid_online_profiles(
         if row["online profile"] == PROFILES["TWITTER"]:
             twitter = True
             twitter_url = row.get("invalid link", twitter_url)
-    fab_ui_edit_online_profiles.go_to(context, supplier_alias)
+
+    # Step 1 - Go to the Edit Online Profiles page
+    response = fab_ui_edit_online_profiles.go_to(session)
+    context.response = response
+
+    # Step 2 - Extract CSRF token
+    extract_and_set_csrf_middleware_token(context, response, supplier_alias)
+
+    # Step 3 - update links to Online Profiles
     logging.debug(
         "Will use following invalid URLs to Online Profiles: %s %s %s",
         facebook_url if facebook else "", linkedin_url if linkedin else "",
         twitter_url if twitter else "")
-    fab_ui_edit_online_profiles.update_profiles(
-        context, supplier_alias, facebook=facebook, linkedin=linkedin,
+    response, _ = fab_ui_edit_online_profiles.update_profiles(
+        actor, company, facebook=facebook, linkedin=linkedin,
         twitter=twitter, specific_facebook=facebook_url,
         specific_linkedin=linkedin_url, specific_twitter=twitter_url)
+    context.response = response
 
 
 def prof_remove_links_to_online_profiles(context, supplier_alias):
@@ -1431,9 +924,9 @@ def prof_remove_links_to_online_profiles(context, supplier_alias):
     linkedin = True if company.linkedin else False
     twitter = True if company.twitter else False
 
-    fab_ui_edit_online_profiles.remove_links(
-        context, supplier_alias, facebook=facebook, linkedin=linkedin,
-        twitter=twitter)
+    response = fab_ui_edit_online_profiles.remove_links(
+        actor, company, facebook=facebook, linkedin=linkedin, twitter=twitter)
+    context.response = response
 
 
 def prof_add_case_study(context, supplier_alias, case_alias):

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -11,10 +11,7 @@ from requests.models import Response
 from scrapy.selector import Selector
 
 from tests.functional.features.db_cleanup import get_dir_db_connection
-from tests.settings import (
-    MAILGUN_EVENTS_URL,
-    MAILGUN_SECRET_API_KEY
-)
+from tests.settings import MAILGUN_EVENTS_URL, MAILGUN_SECRET_API_KEY
 
 
 def get_file_log_handler(log_formatter,


### PR DESCRIPTION
What's changed:
* make Page Object free of behave `context`
* move all `actions` and `assertions` specific to any given Page to a dedicated Page Object
* replace clumsy logic in step implementation with aforementioned reusable `actions` & `assertions`

The reasoning behind the changes:
* group logical parts of the code together (Page Objects)
* remove `behave` (test framework) logic from Page Objects
* make the test code easier to maintain
* improve code re-usability