### PR TITLE
ED-1804 - update multiple case studies

### DIFF
--- a/tests/functional/features/fab/profile.feature
+++ b/tests/functional/features/fab/profile.feature
@@ -395,3 +395,38 @@ Feature: Trade Profile
 
     Then "Peter Alder" should see all case studies on the FAB Company's Directory Profile page
     And "Peter Alder" should see all case studies on the FAS Company's Directory Profile page
+
+
+  @ED-1804
+  @fab
+  @case-study
+  @profile
+  Scenario: Supplier should be able to update multiple case studies for an unverified company
+    Given "Peter Alder" created an unverified profile for randomly selected company "Y"
+    And "Peter Alder" added a complete case study called "no 1"
+    And "Peter Alder" added a complete case study called "no 2"
+    And "Peter Alder" added a complete case study called "no 3"
+
+    When "Peter Alder" updates all the details of case study called "no 1"
+    And "Peter Alder" updates all the details of case study called "no 2"
+    And "Peter Alder" updates all the details of case study called "no 3"
+
+    Then "Peter Alder" should see all case studies on the FAB Company's Directory Profile page
+
+
+  @ED-1804
+  @fab
+  @case-study
+  @profile
+  Scenario: Supplier should be able to update multiple case studies for a verified company
+    Given "Peter Alder" has created and verified profile for randomly selected company "Y"
+    And "Peter Alder" added a complete case study called "no 1"
+    And "Peter Alder" added a complete case study called "no 2"
+    And "Peter Alder" added a complete case study called "no 3"
+
+    When "Peter Alder" updates all the details of case study called "no 1"
+    And "Peter Alder" updates all the details of case study called "no 2"
+    And "Peter Alder" updates all the details of case study called "no 3"
+
+    Then "Peter Alder" should see all case studies on the FAB Company's Directory Profile page
+    And "Peter Alder" should see all case studies on the FAS Company's Directory Profile page


### PR DESCRIPTION
This PR adds 2 new scenarios:

```gherkin
  @ED-1804
  @fab
  @case-study
  @profile
  Scenario: Supplier should be able to update multiple case studies for an unverified company
    Given "Peter Alder" created an unverified profile for randomly selected company "Y"
    And "Peter Alder" added a complete case study called "no 1"
    And "Peter Alder" added a complete case study called "no 2"
    And "Peter Alder" added a complete case study called "no 3"

    When "Peter Alder" updates all the details of case study called "no 1"
    And "Peter Alder" updates all the details of case study called "no 2"
    And "Peter Alder" updates all the details of case study called "no 3"

    Then "Peter Alder" should see all case studies on the FAB Company's Directory Profile page


  @ED-1804
  @fab
  @case-study
  @profile
  Scenario: Supplier should be able to update multiple case studies for a verified company
    Given "Peter Alder" has created and verified profile for randomly selected company "Y"
    And "Peter Alder" added a complete case study called "no 1"
    And "Peter Alder" added a complete case study called "no 2"
    And "Peter Alder" added a complete case study called "no 3"

    When "Peter Alder" updates all the details of case study called "no 1"
    And "Peter Alder" updates all the details of case study called "no 2"
    And "Peter Alder" updates all the details of case study called "no 3"

    Then "Peter Alder" should see all case studies on the FAB Company's Directory Profile page
    And "Peter Alder" should see all case studies on the FAS Company's Directory Profile page
```