### PR TITLE
ED-1933 better logging and error handling

### DIFF
--- a/.behaverc
+++ b/.behaverc
@@ -7,5 +7,3 @@
 #junit_directory=./tests/functional/reports/
 verbose=True
 logging_level=DEBUG
-stdout_capture=True
-stderr_capture=True

--- a/makefile
+++ b/makefile
@@ -98,7 +98,7 @@ SET_DB_URLS := \
 functional_tests:
 	$(SET_PYTEST_ENV_VARS) && \
 	$(SET_DB_URLS) && \
-	behave -k --format progress3 --no-logcapture --tags=-wip --tags=-skip --tags=~fixme tests/functional/features $(BEHAVE_ARGS)
+	behave -k --format progress3 --no-logcapture --stop --tags=-wip --tags=-skip --tags=~fixme tests/functional/features $(BEHAVE_ARGS)
 
 test: pep8 smoke_tests integration_test load_test_minimal
 

--- a/tests/functional/features/environment.py
+++ b/tests/functional/features/environment.py
@@ -18,15 +18,17 @@ def before_step(context, step):
 
 
 def after_step(context, step):
-    logging.debug(context.scenario_data)
     if step.status == "failed":
-        logging.debug('Step "%s %s" has failed. Reason: "%s"', step.step_type,
-                      step.name, step.exception)
+        logging.debug(context.scenario_data)
+        logging.debug(
+            'Step "%s %s" failed. Reason: "%s"', step.step_type, step.name,
+            step.exception)
         if hasattr(context, "response"):
-            print("\nHere's the content of last recorded response:\n",
-                  context.response.content.decode("utf-8"))
-            logging.error("Here's the content of last recorded response:\n%s",
-                          context.response.content.decode("utf-8"))
+            content = context.response.content.decode("utf-8")
+            print("\nThe content of last response:\n%s" % content)
+            delattr(context, "response")
+        else:
+            print("\nThere's no response content to log")
 
 
 def before_scenario(context, scenario):

--- a/tests/functional/features/environment.py
+++ b/tests/functional/features/environment.py
@@ -46,7 +46,7 @@ def after_scenario(context, scenario):
 
 
 def before_all(context):
-    init_loggers()
+    init_loggers(context)
     # this will add some handy functions to the `context` object
     patch_context(context)
 

--- a/tests/functional/features/environment.py
+++ b/tests/functional/features/environment.py
@@ -23,7 +23,9 @@ def after_step(context, step):
         logging.debug('Step "%s %s" has failed. Reason: "%s"', step.step_type,
                       step.name, step.exception)
         if hasattr(context, "response"):
-            logging.debug("Here's the content of last recorded response:\n%s",
+            print("\nHere's the content of last recorded response:\n",
+                  context.response.content.decode("utf-8"))
+            logging.error("Here's the content of last recorded response:\n%s",
                           context.response.content.decode("utf-8"))
 
 

--- a/tests/functional/features/pages/fab_ui_build_profile_address.py
+++ b/tests/functional/features/pages/fab_ui_build_profile_address.py
@@ -7,7 +7,12 @@ from scrapy import Selector
 
 from tests import get_absolute_url
 from tests.functional.features.context_utils import Actor, AddressDetails
-from tests.functional.features.utils import Method, check_response, make_request
+from tests.functional.features.utils import (
+    Method,
+    assertion_msg,
+    check_response,
+    make_request
+)
 
 URL = get_absolute_url("ui-buyer:company-edit")
 EXPECTED_STRINGS = [
@@ -37,7 +42,10 @@ def extract_address_details(response: Response) -> AddressDetails:
     :param response: requests response
     :return: named tuple containing all extracted company details
     """
-    assert response.content, "Response has no content"
+    with assertion_msg(
+            "Could not extract Company's Address Details as the response had no"
+            " content"):
+        assert response.content
     content = response.content.decode("utf-8")
 
     def extract(selector):

--- a/tests/functional/features/pages/fab_ui_edit_online_profiles.py
+++ b/tests/functional/features/pages/fab_ui_edit_online_profiles.py
@@ -8,7 +8,12 @@ from requests import Response, Session
 
 from tests import get_absolute_url
 from tests.functional.features.context_utils import Actor, Company
-from tests.functional.features.utils import Method, check_response, make_request
+from tests.functional.features.utils import (
+    Method,
+    assertion_msg,
+    check_response,
+    make_request
+)
 
 URL = get_absolute_url("ui-buyer:company-edit-social-media")
 EXPECTED_STRINGS = [
@@ -115,11 +120,14 @@ def should_see_errors(
     """
     content = response.content.decode("utf-8")
     if facebook:
-        assert "Please provide a link to Facebook." in content
+        with assertion_msg("Could't find link to Facebook profile"):
+            assert "Please provide a link to Facebook." in content
     if linkedin:
-        assert "Please provide a link to LinkedIn." in content
+        with assertion_msg("Could't find link to LinkedIn profile"):
+            assert "Please provide a link to LinkedIn." in content
     if twitter:
-        assert "Please provide a link to Twitter." in content
+        with assertion_msg("Could't find link to Twitter profile"):
+            assert "Please provide a link to Twitter." in content
 
 
 def remove_links(

--- a/tests/functional/features/pages/fab_ui_landing.py
+++ b/tests/functional/features/pages/fab_ui_landing.py
@@ -5,7 +5,12 @@ import logging
 from requests import Response, Session
 
 from tests import get_absolute_url
-from tests.functional.features.utils import Method, check_response, make_request
+from tests.functional.features.utils import (
+    Method,
+    assertion_msg,
+    check_response,
+    make_request
+)
 
 URL = get_absolute_url("ui-buyer:landing")
 EXPECTED_STRINGS = [
@@ -39,5 +44,11 @@ def should_be_logged_out(response: Response):
 
     :param response: response object
     """
-    assert "sso_display_logged_in" not in response.cookies
-    assert "directory_sso_dev_session" not in response.cookies
+    with assertion_msg(
+            "Found sso_display_logged_in cookie in the response. Maybe user is "
+            "still logged in?"):
+        assert "sso_display_logged_in" not in response.cookies
+    with assertion_msg(
+            "Found directory_sso_dev_session cookie in the response. Maybe user"
+            " is still logged in?"):
+        assert "directory_sso_dev_session" not in response.cookies

--- a/tests/functional/features/pages/fab_ui_profile.py
+++ b/tests/functional/features/pages/fab_ui_profile.py
@@ -8,7 +8,7 @@ from requests import Response
 from tests import get_absolute_url
 from tests.functional.features.context_utils import Company
 from tests.functional.features.pages.common import DETAILS
-from tests.functional.features.utils import check_response
+from tests.functional.features.utils import assertion_msg, check_response
 from tests.settings import SECTORS_WITH_LABELS
 
 URL = get_absolute_url("ui-buyer:company-profile")
@@ -57,46 +57,66 @@ def should_see_details(
     sector = DETAILS["SECTOR"] in visible_details
 
     if title:
-        assert company.title in content
+        with assertion_msg(
+                "Couldn't find company's title '%s' in the response",
+                company.title):
+            assert company.title in content
     if keywords:
         for keyword in company.keywords.split(", "):
-            assert keyword.strip() in content
+            with assertion_msg(
+                    "Couldn't find keyword '%s' in the response", keyword):
+                assert keyword.strip() in content
     if website:
-        assert company.website in content
+        with assertion_msg(
+                "Couldn't find company's website '%s' in the response",
+                company.website):
+            assert company.website in content
     if size:
-        if company.no_employees == "10001+":
-            assert "10,001+" in content
-        elif company.no_employees == "1001-10000":
-            assert "1,001-10,000" in content
-        elif company.no_employees == "501-1000":
-            assert "501-1,000" in content
-        else:
-            assert company.no_employees in content
+        with assertion_msg(
+                "Couldn't find the size of the company '%s' in the response",
+                company.no_employees):
+            if company.no_employees == "10001+":
+                assert "10,001+" in content
+            elif company.no_employees == "1001-10000":
+                assert "1,001-10,000" in content
+            elif company.no_employees == "501-1000":
+                assert "501-1,000" in content
+            else:
+                assert company.no_employees in content
     if sector:
-        assert SECTORS_WITH_LABELS[company.sector] in content
+        with assertion_msg(
+                "Couldn't find company's sector '%s' in the response",
+                SECTORS_WITH_LABELS[company.sector]):
+            assert SECTORS_WITH_LABELS[company.sector] in content
 
 
 def should_see_online_profiles(company: Company, response: Response):
     content = response.content.decode("utf-8")
 
     if company.facebook:
-        assert "Visit Facebook" in content
-        assert company.facebook in content
+        with assertion_msg("Couldn't find link to company's Facebook profile"):
+            assert "Visit Facebook" in content
+            assert company.facebook in content
     if company.linkedin:
-        assert "Visit LinkedIn" in content
-        assert company.linkedin in content
+        with assertion_msg("Couldn't find link to company's LinkedIn profile"):
+            assert "Visit LinkedIn" in content
+            assert company.linkedin in content
     if company.twitter:
-        assert "Visit Twitter" in content
-        assert company.twitter in content
+        with assertion_msg("Couldn't find link to company's Twitter profile"):
+            assert "Visit Twitter" in content
+            assert company.twitter in content
     logging.debug("Supplier can see all expected links to Online Profiles on "
                   "FAB Company's Directory Profile Page")
 
 
 def should_not_see_online_profiles(response: Response):
     content = response.content.decode("utf-8")
-    assert "Add Facebook" in content
-    assert "Add LinkedIn" in content
-    assert "Add Twitter" in content
+    with assertion_msg("Found a link to 'Add Facebook' profile"):
+        assert "Add Facebook" in content
+    with assertion_msg("Found a link to 'Add LinkedIn' profile"):
+        assert "Add LinkedIn" in content
+    with assertion_msg("Found a link to 'Add Twitter' profile"):
+        assert "Add Twitter" in content
     logging.debug("Supplier cannot see links to any Online Profile on FAB "
                   "Company's Directory Profile Page")
 
@@ -104,8 +124,14 @@ def should_not_see_online_profiles(response: Response):
 def should_see_case_studies(case_studies: dict, response: Response):
     content = response.content.decode("utf-8")
     for case in case_studies:
-        assert case_studies[case].title in content
-        assert case_studies[case].description in content
+        with assertion_msg(
+                "Couldn't find Case Study '%s' title '%s'",
+                case_studies[case].alias, case_studies[case].title):
+            assert case_studies[case].title in content
+        with assertion_msg(
+                "Couldn't find Case Study '%s' description '%s'",
+                case_studies[case].alias, case_studies[case].description):
+            assert case_studies[case].description in content
     logging.debug("Supplier can see all %d Case Studies on FAB Company's "
                   "Directory Profile Page", len(case_studies))
 

--- a/tests/functional/features/pages/fas_ui_profile.py
+++ b/tests/functional/features/pages/fas_ui_profile.py
@@ -8,7 +8,12 @@ from requests import Response, Session
 from tests import get_absolute_url
 from tests.functional.features.context_utils import Company
 from tests.functional.features.pages.common import DETAILS
-from tests.functional.features.utils import Method, check_response, make_request
+from tests.functional.features.utils import (
+    Method,
+    assertion_msg,
+    check_response,
+    make_request
+)
 from tests.settings import SECTORS_WITH_LABELS
 
 URL = get_absolute_url("ui-supplier:suppliers")
@@ -52,28 +57,40 @@ def should_be_here(response, *, number=None):
 def should_see_online_profiles(company: Company, response: Response):
     content = response.content.decode("utf-8")
     if company.facebook:
-        assert "Visit Facebook" in content
-        assert company.facebook in content
+        with assertion_msg("Couldn't find link to company's Facebook profile"):
+            assert "Visit Facebook" in content
+            assert company.facebook in content
     if company.linkedin:
-        assert "Visit LinkedIn" in content
-        assert company.linkedin in content
+        with assertion_msg("Couldn't find link to company's LinkedIn profile"):
+            assert "Visit LinkedIn" in content
+            assert company.linkedin in content
     if company.twitter:
-        assert "Visit Twitter" in content
-        assert company.twitter in content
+        with assertion_msg("Couldn't find link to company's Twitter profile"):
+            assert "Visit Twitter" in content
+            assert company.twitter in content
 
 
 def should_not_see_online_profiles(response: Response):
     content = response.content.decode("utf-8")
-    assert "Visit Facebook" not in content
-    assert "Visit LinkedIn" not in content
-    assert "Visit Twitter" not in content
+    with assertion_msg("Found a link to 'Add Facebook' profile"):
+        assert "Visit Facebook" not in content
+    with assertion_msg("Found a link to 'Add LinkedIn' profile"):
+        assert "Visit LinkedIn" not in content
+    with assertion_msg("Found a link to 'Add Twitter' profile"):
+        assert "Visit Twitter" not in content
 
 
 def should_see_case_studies(case_studies: dict, response: Response):
     content = response.content.decode("utf-8")
     for case in case_studies:
-        assert case_studies[case].title in content
-        assert case_studies[case].description in content
+        with assertion_msg(
+                "Couldn't find Case Study '%s' title '%s'",
+                case_studies[case].alias, case_studies[case].title):
+            assert case_studies[case].title in content
+        with assertion_msg(
+                "Couldn't find Case Study '%s' description '%s'",
+                case_studies[case].alias, case_studies[case].description):
+            assert case_studies[case].description in content
 
 
 def should_see_details(
@@ -94,20 +111,30 @@ def should_see_details(
     sector = DETAILS["SECTOR"] in visible_details
 
     if title:
-        assert company.title in content
+        with assertion_msg("Couldn't find Company's title '%s'", company.title):
+            assert company.title in content
     if keywords:
         for keyword in company.keywords.split(", "):
-            assert keyword.strip() in content
+            with assertion_msg("Couldn't find Company's keyword '%s'", keyword):
+                assert keyword.strip() in content
     if website:
-        assert company.website in content
+        with assertion_msg(
+                "Couldn't find Company's website '%s'", company.website):
+            assert company.website in content
     if size:
-        if company.no_employees == "10001+":
-            assert "10,001+" in content
-        elif company.no_employees == "1001-10000":
-            assert "1,001-10,000" in content
-        elif company.no_employees == "501-1000":
-            assert "501-1,000" in content
-        else:
-            assert company.no_employees in content
+        with assertion_msg(
+                "Couldn't find the size of the company '%s' in the response",
+                company.no_employees):
+            if company.no_employees == "10001+":
+                assert "10,001+" in content
+            elif company.no_employees == "1001-10000":
+                assert "1,001-10,000" in content
+            elif company.no_employees == "501-1000":
+                assert "501-1,000" in content
+            else:
+                assert company.no_employees in content
     if sector:
-        assert SECTORS_WITH_LABELS[company.sector] in content
+        with assertion_msg(
+                "Couldn't find company's sector '%s' in the response",
+                SECTORS_WITH_LABELS[company.sector]):
+            assert SECTORS_WITH_LABELS[company.sector] in content

--- a/tests/functional/features/pages/int_api_ch_search.py
+++ b/tests/functional/features/pages/int_api_ch_search.py
@@ -3,7 +3,7 @@ import logging
 from jsonschema import validate
 
 from tests import get_absolute_url
-from tests.functional.features.utils import Method, make_request
+from tests.functional.features.utils import Method, assertion_msg, make_request
 from tests.functional.schemas.Companies import COMPANIES
 
 URL = get_absolute_url('internal-api:companies-house-search')
@@ -22,10 +22,11 @@ def search(term: str) -> dict:
     params = {"term": term}
     response = make_request(Method.GET, URL, params=params,
                             allow_redirects=False)
-    assert response.status_code == 200, (
-        "Expected 200 but got {}. In case you're getting 301 Redirect then "
-        "check if you're using correct protocol https or http"
-        .format(response.status_code))
+    with assertion_msg(
+            "Expected 200 OK from GET %s but instead got {}. In case you're "
+            "getting 301 Redirect then check if you're using correct protocol "
+            "https or http", response.url, response.status_code):
+        assert response.status_code == 200
     logging.debug("Company House Search result: %s", response.json())
     validate(response.json(), COMPANIES)
 

--- a/tests/functional/features/pages/sso_ui_confim_your_email.py
+++ b/tests/functional/features/pages/sso_ui_confim_your_email.py
@@ -7,7 +7,12 @@ from requests import Response, Session
 
 from tests import get_absolute_url
 from tests.functional.features.context_utils import Actor
-from tests.functional.features.utils import Method, check_response, make_request
+from tests.functional.features.utils import (
+    Method,
+    assertion_msg,
+    check_response,
+    make_request
+)
 
 EXPECTED_STRINGS = [
     "Confirm email Address", "Please confirm that", "is an email",
@@ -31,7 +36,8 @@ def open_confirmation_link(session: Session, link: str) -> Response:
     :param link: email confirmation link
     :return: response object
     """
-    assert link, "Expected a non-empty email confirmation link"
+    with assertion_msg("Expected a non-empty email confirmation link"):
+        assert link
     response = make_request(Method.GET, link, session=session)
     return response
 

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -169,6 +169,20 @@ def has_fas_profile(company_number: str) -> bool:
     return response.status_code == 301
 
 
+def already_registered(company_number: str) -> bool:
+    """Will check if Company is already registered with FAB.
+
+    :param company_number:
+    :return: True/False based on the presence of FAB profile
+    """
+    url = get_absolute_url('ui-buyer:landing')
+    data = {"company_number": company_number}
+    headers = {"Referer": url}
+
+    response = make_request(Method.POST, url, headers=headers, data=data)
+    return "Already registered" in response.content.decode("utf-8")
+
+
 def get_companies(*, number: int = 100) -> CompaniesList:
     """Find a number of active companies without FAS profile.
 

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -16,6 +16,7 @@ from tests.functional.features.context_utils import CaseStudy, Company
 from tests.functional.features.pages import int_api_ch_search
 from tests.functional.features.utils import (
     Method,
+    assertion_msg,
     extract_csrf_middleware_token,
     make_request
 )
@@ -138,9 +139,10 @@ def find_active_company_without_fas_profile(alias: str) -> Company:
             exists = True
             if json[0]["company_status"] == "active":
                 active = True
-                assert json[0]["company_number"] == random_company_number, (
-                    "Expected to get details of company no.: %s but got %s",
-                    random_company_number, json[0]["company_number"])
+                with assertion_msg(
+                        "Expected to get details of company no.: %s but got %s",
+                        random_company_number, json[0]["company_number"]):
+                    assert json[0]["company_number"] == random_company_number
             else:
                 counter += 1
                 has_profile, is_registered, exists, active = True, True, False, False

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -5,6 +5,7 @@ import logging
 from behave.model import Table
 from behave.runner import Context
 from requests import Response
+from retrying import retry
 
 from tests.functional.features.pages import (
     fab_ui_build_profile_basic,

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -5,7 +5,6 @@ import logging
 from behave.model import Table
 from behave.runner import Context
 from requests import Response
-from retrying import retry
 
 from tests.functional.features.pages import (
     fab_ui_build_profile_basic,
@@ -39,7 +38,6 @@ def reg_sso_account_should_be_created(response: Response, supplier_alias: str):
     logging.debug("Successfully created new SSO account for %s", supplier_alias)
 
 
-@retry(wait_fixed=5000, stop_max_attempt_number=18)
 def reg_should_get_verification_email(context: Context, alias: str):
     """Will check if the Supplier received an email verification message.
 

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -43,6 +43,7 @@ from tests.functional.features.pages.utils import (
     random_case_study_data
 )
 from tests.functional.features.utils import (
+    assertion_msg,
     check_response,
     extract_confirm_email_form_action,
     extract_csrf_middleware_token,
@@ -483,7 +484,10 @@ def prof_attempt_to_sign_in_to_fab(context, supplier_alias):
 
     # Step 2 - check if Supplier is on SSO Login page & extract CSRF token
     sso_ui_login.should_be_here(response)
-    assert response.cookies.get("sso_display_logged_in") == "false"
+    with assertion_msg(
+            "It looks like user is still logged in, as the "
+            "sso_display_logged_in cookie is not equal to False"):
+        assert response.cookies.get("sso_display_logged_in") == "false"
     token = extract_csrf_middleware_token(response)
     context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
 
@@ -538,7 +542,10 @@ def prof_sign_in_to_fab(context, supplier_alias):
 
     # Step 2 - check if Supplier is on the SSO Login page
     sso_ui_login.should_be_here(response)
-    assert response.cookies.get("sso_display_logged_in") == "false"
+    with assertion_msg(
+            "It looks like user is still logged in, as the "
+            "sso_display_logged_in cookie is not equal to False"):
+        assert response.cookies.get("sso_display_logged_in") == "false"
 
     # Step 3 - extract CSRF token
     token = extract_csrf_middleware_token(response)
@@ -550,8 +557,14 @@ def prof_sign_in_to_fab(context, supplier_alias):
 
     # Step 5 - check if Supplier is on the FAB profile page
     fab_ui_profile.should_be_here(response)
-    assert "sso_display_logged_in" not in response.cookies
-    assert "directory_sso_dev_session" not in response.cookies
+    with assertion_msg(
+            "Found sso_display_logged_in cookie in the response. Maybe user is "
+            "still logged in?"):
+        assert "sso_display_logged_in" not in response.cookies
+    with assertion_msg(
+            "Found directory_sso_dev_session cookie in the response. Maybe user"
+            " is still logged in?"):
+        assert "directory_sso_dev_session" not in response.cookies
 
 
 def reg_create_standalone_sso_account(context: Context, supplier_alias: str):
@@ -571,7 +584,10 @@ def reg_create_standalone_sso_account(context: Context, supplier_alias: str):
     context.response = response
 
     # Step 2: Check if User is not logged in
-    assert response.cookies.get("sso_display_logged_in") == "false"
+    with assertion_msg(
+            "It looks like user is still logged in, as the "
+            "sso_display_logged_in cookie is not equal to False"):
+        assert response.cookies.get("sso_display_logged_in") == "false"
 
     # Step 3: POST SSO accounts/signup/
     response = sso_ui_register.submit_no_company(actor)
@@ -579,7 +595,10 @@ def reg_create_standalone_sso_account(context: Context, supplier_alias: str):
 
     # Step 3: Check if Supplier is on Verify your email page & is not logged in
     sso_ui_verify_your_email.should_be_here(response)
-    assert response.cookies.get("sso_display_logged_in") == "false"
+    with assertion_msg(
+            "It looks like user is still logged in, as the "
+            "sso_display_logged_in cookie is not equal to False"):
+        assert response.cookies.get("sso_display_logged_in") == "false"
 
 
 def sso_supplier_confirms_email_address(context, supplier_alias):

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -859,6 +859,7 @@ def prof_add_online_profiles(context, supplier_alias, online_profiles):
 
     # Step 1 - Go to the FAB Edit Online Profiles page
     response = fab_ui_edit_online_profiles.go_to(session)
+    context.response = response
 
     # Step 2 - Extract CSRF token
     extract_and_set_csrf_middleware_token(context, response, supplier_alias)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -810,7 +810,7 @@ def prof_update_company_details(
     fab_ui_profile.should_be_here(response)
 
     # Step 5 - Go to the Edit Sector page
-    fab_ui_edit_sector.go_to(session)
+    response = fab_ui_edit_sector.go_to(session)
     context.response = response
 
     # Step 5 - extract CSRF token

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -483,32 +483,25 @@ def mailgun_get_message_url(recipient: str) -> str:
 
 
 @contextmanager
-def assertion_msg(*args):
+def assertion_msg(message: str, *args):
     """This will:
         * print the custom assertion message
         * print the traceback (stack trace)
         * raise the original AssertionError exception
 
-    :param args: a custom assertion message. It can be:
-                 * just a string, eg.:
-                    log_assertion_error("This is a simple assertion error")
-                 * or contain standard string format placeholders, like: %s, %d
-                   but then correct number of arguments needs to be provided eg:
-                    log_assertion_error("Expected %s got %s", "a", "b")
+    :param message: a message that will be printed & logged when assertion fails
+    :param args: values that will replace % conversion specifications in message
+                 like: %s, %d
     """
     try:
         yield
     except AssertionError as e:
-        logging.error(*args)
-        if len(args) > 1:
-            # format the assertion error message.
-            # This assumes that the first argument contains a string with
-            # format placeholders, like: %s, %d etc
-            e.args += (args[0] % tuple(args[1:]), )
-        else:
-            e.args += args
+        if args:
+            message = message % args
+        logging.error(message)
+        e.args += (message,)
         _, _, tb = sys.exc_info()
-        traceback.print_tb(tb)  # Fixed format
+        traceback.print_tb(tb)
         raise
 
 

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -480,7 +480,9 @@ def mailgun_get_message_url(recipient: str) -> str:
     response = requests.get(url, auth=("api", api_key), params=params)
 
     assert response.status_code == 200
-    assert len(response.json()["items"]) == message_limit
+    no_of_items = len(response.json()["items"])
+    with log_assertion_error("Could not find MailGun event for %s", recipient):
+        assert no_of_items == message_limit
     logging.debug("Found event with recipient: {}".format(recipient))
     return response.json()["items"][0]["storage"]["url"]
 

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -16,10 +16,10 @@ from tests.functional.features.db_cleanup import get_dir_db_connection
 from tests.settings import MAILGUN_EVENTS_URL, MAILGUN_SECRET_API_KEY
 
 
-def get_file_log_handler(log_formatter,
-                         log_file=os.path.join(".", "tests", "functional",
-                                               "reports", "behave.log"),
-                         log_level=logging.DEBUG):
+def get_file_log_handler(
+        log_formatter, log_file=os.path.join(
+            ".", "tests", "functional", "reports", "behave.log"),
+        log_level=logging.DEBUG):
     """Configure the console logger.
 
     Will use DEBUG logging level by default.

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -8,6 +8,7 @@ from enum import Enum
 
 import requests
 from requests.models import Response
+from retrying import retry
 from scrapy.selector import Selector
 
 from tests.functional.features.db_cleanup import get_dir_db_connection
@@ -502,6 +503,7 @@ def mailgun_get_message_url(recipient: str) -> str:
     return response.json()["items"][0]["storage"]["url"]
 
 
+@retry(wait_fixed=3000, stop_max_attempt_number=15)
 def get_verification_link(recipient: str) -> str:
     """Get email verification link sent by SSO to specified recipient.
 

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -7,6 +7,7 @@ import os
 from enum import Enum
 
 import requests
+from behave.runner import Context
 from requests.models import Response
 from retrying import retry
 from scrapy.selector import Selector
@@ -50,22 +51,15 @@ def get_console_log_handler(log_formatter, log_level=logging.ERROR):
     return console_handler
 
 
-def init_loggers():
+def init_loggers(context: Context):
     """Will initialize console and file loggers."""
-    # get the root logger
-    root_logger = logging.getLogger()
-    # "disable" `urllib3` logger, which is used by `requests`
-    logging.getLogger("boto").setLevel(logging.WARNING)
-    logging.getLogger("urllib3").setLevel(logging.WARNING)
-
     # configure the formatter
     fmt = ('%(asctime)s-%(filename)s[line:%(lineno)d]-%(name)s-%(levelname)s: '
            '%(message)s')
     log_formatter = logging.Formatter(fmt)
-
-    # configure the file & console loggers
-    root_logger.addHandler(get_file_log_handler(log_formatter))
-    root_logger.addHandler(get_console_log_handler(log_formatter))
+    log_file_handler = get_file_log_handler(log_formatter)
+    # Add log file handler to Behave's logging
+    context.config.setup_logging(handlers=[log_file_handler])
 
 
 class Method(Enum):

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -36,21 +36,6 @@ def get_file_log_handler(log_formatter,
     return file_handler
 
 
-def get_console_log_handler(log_formatter, log_level=logging.ERROR):
-    """Configure the console logger.
-
-    Will use ERROR logging level by default.
-
-    :param log_formatter: specifies how the log entries will look like
-    :param log_level: specifies logging level, e.g.: logging.ERROR
-    :return: configured console log handler
-    """
-    console_handler = logging.StreamHandler()
-    console_handler.setFormatter(log_formatter)
-    console_handler.setLevel(log_level)
-    return console_handler
-
-
 def init_loggers(context: Context):
     """Will initialize console and file loggers."""
     # configure the formatter


### PR DESCRIPTION
[This ticket](https://uktrade.atlassian.net/browse/ED-1933)

This add a custom context manager for `with` statement that allows to:
* print the custom assertion message
* print the `traceback` (stack trace)
* raise the original `AssertionError` exception
in one go.

Apart from that:
* I've added a step to verify whether company is already registered with FAB or not
* added `--stop` parameter to `functional_tests` target in make file, which forces `behave` to stop the test run on first failure (can save us some time)
* make `behave` print to the console last recorded response content, should help to shorten the time required to analyse the reason behind the failure.

Here's an example of it in action:
```bash
$ behave -k --format progress3 --stop tests/functional/features -t exception --no-logcapture
Supplied path: "tests/functional/features"
Trying base directory: /home/jk/git/dit/directory-tests/tests/functional/features
Behave log file: ./tests/functional/reports/behave.log
Trade Profile    # tests/functional/features/fab/profile.feature
  test exception  F
--------------------------------------------------------------------------------
FAILURE in step 'exception' (tests/functional/features/fab/profile.feature:437):
Assertion Failed: Expected 300 but got 200
Captured stderr:
  File "tests/functional/features/steps/fab_given_def.py", line 141, in log_assertion_error
    yield
  File "tests/functional/features/steps/fab_given_def.py", line 165, in step_impl
    assert given_status_code == exp_status_code

--------------------------------------------------------------------------------


Failing scenarios:
  tests/functional/features/fab/profile.feature:436  test exception

0 features passed, 1 failed, 0 skipped, 1 untested
0 scenarios passed, 1 failed, 29 skipped, 2 untested
0 steps passed, 1 failed, 158 skipped, 0 undefined, 9 untested
Took 0m0.000s
```