### PR TITLE
ED-1746 more find by case study details scenarios

### DIFF
--- a/tests/functional/features/fas/search.feature
+++ b/tests/functional/features/fas/search.feature
@@ -40,8 +40,6 @@ Feature: Find a Supplier
   @profile
   @verified
   @published
-  @wip
-  @skip
   Scenario: Buyers should be able to find Supplier by uniquely identifying words present on any of Supplier's case studies
     Given "Annette Geissinger" is a buyer
     And "Peter Alder" is an unauthenticated supplier
@@ -62,8 +60,6 @@ Feature: Find a Supplier
   @profile
   @unverified
   @unpublished
-  @wip
-  @skip
   Scenario: Buyers should NOT be able to find unverified Supplier by uniquely identifying words present on Supplier's case study
     Given "Annette Geissinger" is a buyer
     And "Peter Alder" is an unauthenticated supplier

--- a/tests/functional/features/fas/search.feature
+++ b/tests/functional/features/fas/search.feature
@@ -51,9 +51,9 @@ Feature: Find a Supplier
     And "Peter Alder" adds a complete case study called "no 2"
     And "Peter Alder" adds a complete case study called "no 3"
 
-    Then "Annette Geissinger" should be able to find company "Y" on FAS by using any unique word present on case study "no 1"
-    And "Annette Geissinger" should be able to find company "Y" on FAS by using any unique word present on case study "no 2"
-    And "Annette Geissinger" should be able to find company "Y" on FAS by using any unique word present on case study "no 3"
+    Then "Annette Geissinger" should be able to find company "Y" on FAS using any part of case study "no 1"
+    And "Annette Geissinger" should be able to find company "Y" on FAS using any part of case study "no 2"
+    And "Annette Geissinger" should be able to find company "Y" on FAS using any part of case study "no 3"
 
 
   @ED-1746
@@ -67,8 +67,8 @@ Feature: Find a Supplier
   Scenario: Buyers should NOT be able to find unverified Supplier by uniquely identifying words present on Supplier's case study
     Given "Annette Geissinger" is a buyer
     And "Peter Alder" is an unauthenticated supplier
-    And "Peter Alder" has created and unverified profile for randomly selected company "Y"
+    And "Peter Alder" created an unverified profile for randomly selected company "Y"
 
     When "Peter Alder" adds a complete case study called "no 1"
 
-    Then "Annette Geissinger" should NOT be able to find company "Y" on FAS by using any unique word present on case study "no 1"
+    Then "Annette Geissinger" should NOT be able to find company "Y" on FAS by using any part of case study "no 1"

--- a/tests/functional/features/pages/fab_ui_confirm_company.py
+++ b/tests/functional/features/pages/fab_ui_confirm_company.py
@@ -40,7 +40,7 @@ def should_be_here(response: Response, company: Company):
     :param response: response with Confirm Export Status page
     :param company: a namedtuple with Company details
     """
-    escaped_company_title = escape_html(company.title).upper()
+    escaped_company_title = escape_html(company.title, upper=True)
     expected = EXPECTED_STRINGS + [escaped_company_title, company.number]
     check_response(response, 200, body_contains=expected)
     logging.debug("Successfully got to the Confirm your Company page")

--- a/tests/functional/features/pages/fab_ui_confirm_company.py
+++ b/tests/functional/features/pages/fab_ui_confirm_company.py
@@ -6,6 +6,7 @@ from requests import Response, Session
 
 from tests import get_absolute_url
 from tests.functional.features.context_utils import Company
+from tests.functional.features.pages.utils import escape_html
 from tests.functional.features.utils import Method, check_response, make_request
 
 URL = get_absolute_url('ui-buyer:landing')
@@ -39,11 +40,7 @@ def should_be_here(response: Response, company: Company):
     :param response: response with Confirm Export Status page
     :param company: a namedtuple with Company details
     """
-    # a bit of HTML escaping is required to assert that we're confirming the
-    # selection of correct company
-    html_escape_table = {"&": "&amp;", "'": "&#39;"}
-    escaped_company_title = "".join(html_escape_table.get(c, c) for c in
-                                    company.title.upper())
+    escaped_company_title = escape_html(company.title).upper()
     expected = EXPECTED_STRINGS + [escaped_company_title, company.number]
     check_response(response, 200, body_contains=expected)
     logging.debug("Successfully got to the Confirm your Company page")

--- a/tests/functional/features/pages/fas_ui_find_supplier.py
+++ b/tests/functional/features/pages/fas_ui_find_supplier.py
@@ -5,6 +5,7 @@ import logging
 from requests import Response, Session
 
 from tests import get_absolute_url
+from tests.functional.features.pages.utils import escape_html
 from tests.functional.features.utils import Method, check_response, make_request
 
 URL = get_absolute_url("ui-supplier:search")
@@ -43,9 +44,9 @@ def should_be_here(response, *, number=None):
 
 def should_see_company(response: Response, company_title: str) -> bool:
     content = response.content.decode("utf-8")
-    return company_title in content
+    return escape_html(company_title).upper() in content
 
 
 def should_not_see_company(response: Response, company_title: str) -> bool:
     content = response.content.decode("utf-8")
-    return company_title not in content
+    return escape_html(company_title).upper() not in content

--- a/tests/functional/features/pages/fas_ui_find_supplier.py
+++ b/tests/functional/features/pages/fas_ui_find_supplier.py
@@ -44,3 +44,8 @@ def should_be_here(response, *, number=None):
 def should_see_company(response: Response, company_title: str) -> bool:
     content = response.content.decode("utf-8")
     return company_title in content
+
+
+def should_not_see_company(response: Response, company_title: str) -> bool:
+    content = response.content.decode("utf-8")
+    return company_title not in content

--- a/tests/functional/features/pages/fas_ui_find_supplier.py
+++ b/tests/functional/features/pages/fas_ui_find_supplier.py
@@ -44,9 +44,9 @@ def should_be_here(response, *, number=None):
 
 def should_see_company(response: Response, company_title: str) -> bool:
     content = response.content.decode("utf-8")
-    return escape_html(company_title).upper() in content
+    return escape_html(company_title, upper=True) in content
 
 
 def should_not_see_company(response: Response, company_title: str) -> bool:
     content = response.content.decode("utf-8")
-    return escape_html(company_title).upper() not in content
+    return escape_html(company_title, upper=True)not in content

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -226,3 +226,13 @@ def load_companies() -> CompaniesList:
     """
     with open(os.path.join(TEST_IMAGES_DIR, 'companies.pkl'), 'rb') as f:
         return pickle.load(f)
+
+
+def escape_html(text: str) -> str:
+    """Escape some of the special characters that are replaced by FAB/SSO.
+
+    :param text: a string to escape
+    :return: a string with escaped characters
+    """
+    html_escape_table = {"&": "&amp;", "'": "&#39;"}
+    return "".join(html_escape_table.get(c, c) for c in text)

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -228,11 +228,14 @@ def load_companies() -> CompaniesList:
         return pickle.load(f)
 
 
-def escape_html(text: str) -> str:
+def escape_html(text: str, *, upper: bool = False) -> str:
     """Escape some of the special characters that are replaced by FAB/SSO.
 
     :param text: a string to escape
+    :param upper: (optional) change to upper case before escaping the characters
     :return: a string with escaped characters
     """
     html_escape_table = {"&": "&amp;", "'": "&#39;"}
+    if upper:
+        text = text.upper()
     return "".join(html_escape_table.get(c, c) for c in text)

--- a/tests/functional/features/steps/fab_given_def.py
+++ b/tests/functional/features/steps/fab_given_def.py
@@ -6,6 +6,7 @@ from tests.functional.features.steps.fab_given_impl import (
     bp_build_company_profile,
     reg_confirm_email_address,
     reg_create_sso_account_associated_with_company,
+    reg_create_unverified_profile,
     reg_create_verified_profile,
     reg_select_random_company_and_confirm_export_status,
     sso_create_standalone_unverified_sso_account,
@@ -108,12 +109,7 @@ def given_supplier_adds_valid_links_to_online_profiles(context, supplier_alias):
 @given('"{supplier_alias}" created an unverified profile for randomly selected '
        'company "{company_alias}"')
 def given_unverified_profile(context, supplier_alias, company_alias):
-    supplier = unauthenticated_supplier(supplier_alias)
-    context.add_actor(supplier)
-    reg_create_sso_account_associated_with_company(
-        context, supplier_alias, company_alias)
-    reg_confirm_email_address(context, supplier_alias)
-    bp_build_company_profile(context, supplier_alias)
+    reg_create_unverified_profile(context, supplier_alias, company_alias)
 
 
 @given('"{supplier_alias}" has set "{picture}" picture as company\'s logo')

--- a/tests/functional/features/steps/fab_given_impl.py
+++ b/tests/functional/features/steps/fab_given_impl.py
@@ -160,3 +160,12 @@ def reg_select_random_company_and_confirm_export_status(
     reg_confirm_company_selection(context, supplier_alias, company_alias)
     reg_confirm_export_status(context, supplier_alias, exported=True)
     bp_should_be_prompted_to_build_your_profile(context, supplier_alias)
+
+
+def reg_create_unverified_profile(context, supplier_alias, company_alias):
+    supplier = unauthenticated_supplier(supplier_alias)
+    context.add_actor(supplier)
+    reg_create_sso_account_associated_with_company(
+        context, supplier_alias, company_alias)
+    reg_confirm_email_address(context, supplier_alias)
+    bp_build_company_profile(context, supplier_alias)

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -172,7 +172,8 @@ def then_supplier_should_see_new_details_on_fas(context, supplier_alias):
 def then_buyer_should_find_supplier_using_part_of_case_study(
         context, buyer_alias, company_alias, case_alias):
     fas_find_supplier_using_case_study_details(
-        context, buyer_alias, company_alias, case_alias, context.table)
+        context, buyer_alias, company_alias, case_alias,
+        properties=context.table)
 
 
 @then('"{buyer_alias}" should NOT be able to find company "{company_alias}" on '

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -26,8 +26,8 @@ from tests.functional.features.steps.fab_then_impl import (
     reg_sso_account_should_be_created,
     reg_supplier_has_to_verify_email_first,
     reg_supplier_is_not_appropriate_for_fab,
-    sso_should_be_signed_in_to_sso_account
-)
+    sso_should_be_signed_in_to_sso_account,
+    fas_supplier_cannot_be_found_using_case_study_details)
 
 
 @then('"{alias}" should be told about the verification email')
@@ -169,7 +169,22 @@ def then_supplier_should_see_new_details_on_fas(context, supplier_alias):
 
 @then('"{buyer_alias}" should be able to find company "{company_alias}" on FAS '
       'using words from case study "{case_alias}"')
-def then_buyer_should_find_supplier_using_unique_words(
+def then_buyer_should_find_supplier_using_part_of_case_study(
         context, buyer_alias, company_alias, case_alias):
     fas_find_supplier_using_case_study_details(
         context, buyer_alias, company_alias, case_alias, context.table)
+
+
+@then('"{buyer_alias}" should NOT be able to find company "{company_alias}" on '
+      'FAS by using any part of case study "{case_alias}"')
+def step_impl(context, buyer_alias, company_alias, case_alias):
+    fas_supplier_cannot_be_found_using_case_study_details(
+        context, buyer_alias, company_alias, case_alias)
+
+
+@then('"{buyer_alias}" should be able to find company "{company_alias}" on FAS '
+      'using any part of case study "{case_alias}"')
+def then_buyer_should_find_supplier_using_any_part_of_case_study(
+        context, buyer_alias, company_alias, case_alias):
+    fas_find_supplier_using_case_study_details(
+        context, buyer_alias, company_alias, case_alias)

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -16,6 +16,7 @@ from tests.functional.features.steps.fab_then_impl import (
     fas_should_see_all_case_studies,
     fas_should_see_company_details,
     fas_should_see_logo_picture,
+    fas_supplier_cannot_be_found_using_case_study_details,
     prof_all_unsupported_files_should_be_rejected,
     prof_should_be_on_profile_page,
     prof_should_be_told_about_invalid_links,
@@ -26,8 +27,8 @@ from tests.functional.features.steps.fab_then_impl import (
     reg_sso_account_should_be_created,
     reg_supplier_has_to_verify_email_first,
     reg_supplier_is_not_appropriate_for_fab,
-    sso_should_be_signed_in_to_sso_account,
-    fas_supplier_cannot_be_found_using_case_study_details)
+    sso_should_be_signed_in_to_sso_account
+)
 
 
 @then('"{alias}" should be told about the verification email')

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -52,7 +52,7 @@ def reg_should_get_verification_email(context: Context, alias: str):
     """
     logging.debug("Searching for an email verification message...")
     actor = context.get_actor(alias)
-    link = get_verification_link(actor.email)
+    link = get_verification_link(context, actor.email)
     context.set_actor_email_confirmation_link(alias, link)
 
 

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -355,10 +355,8 @@ def fas_find_supplier_using_case_study_details(
     search_terms = {}
     for key in keys:
         if key == "keywords":
-            i = 0
-            for keyword in case_study.keywords.split(", "):
-                i += 1
-                search_terms["keyword #{}".format(i)] = keyword
+            for index, keyword in enumerate(case_study.keywords.split(", ")):
+                search_terms["keyword #{}".format(index)] = keyword
         else:
             search_terms[key] = getattr(case_study, key.replace(" ", "_"))
     logging.debug(
@@ -388,10 +386,8 @@ def fas_supplier_cannot_be_found_using_case_study_details(
     search_terms = {}
     for key in keys:
         if key == "keywords":
-            i = 0
-            for keyword in case_study.keywords.split(", "):
-                i += 1
-                search_terms["keyword #{}".format(i)] = keyword
+            for index, keyword in enumerate(case_study.keywords.split(", ")):
+                search_terms["keyword #{}".format(index)] = keyword
         else:
             search_terms[key] = getattr(case_study, key)
     logging.debug(

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -24,6 +24,7 @@ from tests.functional.features.utils import (
     extract_logo_url,
     get_verification_link
 )
+from tests.settings import SEARCHABLE_CASE_STUDY_DETAILS
 
 
 def reg_sso_account_should_be_created(response: Response, supplier_alias: str):
@@ -348,11 +349,9 @@ def fas_find_supplier_using_case_study_details(
     session = actor.session
     company = context.get_company(company_alias)
     case_study = company.case_studies[case_alias]
+    keys = SEARCHABLE_CASE_STUDY_DETAILS
     if properties:
         keys = [row['search using case study\'s'] for row in properties]
-    else:
-        skip = ['alias', 'image_1', 'image_2', 'image_3', 'sector']
-        keys = list(filter(lambda x: x not in skip, case_study._fields))
     search_terms = {}
     for key in keys:
         if key == "keywords":
@@ -385,7 +384,7 @@ def fas_supplier_cannot_be_found_using_case_study_details(
     session = actor.session
     company = context.get_company(company_alias)
     case_study = company.case_studies[case_alias]
-    keys = list(filter(lambda x: x != 'alias', case_study._fields))
+    keys = SEARCHABLE_CASE_STUDY_DETAILS
     search_terms = {}
     for key in keys:
         if key == "keywords":

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -351,7 +351,8 @@ def fas_find_supplier_using_case_study_details(
     if properties:
         keys = [row['search using case study\'s'] for row in properties]
     else:
-        keys = list(filter(lambda x: x != 'alias', case_study._fields))
+        skip = ['alias', 'image_1', 'image_2', 'image_3']
+        keys = list(filter(lambda x: x not in skip, case_study._fields))
     search_terms = {}
     for key in keys:
         if key == "keywords":

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -406,8 +406,10 @@ def fas_supplier_cannot_be_found_using_case_study_details(
         response = fas_ui_find_supplier.go_to(session, term=term)
         context.response = response
         found = fas_ui_find_supplier.should_not_see_company(response, company.title)
-        assert found, ("Buyer found Supplier '{}' on FAS using {}: {}"
-                       .format(company.title, term_name, term))
+        with assertion_msg(
+                "Buyer found Supplier '%s' on FAS using %s: %s", company.title,
+                term_name, term):
+            assert found
         logging.debug(
             "Buyer was not able to find unverified Supplier '%s' on FAS using "
             "%s: %s", company.title, term_name, term)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -351,7 +351,7 @@ def fas_find_supplier_using_case_study_details(
     if properties:
         keys = [row['search using case study\'s'] for row in properties]
     else:
-        skip = ['alias', 'image_1', 'image_2', 'image_3']
+        skip = ['alias', 'image_1', 'image_2', 'image_3', 'sector']
         keys = list(filter(lambda x: x not in skip, case_study._fields))
     search_terms = {}
     for key in keys:

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -956,7 +956,6 @@ def prof_add_case_study(context, supplier_alias, case_alias):
     :param context: behave `context` object
     :param supplier_alias: alias of the Actor used in the scope of the scenario
     :param case_alias: alias of the Case Study used in the scope of the scenario
-    :param unique: use uniquely identifying words if True, otherwise False
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -440,7 +440,7 @@ def check_hash_of_remote_file(expected_hash, file_url):
         assert expected_hash == file_hash
 
 
-@retry(wait_fixed=3000, stop_max_attempt_number=15)
+@retry(wait_fixed=10000, stop_max_attempt_number=9)
 def mailgun_get_message(context: Context, url: str) -> dict:
     """Get message detail by its URL.
 
@@ -461,7 +461,7 @@ def mailgun_get_message(context: Context, url: str) -> dict:
     return response.json()
 
 
-@retry(wait_fixed=3000, stop_max_attempt_number=15)
+@retry(wait_fixed=10000, stop_max_attempt_number=9)
 def mailgun_get_message_url(context: Context, recipient: str) -> str:
     """Will try to find the message URL among 100 emails sent in last 1 hour.
 

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -114,9 +114,12 @@ def make_request(method: Method, url, *, session=None, params=None,
     req = session or requests
     trim_offset = 150  # define the length of logged response content
 
+    connect_timeout = 3.05
+    read_timeout = 60
     request_kwargs = dict(url=url, params=params, headers=headers,
                           cookies=cookies, data=data, files=files,
-                          allow_redirects=allow_redirects)
+                          allow_redirects=allow_redirects,
+                          timeout=(connect_timeout, read_timeout))
 
     if method == Method.DELETE:
         res = req.delete(**request_kwargs)

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -440,6 +440,7 @@ def check_hash_of_remote_file(expected_hash, file_url):
         assert expected_hash == file_hash
 
 
+@retry(wait_fixed=3000, stop_max_attempt_number=15)
 def mailgun_get_message(context: Context, url: str) -> dict:
     """Get message detail by its URL.
 
@@ -460,6 +461,7 @@ def mailgun_get_message(context: Context, url: str) -> dict:
     return response.json()
 
 
+@retry(wait_fixed=3000, stop_max_attempt_number=15)
 def mailgun_get_message_url(context: Context, recipient: str) -> str:
     """Will try to find the message URL among 100 emails sent in last 1 hour.
 
@@ -513,7 +515,6 @@ def assertion_msg(message: str, *args):
         raise
 
 
-@retry(wait_fixed=3000, stop_max_attempt_number=15)
 def get_verification_link(context: Context, recipient: str) -> str:
     """Get email verification link sent by SSO to specified recipient.
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -167,3 +167,10 @@ nine = sorted(set([w.lower() for w in words
 """
 with open(os.path.join(TEST_IMAGES_DIR, "rare.txt"), "r") as f:
     RARE_WORDS = f.read().split()
+
+
+SEARCHABLE_CASE_STUDY_DETAILS = [
+    'title', 'summary', 'description', 'website', 'keywords', 'caption_1',
+    'caption_2', 'caption_3', 'testimonial', 'source_name', 'source_job',
+    'source_company'
+]


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-1746)
This implements 2 scenarios:

```gherkin
  @ED-1746
  @fas
  @case-study
  @profile
  @verified
  @published
  Scenario: Buyers should be able to find Supplier by uniquely identifying words present on any of Supplier's case studies
    Given "Annette Geissinger" is a buyer
    And "Peter Alder" is an unauthenticated supplier
    And "Peter Alder" has created and verified profile for randomly selected company "Y"

    When "Peter Alder" adds a complete case study called "no 1"
    And "Peter Alder" adds a complete case study called "no 2"
    And "Peter Alder" adds a complete case study called "no 3"

    Then "Annette Geissinger" should be able to find company "Y" on FAS using any part of case study "no 1"
    And "Annette Geissinger" should be able to find company "Y" on FAS using any part of case study "no 2"
    And "Annette Geissinger" should be able to find company "Y" on FAS using any part of case study "no 3"


  @ED-1746
  @fas
  @case-study
  @profile
  @unverified
  @unpublished
  Scenario: Buyers should NOT be able to find unverified Supplier by uniquely identifying words present on Supplier's case study
    Given "Annette Geissinger" is a buyer
    And "Peter Alder" is an unauthenticated supplier
    And "Peter Alder" created an unverified profile for randomly selected company "Y"

    When "Peter Alder" adds a complete case study called "no 1"

    Then "Annette Geissinger" should NOT be able to find company "Y" on FAS by using any part of case study "no 1"
```