### PR TITLE
ED-1967 find Supplier on FAS by company's details

### DIFF
--- a/requirements_functional.ini
+++ b/requirements_functional.ini
@@ -1,6 +1,5 @@
 beautifulsoup4==4.6.0
 behave==1.2.5
-Faker==0.7.17
 flake8==3.0.4
 jsonschema==2.6.0
 langdetect==1.0.7

--- a/requirements_functional.txt
+++ b/requirements_functional.txt
@@ -15,7 +15,6 @@ chardet==3.0.4            # via requests
 constantly==15.1.0        # via twisted
 cryptography==2.0.3       # via pyopenssl
 cssselect==1.0.1          # via parsel, scrapy
-faker==0.7.17
 flake8==3.0.4
 hyperlink==17.3.0         # via twisted
 idna==2.5                 # via cryptography, requests
@@ -35,13 +34,12 @@ pycparser==2.18           # via cffi
 pydispatcher==2.0.5       # via scrapy
 pyflakes==1.2.3           # via flake8
 pyopenssl==17.2.0         # via scrapy, service-identity
-python-dateutil==2.6.1    # via faker
 queuelib==1.4.2           # via scrapy
 requests==2.17.3
 retrying==1.3.3
 scrapy==1.4.0
 service-identity==17.0.0  # via scrapy
-six==1.10.0               # via automat, behave, cryptography, faker, langdetect, parse-type, parsel, pyopenssl, python-dateutil, retrying, scrapy, w3lib
+six==1.10.0               # via automat, behave, cryptography, langdetect, parse-type, parsel, pyopenssl, retrying, scrapy, w3lib
 termcolor==1.1.0
 twisted==17.5.0           # via scrapy
 urllib3==1.21.1           # via requests

--- a/tests/functional/features/fas/search.feature
+++ b/tests/functional/features/fas/search.feature
@@ -68,3 +68,44 @@ Feature: Find a Supplier
     When "Peter Alder" adds a complete case study called "no 1"
 
     Then "Annette Geissinger" should NOT be able to find company "Y" on FAS by using any part of case study "no 1"
+
+
+  @ED-1967
+  @fas
+  @search
+  @profile
+  @verified
+  @published
+  Scenario: Buyers should be able to find Supplier by uniquely identifying words present on Supplier's profile
+    Given "Annette Geissinger" is a buyer
+    And "Peter Alder" is an unauthenticated supplier
+    And "Peter Alder" has created and verified profile for randomly selected company "Y"
+    And "Peter Alder" has added links to online profiles
+      | online profile  |
+      | Facebook        |
+      | LinkedIn        |
+      | Twitter         |
+
+    When "Annette Geissinger" searches for company "Y" on FAS using selected company's details
+      | company detail |
+      | title          |
+      | number         |
+      | keywords       |
+      | website        |
+      | summary        |
+      | description    |
+      | facebook       |
+      | twitter        |
+      | linkedin       |
+
+    Then "Annette Geissinger" should be able to find company "Y" on FAS using selected company's details
+      | company detail |
+      | title          |
+      | number         |
+      | keywords       |
+      | website        |
+      | summary        |
+      | description    |
+      | facebook       |
+      | twitter        |
+      | linkedin       |

--- a/tests/functional/features/pages/fab_ui_case_study_basic.py
+++ b/tests/functional/features/pages/fab_ui_case_study_basic.py
@@ -2,7 +2,6 @@
 """FAB - Add Case Study - Basic page"""
 import logging
 
-from faker import Factory
 from requests import Response, Session
 
 from tests import get_absolute_url
@@ -31,7 +30,6 @@ EXPECTED_STRINGS = [
     ("These keywords will be used to help potential overseas buyers find your "
      "case study."), "Next", "Cancel"
 ]
-FAKE = Factory.create()
 
 
 def should_be_here(response: Response):

--- a/tests/functional/features/pages/fab_ui_case_study_images.py
+++ b/tests/functional/features/pages/fab_ui_case_study_images.py
@@ -2,7 +2,6 @@
 """FAB - Add Case Study - Images page"""
 import logging
 
-from faker import Factory
 from requests import Response, Session
 
 from tests import get_absolute_url
@@ -30,7 +29,6 @@ EXPECTED_STRINGS = [
     "Job title of the source (optional):", "< Back to previous step", "Save",
     "Company name of the source (optional):"
 ]
-FAKE = Factory.create()
 
 
 def should_be_here(response: Response):

--- a/tests/functional/features/pages/fab_ui_edit_address.py
+++ b/tests/functional/features/pages/fab_ui_edit_address.py
@@ -2,11 +2,11 @@
 """FAB - Edit the name of the letters recipient"""
 import logging
 
-from faker import Factory
 from requests import Response
 
 from tests import get_absolute_url
 from tests.functional.features.context_utils import Actor, Company
+from tests.functional.features.pages.utils import rare_word
 from tests.functional.features.utils import Method, check_response, make_request
 
 URL = get_absolute_url("ui-buyer:company-edit")
@@ -19,7 +19,6 @@ EXPECTED_STRINGS = [
     "Address line 1:", "Address line 2:", "City:", "Country:", "Postcode:",
     "PO box:", "Back to previous step", "Save"
 ]
-FAKE = Factory.create()
 
 
 def should_be_here(response: Response):
@@ -49,7 +48,7 @@ def update_letters_recipient(
     address = company.address_details
 
     if update:
-        new_full_name = full_name or FAKE.name()
+        new_full_name = full_name or rare_word()
     else:
         new_full_name = address.letter_recipient
 

--- a/tests/functional/features/pages/fab_ui_edit_details.py
+++ b/tests/functional/features/pages/fab_ui_edit_details.py
@@ -71,7 +71,7 @@ def update_details(
         new_title = company.title
 
     if website:
-        new_website = specific_website or "http://{}".format(rare_word())
+        new_website = specific_website or "http://{}.com".format(rare_word())
     else:
         new_website = company.website
 

--- a/tests/functional/features/pages/fab_ui_edit_details.py
+++ b/tests/functional/features/pages/fab_ui_edit_details.py
@@ -2,11 +2,11 @@
 """FAB - Edit Company's Details page"""
 import random
 
-from faker import Factory
 from requests import Response, Session
 
 from tests import get_absolute_url
 from tests.functional.features.context_utils import Actor, Company
+from tests.functional.features.pages.utils import rare_word, sentence
 from tests.functional.features.utils import Method, check_response, make_request
 from tests.settings import NO_OF_EMPLOYEES
 
@@ -21,7 +21,6 @@ EXPECTED_STRINGS = [
     ("Tell international buyers more about your business to ensure the right "
      "buyers can find you.")
 ] + NO_OF_EMPLOYEES
-FAKE = Factory.create()
 
 
 def should_be_here(response: Response):
@@ -67,17 +66,17 @@ def update_details(
     token = actor.csrfmiddlewaretoken
 
     if title:
-        new_title = specific_title or FAKE.sentence()
+        new_title = specific_title or sentence()
     else:
         new_title = company.title
 
     if website:
-        new_website = specific_website or "http://{}".format(FAKE.domain_name())
+        new_website = specific_website or "http://{}".format(rare_word())
     else:
         new_website = company.website
 
     if keywords:
-        random_keywords = ", ".join(FAKE.sentence().replace(".", "").split())
+        random_keywords = ", ".join(sentence().split())
         new_keywords = specific_keywords or random_keywords
     else:
         new_keywords = company.keywords

--- a/tests/functional/features/pages/fab_ui_edit_online_profiles.py
+++ b/tests/functional/features/pages/fab_ui_edit_online_profiles.py
@@ -3,7 +3,6 @@
 import logging
 import random
 
-from faker import Factory
 from requests import Response, Session
 
 from tests import get_absolute_url
@@ -26,7 +25,6 @@ EXPECTED_STRINGS = [
     "Use a full web address (URL) including http:// or https://",
     "Save", "Cancel"
 ]
-FAKE = Factory.create()
 
 
 def should_be_here(response: Response):

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -53,7 +53,7 @@ def sentence(*, max_length: int = 60, min_word_length: int = 9, max_words: int =
     :return: a sentence consisting of rare english words
     """
     words = []
-    while len(words) <= max_words:
+    while len(words) < max_words:
         word = random.choice(RARE_WORDS)
         if len(word) > min_word_length:
             words.append(word)

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -89,7 +89,7 @@ def random_case_study_data(alias: str) -> CaseStudy:
     image_1, image_2, image_3 = (choice(images) for _ in range(3))
     (title, summary, description, caption_1, caption_2, caption_3, testimonial,
      source_name, source_job, source_company) = (sentence() for _ in range(10))
-    website = "http://{}.com".format(rare_word(min_length=15))
+    website = "http://{}.{}".format(rare_word(), rare_word())
     keywords = ", ".join(sentence().split())
 
     case_study = CaseStudy(

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -8,7 +8,6 @@ from random import choice
 from typing import List
 
 from behave.runner import Context
-from faker import Factory
 from requests import Response
 
 from tests import get_absolute_url
@@ -29,7 +28,6 @@ from tests.settings import (
     PNGs
 )
 
-FAKE = Factory.create()
 CompaniesList = List[Company]  # a type hint for a List of Company named tuples
 
 

--- a/tests/functional/features/steps/fab_given_impl.py
+++ b/tests/functional/features/steps/fab_given_impl.py
@@ -5,11 +5,11 @@ import string
 import uuid
 
 from behave.runner import Context
-from faker import Factory
 from requests import Session
 
 from tests.functional.features.context_utils import Actor
 from tests.functional.features.pages import fab_ui_profile, profile_ui_landing
+from tests.functional.features.pages.utils import sentence
 from tests.functional.features.steps.fab_then_impl import (
     bp_should_be_prompted_to_build_your_profile,
     prof_should_be_on_profile_page,
@@ -77,8 +77,7 @@ def unauthenticated_buyer(buyer_alias: str) -> Actor:
     email = ("test+buyer_{}{}@directory.uktrade.io"
              .format(buyer_alias, str(uuid.uuid4()))
              .replace("-", "").replace(" ", "").lower())
-    fake = Factory.create()
-    company_name = fake.sentence()[:60].strip()
+    company_name = sentence()
     return Actor(
         alias=buyer_alias, email=email, session=session,
         company_alias=company_name)

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -13,6 +13,7 @@ from tests.functional.features.steps.fab_then_impl import (
     fas_find_supplier_using_case_study_details,
     fas_no_links_to_online_profiles_are_visible,
     fas_should_be_on_profile_page,
+    fas_should_find_with_company_details,
     fas_should_see_all_case_studies,
     fas_should_see_company_details,
     fas_should_see_logo_picture,
@@ -190,3 +191,10 @@ def then_buyer_should_find_supplier_using_any_part_of_case_study(
         context, buyer_alias, company_alias, case_alias):
     fas_find_supplier_using_case_study_details(
         context, buyer_alias, company_alias, case_alias)
+
+
+@then('"{buyer_alias}" should be able to find company "{company_alias}" on FAS '
+      'using selected company\'s details')
+def then_buyer_should_find_supplier_using_company_details(
+        context, buyer_alias, company_alias):
+    fas_should_find_with_company_details(context, buyer_alias, company_alias)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -423,6 +423,7 @@ def fas_should_find_with_company_details(
     """
     assert hasattr(context, "search_results")
     for result in context.search_results:
-        assert context.search_results[result], (
-            "%s wasn't able to find %s using %s" % (
-                buyer_alias, company_alias, result))
+        with assertion_msg(
+                "%s wasn't able to find %s using %s", buyer_alias,
+                company_alias, result):
+            assert context.search_results[result]

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -408,3 +408,21 @@ def fas_supplier_cannot_be_found_using_case_study_details(
         logging.debug(
             "Buyer was not able to find unverified Supplier '%s' on FAS using "
             "%s: %s", company.title, term_name, term)
+
+
+def fas_should_find_with_company_details(
+        context: Context, buyer_alias: str, company_alias: str):
+    """Check if Buyer was able to find Supplier using all selected search terms.
+
+    NOTE:
+    This step requires the search_results dict to be stored in context
+
+    :param context: behave `context` object
+    :param buyer_alias: alias of the Actor used in the scope of the scenario
+    :param company_alias: alias of the Company used in the scope of the scenario
+    """
+    assert hasattr(context, "search_results")
+    for result in context.search_results:
+        assert context.search_results[result], (
+            "%s wasn't able to find %s using %s" % (
+                buyer_alias, company_alias, result))

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -8,6 +8,7 @@ from tests.functional.features.steps.fab_when_impl import (
     bp_provide_full_name,
     bp_select_random_sector_and_export_to_country,
     fab_update_case_study,
+    fas_search_using_company_details,
     prof_add_case_study,
     prof_add_invalid_online_profiles,
     prof_add_online_profiles,
@@ -173,3 +174,11 @@ def when_supplier_attempts_to_upload_unsupported_file(context, supplier_alias):
       '"{case_alias}"')
 def when_supplier_updates_case_study(context, supplier_alias, case_alias):
     fab_update_case_study(context, supplier_alias, case_alias)
+
+
+@when('"{buyer_alias}" searches for company "{company_alias}" on FAS using '
+      'selected company\'s details')
+def when_buyer_searches_on_fas_using_company_details(
+        context, buyer_alias, company_alias):
+    fas_search_using_company_details(
+        context, buyer_alias, company_alias, table_of_details=context.table)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -742,13 +742,12 @@ def prof_supplier_uploads_logo(context, supplier_alias, picture):
     prof_upload_logo(context, supplier_alias, picture)
 
 
-def prof_to_upload_unsupported_logos(context, supplier_alias, table):
+def prof_to_upload_unsupported_logos(
+        context: Context, supplier_alias: str, table: Table):
     """Upload a picture and set it as Company's logo.
 
     :param context: behave `context` object
-    :type context: behave.runner.Context
     :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
     :param table: context.table containing data table
                   see: https://pythonhosted.org/behave/gherkin.html#table
     """
@@ -839,13 +838,12 @@ def prof_update_company_details(
         new_countries)
 
 
-def prof_add_online_profiles(context, supplier_alias, online_profiles):
+def prof_add_online_profiles(
+        context: Context, supplier_alias: str, online_profiles: Table):
     """Update links to Company's Online Profiles.
 
     :param context: behave `context` object
-    :type  context: behave.runner.Context
     :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type  supplier_alias: str
     :param online_profiles: context.table containing data table
             see: https://pythonhosted.org/behave/gherkin.html#table
     """
@@ -887,9 +885,7 @@ def prof_add_invalid_online_profiles(
     """Attempt to update links to Company's Online Profiles using invalid URLs.
 
     :param context: behave `context` object
-    :type  context: behave.runner.Context
     :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type  supplier_alias: str
     :param online_profiles: context.table containing data table
             see: https://pythonhosted.org/behave/gherkin.html#table
     """

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -5,7 +5,6 @@ import random
 
 from behave.model import Table
 from behave.runner import Context
-from faker import Factory
 from requests import Response
 from scrapy import Selector
 
@@ -27,6 +26,7 @@ from tests.functional.features.pages import (
     fab_ui_profile,
     fab_ui_upload_logo,
     fab_ui_verify_company,
+    fas_ui_find_supplier,
     fas_ui_profile,
     profile_ui_find_a_buyer,
     profile_ui_landing,
@@ -40,7 +40,9 @@ from tests.functional.features.pages.common import DETAILS, PROFILES
 from tests.functional.features.pages.utils import (
     extract_and_set_csrf_middleware_token,
     get_active_company_without_fas_profile,
-    random_case_study_data
+    random_case_study_data,
+    rare_word,
+    sentence
 )
 from tests.functional.features.utils import (
     assertion_msg,
@@ -53,8 +55,6 @@ from tests.functional.features.utils import (
     get_verification_code
 )
 from tests.settings import COUNTRIES, NO_OF_EMPLOYEES, SECTORS
-
-FAKE = Factory.create()
 
 
 def select_random_company(
@@ -253,8 +253,8 @@ def bp_provide_company_details(context, supplier_alias):
     # Step 0 - generate random details & update Company matching details
     # Need to get Company details after updating it in the Scenario Data
     size = random.choice(NO_OF_EMPLOYEES)
-    website = "https://{}".format(FAKE.domain_name())
-    keywords = ", ".join(FAKE.sentence().replace(".", "").split())
+    website = "http://{}.com".format(rare_word(min_length=15))
+    keywords = ", ".join(sentence().split())
     context.set_company_details(
         company_alias, no_employees=size, website=website, keywords=keywords
     )
@@ -394,8 +394,8 @@ def prof_set_company_description(context, supplier_alias):
     logging.debug("Supplier is on the Set Company Description page")
 
     # Step 2 - Submit company description
-    summary = FAKE.sentence()
-    description = FAKE.sentence()
+    summary = sentence()
+    description = sentence()
     response = fab_ui_edit_description.submit(
         session, token, summary, description)
     context.response = response


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-1967)

```gherkin
  @ED-1967
  @fas
  @search
  @profile
  @verified
  @published
  Scenario: Buyers should be able to find Supplier by uniquely identifying words present on Supplier's profile
    Given "Annette Geissinger" is a buyer
    And "Peter Alder" is an unauthenticated supplier
    And "Peter Alder" has created and verified profile for randomly selected company "Y"
    And "Peter Alder" has added links to online profiles
      | online profile  |
      | Facebook        |
      | LinkedIn        |
      | Twitter         |

    When "Annette Geissinger" searches for company "Y" on FAS using selected company's details
      | company detail |
      | title          |
      | number         |
      | keywords       |
      | website        |
      | summary        |
      | description    |
      | facebook       |
      | twitter        |
      | linkedin       |

    Then "Annette Geissinger" should be able to find company "Y" on FAS using selected company's details
      | company detail |
      | title          |
      | number         |
      | keywords       |
      | website        |
      | summary        |
      | description    |
      | facebook       |
      | twitter        |
      | linkedin       |
```