### PR TITLE
ED-2000 FAS: empty search query

### DIFF
--- a/tests/functional/features/fas/search.feature
+++ b/tests/functional/features/fas/search.feature
@@ -109,3 +109,14 @@ Feature: Find a Supplier
       | facebook       |
       | twitter        |
       | linkedin       |
+
+
+  @ED-2000
+  @fas
+  @search
+  Scenario: Empty search query should return no results
+    Given "Annette Geissinger" is a buyer
+
+    When "Annette Geissinger" searches for companies on FAS with empty search query
+
+    Then "Annette Geissinger" should be told that the search did not match any UK trade profiles

--- a/tests/functional/features/pages/fab_ui_edit_details.py
+++ b/tests/functional/features/pages/fab_ui_edit_details.py
@@ -71,7 +71,8 @@ def update_details(
         new_title = company.title
 
     if website:
-        new_website = specific_website or "http://{}.com".format(rare_word())
+        new_website = specific_website or ("http://{}.{}"
+                                           .format(rare_word(), rare_word()))
     else:
         new_website = company.website
 

--- a/tests/functional/features/pages/fas_ui_find_supplier.py
+++ b/tests/functional/features/pages/fas_ui_find_supplier.py
@@ -23,13 +23,13 @@ def go_to(session: Session, *, term: str = None) -> Response:
     :param term: (optional) search term
     :return: response object
     """
-    params = {"term": term} if term else {}
+    params = {"term": term} if term is not None else {}
     headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
     response = make_request(
         Method.GET, URL, session=session, params=params, headers=headers)
 
     should_be_here(response)
-    if term:
+    if term is not None:
         logging.debug("Buyer searched for Suppliers using term: %s", term)
     else:
         logging.debug("Buyer is on the FAS Find a Supplier page")

--- a/tests/functional/features/pages/fas_ui_find_supplier.py
+++ b/tests/functional/features/pages/fas_ui_find_supplier.py
@@ -15,6 +15,11 @@ EXPECTED_STRINGS = [
     "Search"
 ]
 
+NO_MATCH = [
+    "Your search", "&quot;<span class=\"term\">", "</span>&quot;",
+    "did not match any UK trade profiles."
+]
+
 
 def go_to(session: Session, *, term: str = None) -> Response:
     """Go to "FAS Find a Supplier" page.
@@ -50,3 +55,10 @@ def should_see_company(response: Response, company_title: str) -> bool:
 def should_not_see_company(response: Response, company_title: str) -> bool:
     content = response.content.decode("utf-8")
     return escape_html(company_title, upper=True)not in content
+
+
+def should_see_no_matches(response: Response, *, term: str = None):
+    expected = NO_MATCH
+    if term:
+        expected += term
+    check_response(response, 200, body_contains=expected)

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -31,6 +31,9 @@ from tests.functional.features.steps.fab_then_impl import (
     reg_supplier_is_not_appropriate_for_fab,
     sso_should_be_signed_in_to_sso_account
 )
+from tests.functional.features.steps.fab_when_impl import (
+    fas_should_be_told_about_empty_search_results
+)
 
 
 @then('"{alias}" should be told about the verification email')
@@ -207,3 +210,9 @@ def then_page_should_be_in(context, page_part, language, probability):
     fas_pages_should_be_in_selected_language(
         context, pages_table=context.table, language=language,
         page_part=page_part, probability=float(probability))
+
+
+@then('"{buyer_alias}" should be told that the search did not match any UK '
+      'trade profiles')
+def then_should_be_told_about_empty_search_results(context, buyer_alias):
+    fas_should_be_told_about_empty_search_results(context, buyer_alias)

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -10,6 +10,7 @@ from tests.functional.features.steps.fab_when_impl import (
     fab_update_case_study,
     fas_search_using_company_details,
     fas_view_pages_in_selected_language,
+    fas_search_with_empty_query,
     prof_add_case_study,
     prof_add_invalid_online_profiles,
     prof_add_online_profiles,
@@ -190,3 +191,8 @@ def when_buyer_searches_on_fas_using_company_details(
 def when_buyer_views_page_in_selected_language(context, buyer_alias, language):
     fas_view_pages_in_selected_language(
         context, buyer_alias, pages_table=context.table, language=language)
+
+
+@when('"{buyer_alias}" searches for companies on FAS with empty search query')
+def when_buyer_searches_with_emtpy_search_query(context, buyer_alias):
+    fas_search_with_empty_query(context, buyer_alias)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1111,3 +1111,16 @@ def fas_view_pages_in_selected_language(
         response = make_request(Method.GET, page_url, session=session)
         views[page_name] = response
     context.views = views
+
+
+def fas_search_with_empty_query(context, buyer_alias):
+    actor = context.get_actor(buyer_alias)
+    session = actor.session
+    context.response = fas_ui_find_supplier.go_to(session, term="")
+
+
+def fas_should_be_told_about_empty_search_results(context, buyer_alias):
+    fas_ui_find_supplier.should_see_no_matches(context.response)
+    logging.debug(
+        "%s was told that the search did not match any UK trade profiles",
+        buyer_alias)

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -588,7 +588,8 @@ def mailgun_get_message_url(context: Context, recipient: str) -> str:
         "recipient": recipient,
         "event": "accepted"
     }
-    response = make_request(Method.GET, url, auth=("api", api_key), params=params)
+    response = make_request(
+        Method.GET, url, auth=("api", api_key), params=params)
     context.response = response
 
     with assertion_msg(

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -560,7 +560,8 @@ def mailgun_get_message(context: Context, url: str) -> dict:
     api_key = MAILGUN_SECRET_API_KEY
     # this will help us to get the raw MIME
     headers = {"Accept": "message/rfc2822"}
-    response = requests.get(url, auth=("api", api_key), headers=headers)
+    response = make_request(
+        Method.GET, url, headers=headers, auth=("api", api_key))
     context.response = response
 
     with assertion_msg(


### PR DESCRIPTION
This implements scenario for this (ticker](https://uktrade.atlassian.net/browse/ED-2000)
```gherkin
  @ED-2000
  @fas
  @search
  Scenario: Empty search query should return no results
    Given "Annette Geissinger" is a buyer

    When "Annette Geissinger" searches for companies on FAS with empty search query

    Then "Annette Geissinger" should be told that the search did not match any UK trade profiles
```