### PR TITLE
ED-2012 FAS: send feedback

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -57,6 +57,7 @@ urls = {
     'ui-supplier:industries-tech-summary': 'industries/tech/summary',
     'ui-supplier:industries-creative-summary': 'industries/creative/summary',
     'ui-supplier:industries-food-summary': 'industries/food-and-drink/summary',
+    'ui-supplier:feedback': 'feedback',
     'ui-supplier:search': 'search',
     'ui-supplier:terms': 'terms-and-conditions',
     'ui-supplier:privacy': 'privacy-policy',

--- a/tests/functional/features/context_utils.py
+++ b/tests/functional/features/context_utils.py
@@ -47,6 +47,12 @@ Company = namedtuple(
         'export_to_countries'
     ]
 )
+Feedback = namedtuple(
+    'Feedback',
+    [
+        'name', 'email', 'company_name', 'country', 'comment', 'terms'
+    ]
+)
 # Set all fields to None by default.
 Actor.__new__.__defaults__ = (None,) * len(Actor._fields)
 Company.__new__.__defaults__ = (None,) * len(Company._fields)

--- a/tests/functional/features/environment.py
+++ b/tests/functional/features/environment.py
@@ -13,6 +13,7 @@ from tests.functional.features.db_cleanup import (
 )
 from tests.functional.features.pages.utils import (
     extract_form_errors,
+    extract_main_error,
     extract_section_error
 )
 from tests.functional.features.utils import (
@@ -42,10 +43,14 @@ def after_step(context, step):
         if not is_request_exception and has_content:
             res = context.response
             content = res.content.decode("utf-8")
+            main_errors = extract_main_error(content)
             section_errors = extract_section_error(content)
             form_errors = extract_form_errors(content)
+            if main_errors:
+                red("Found errors in the `main` part of the response")
+                print(main_errors)
             if section_errors:
-                red("Found errors in the main section of the response")
+                red("Found errors in the `section` of the response")
                 print(section_errors)
             if form_errors:
                 red("Found form related error(s)")

--- a/tests/functional/features/fas/feedback.feature
+++ b/tests/functional/features/fas/feedback.feature
@@ -1,0 +1,12 @@
+@fas
+Feature: Send feedback
+
+
+  @ED-2012
+  @feedback
+  Scenario: Buyer should be able to send us a feedback from "Industries" FAS page
+    Given "Annette Geissinger" is a buyer
+
+    When "Annette Geissinger" sends a Trade Profiles feedback request from "Industries" FAS page
+
+    Then "Annette Geissinger" should be told that the feedback request has been submitted

--- a/tests/functional/features/pages/fas_ui_feedback.py
+++ b/tests/functional/features/pages/fas_ui_feedback.py
@@ -6,11 +6,7 @@ from requests import Response, Session
 
 from tests import get_absolute_url
 from tests.functional.features.context_utils import Feedback
-from tests.functional.features.utils import (
-    Method,
-    check_response,
-    make_request
-)
+from tests.functional.features.utils import Method, check_response, make_request
 
 URL = get_absolute_url("ui-supplier:feedback")
 EXPECTED_STRINGS_FORM = [

--- a/tests/functional/features/pages/fas_ui_feedback.py
+++ b/tests/functional/features/pages/fas_ui_feedback.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""FAB - Edit Company's Directory Profile page"""
+import logging
+
+from requests import Response, Session
+
+from tests import get_absolute_url
+from tests.functional.features.context_utils import Feedback
+from tests.functional.features.utils import (
+    Method,
+    check_response,
+    make_request
+)
+
+URL = get_absolute_url("ui-supplier:feedback")
+EXPECTED_STRINGS_FORM = [
+    "Get UK companies to fulfil your business needs",
+    ("Tell us what kind of goods or services you need. We'll put you in touch "
+     "with relevant UK suppliers."),
+    "Your name", "Email address", "Organisation name", "Country",
+    "Describe what you need", "Maximum 1000 characters.",
+    "I agree to the great.gov.uk terms and conditions", "Send"
+]
+EXPECTED_STRINGS_SUCCESSFUL_SUBMISSION = [
+    "Your request has been submitted",
+    "Thank you for letting us know about your organisation’s needs.",
+    ("UK government staff based in your region will be in touch to let you know"
+     " how UK businesses can help you.")
+]
+EXPECTED_STRINGS_ERRORS = [
+    "This field is required.",
+    "Tick the box to confirm you agree to the terms and conditions."
+]
+
+
+def go_to(session: Session) -> Response:
+    """Go to FAS send Feedback form page.
+
+    :param session: Buyer session object
+    :return: response object
+    """
+    headers = {"Referer": get_absolute_url("ui-supplier:feedback")}
+    response = make_request(Method.GET, URL, session=session, headers=headers)
+    should_be_here(response)
+    return response
+
+
+def should_be_here(response):
+    check_response(response, 200, body_contains=EXPECTED_STRINGS_FORM)
+    logging.debug("Buyer is on FAS send Feedback page")
+
+
+def should_see_feedback_submission_confirmation(response):
+    check_response(
+        response, 200, body_contains=EXPECTED_STRINGS_SUCCESSFUL_SUBMISSION)
+    logging.debug("Feedback submission was confirmed.")
+
+
+def should_see_errors(response):
+    check_response(response, 200, body_contains=EXPECTED_STRINGS_ERRORS)
+    logging.debug("Buyer was presented with Feedback submission errors.")
+
+
+def submit(
+        session: Session, feedback: Feedback, *, referer: str = None) -> Response:
+    """Submit feedback form.
+
+    :param session: Buyer session object
+    :param feedback: a namedtuple with Feedback request details
+    :param referer: (optional) Originating page. Defaults to "{FAS}/feedback"
+    :return: response object
+    """
+    if referer:
+        headers = {"Referer": referer}
+    else:
+        headers = {"Referer": get_absolute_url("ui-supplier:feedback")}
+
+    data = {
+        "full_name": feedback.name,
+        "email_address": feedback.email,
+        "company_name": feedback.company_name,
+        "country": feedback.country,
+        "comment": feedback.comment,
+        "terms": feedback.terms
+    }
+    response = make_request(
+        Method.POST, URL, session=session, headers=headers, data=data)
+    return response

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -307,8 +307,30 @@ def get_fas_page_url(page_name: str, *, language_code: str = None):
     return url
 
 
+def extract_main_error(content: str) -> str:
+    """Extract error from page `main` block.
+
+    :param content: a raw HTML content
+    :return: error message or None is no error was detected
+    """
+    soup = BeautifulSoup(content, "lxml")
+    sections = soup.find_all('main')
+    lines = [
+        line.strip().lower()
+        for section in sections
+        for line in section.text.splitlines()
+        if line
+    ]
+    has_errors = any(
+        indicator in line
+        for line in lines
+        for indicator in ERROR_INDICATORS
+    )
+    return "\n".join(lines) if has_errors else ""
+
+
 def extract_section_error(content: str) -> str:
-    """Extract error from page main 'section'.
+    """Extract error from 'section'.
 
     :param content: a raw HTML content
     :return: error message or None is no error was detected

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -16,7 +16,7 @@ from langdetect import DetectorFactory, detect_langs
 from requests import Response
 
 from tests import get_absolute_url
-from tests.functional.features.context_utils import CaseStudy, Company
+from tests.functional.features.context_utils import CaseStudy, Company, Feedback
 from tests.functional.features.pages import int_api_ch_search
 from tests.functional.features.utils import (
     Method,
@@ -139,6 +139,24 @@ def random_case_study_data(alias: str) -> CaseStudy:
         source_company=source_company)
 
     return case_study
+
+
+def random_feedback_data(
+        *, name: str = None, email: str = None, company_name: str = None,
+        country: str = None, comment: str = None, terms: str = None) -> Feedback:
+    name = name or rare_word(min_length=12)
+    email = email or ("test+buyer_{}@directory.uktrade.io"
+                      .format(rare_word(min_length=15)))
+    company_name = company_name or rare_word(min_length=12)
+    country = country or rare_word(min_length=12)
+    comment = comment or sentence(max_length=1000)
+    terms = terms or "on"
+
+    feedback = Feedback(
+        name=name, email=email, company_name=company_name,
+        country=country, comment=comment, terms=terms)
+
+    return feedback
 
 
 def find_active_company_without_fas_profile(alias: str) -> Company:

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -32,6 +32,7 @@ from tests.functional.features.steps.fab_then_impl import (
     sso_should_be_signed_in_to_sso_account
 )
 from tests.functional.features.steps.fab_when_impl import (
+    fas_feedback_request_should_be_submitted,
     fas_should_be_told_about_empty_search_results
 )
 
@@ -216,3 +217,10 @@ def then_page_should_be_in(context, page_part, language, probability):
       'trade profiles')
 def then_should_be_told_about_empty_search_results(context, buyer_alias):
     fas_should_be_told_about_empty_search_results(context, buyer_alias)
+
+
+@then('"{buyer_alias}" should be told that the feedback request has been '
+      'submitted')
+def then_buyer_should_be_told_about_feedback_request_confirmation(
+        context, buyer_alias):
+    fas_feedback_request_should_be_submitted(context, buyer_alias)

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -9,6 +9,7 @@ from tests.functional.features.steps.fab_when_impl import (
     bp_select_random_sector_and_export_to_country,
     fab_update_case_study,
     fas_search_using_company_details,
+    fas_send_feedback_request,
     fas_view_pages_in_selected_language,
     fas_search_with_empty_query,
     prof_add_case_study,
@@ -196,3 +197,9 @@ def when_buyer_views_page_in_selected_language(context, buyer_alias, language):
 @when('"{buyer_alias}" searches for companies on FAS with empty search query')
 def when_buyer_searches_with_emtpy_search_query(context, buyer_alias):
     fas_search_with_empty_query(context, buyer_alias)
+
+
+@when('"{buyer_alias}" sends a Trade Profiles feedback request from '
+      '"{page_name}" FAS page')
+def when_buyer_sends_feedback_request(context, buyer_alias, page_name):
+    fas_send_feedback_request(context, buyer_alias, page_name)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1144,7 +1144,7 @@ def fas_send_feedback_request(
 
 
 def fas_feedback_request_should_be_submitted(context: Context, buyer_alias: str):
-    response = context.respone
+    response = context.response
     fas_ui_feedback.should_see_feedback_submission_confirmation(response)
     logging.debug(
         "% was told that the feedback request has been submitted", buyer_alias)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1140,6 +1140,11 @@ def fas_send_feedback_request(
     # Step 2: submit the form
     response = fas_ui_feedback.submit(session, feedback, referer=referer_url)
     context.response = response
+    logging.debug("% submitted the feedback request", buyer_alias)
 
-    # Step 3: check if Buyer was presented with a submission confirmation
+
+def fas_feedback_request_should_be_submitted(context: Context, buyer_alias: str):
+    response = context.respone
     fas_ui_feedback.should_see_feedback_submission_confirmation(response)
+    logging.debug(
+        "% was told that the feedback request has been submitted", buyer_alias)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -26,6 +26,7 @@ from tests.functional.features.pages import (
     fab_ui_profile,
     fab_ui_upload_logo,
     fab_ui_verify_company,
+    fas_ui_feedback,
     fas_ui_find_supplier,
     fas_ui_profile,
     profile_ui_find_a_buyer,
@@ -43,6 +44,7 @@ from tests.functional.features.pages.utils import (
     get_fas_page_url,
     get_language_code,
     random_case_study_data,
+    random_feedback_data,
     rare_word,
     sentence
 )
@@ -1124,3 +1126,20 @@ def fas_should_be_told_about_empty_search_results(context, buyer_alias):
     logging.debug(
         "%s was told that the search did not match any UK trade profiles",
         buyer_alias)
+
+
+def fas_send_feedback_request(
+        context: Context, buyer_alias: str, page_name: str):
+    actor = context.get_actor(buyer_alias)
+    session = actor.session
+    referer_url = get_fas_page_url(page_name)
+
+    # Step 1: generate random form data for our Buyer
+    feedback = random_feedback_data(email=actor.email)
+
+    # Step 2: submit the form
+    response = fas_ui_feedback.submit(session, feedback, referer=referer_url)
+    context.response = response
+
+    # Step 3: check if Buyer was presented with a submission confirmation
+    fas_ui_feedback.should_see_feedback_submission_confirmation(response)


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2012)
Implements:
```gherkin
  @ED-2012
  @feedback
  Scenario: Buyer should be able to send us a feedback from "Industries" FAS page
    Given "Annette Geissinger" is a buyer

    When "Annette Geissinger" sends a Trade Profiles feedback request from "Industries" FAS page

    Then "Annette Geissinger" should be told that the feedback request has been submitted
```