### PR TITLE
ED-2020 find supplier by product, service or keyword

### DIFF
--- a/tests/functional/features/fas/search.feature
+++ b/tests/functional/features/fas/search.feature
@@ -109,3 +109,17 @@ Feature: Find a Supplier
     When "Annette Geissinger" searches for companies on FAS with empty search query
 
     Then "Annette Geissinger" should be told that the search did not match any UK trade profiles
+
+
+  @ED-2020
+  @search
+  Scenario: Buyers should be able to find Suppliers by product, service or company keyword
+    Given "Annette Geissinger" is a buyer
+
+    When "Annette Geissinger" searches for Suppliers using product name, service name and a keyword
+      | product                      | service                                  | keyword                    | company                                                  |
+      | Aerosol Paints               | Supply all types of Aerosols             | vanishing spray            | KING OF PAINTS                                           |
+      | LINSIG traffic signal models | management of transport                  | drainage civil engineering | CALLIDUS TRANSPORT & ENGINEERING LTD                     |
+      | peristaltic pump             | deliver the maximum possible performance | brushless                  | ZIKODRIVE MOTOR CONTROLLERS (ROUND BANK ENGINEERING LTD) |
+
+    Then "Annette Geissinger" should be able to find all sought companies

--- a/tests/functional/features/fas/search.feature
+++ b/tests/functional/features/fas/search.feature
@@ -1,8 +1,8 @@
+@fas
 Feature: Find a Supplier
 
 
   @ED-1746
-  @fas
   @case-study
   @profile
   @verified
@@ -35,7 +35,6 @@ Feature: Find a Supplier
 
 
   @ED-1746
-  @fas
   @case-study
   @profile
   @verified
@@ -55,7 +54,6 @@ Feature: Find a Supplier
 
 
   @ED-1746
-  @fas
   @case-study
   @profile
   @unverified
@@ -71,7 +69,6 @@ Feature: Find a Supplier
 
 
   @ED-1967
-  @fas
   @search
   @profile
   @verified
@@ -101,7 +98,6 @@ Feature: Find a Supplier
 
 
   @ED-2000
-  @fas
   @search
   Scenario: Empty search query should return no results
     Given "Annette Geissinger" is a buyer

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -469,19 +469,20 @@ def detect_page_language(
 
 
 def get_number_of_search_result_pages(response: Response) -> int:
-    """Will extract number of FAS Search Result pages.
+    """Will extract the last search result page number from provided response.
 
-    NOTE:
-    This will parse string like `page 1 of 2` and return the last number.
+    The CSS selector will return string like: `page 1 of 2`.
+    Then we extract the numbers from it and return the last one.
+    In case of lack of thereof a 0 is returned.
 
     :param response: FAS Search Result response
-    :return: a number of FAS Search Result pages
+    :return: a number of FAS Search Result pages or 0 if couldn't find
+             information about number of pages
     """
+    no_page_counter = 0
     css_selector = (".company-profile-details-body-toolbar-bottom"
                     " span.current::text")
     pages = extract_by_css(response, css_selector).strip()
     page_numbers = [int(word) for word in pages.split() if word.isdigit()]
-    with assertion_msg(
-            "Couldn't find information about the number of Search Result Pages"):
-        assert len(page_numbers) == 2
-    return page_numbers[-1]
+    last_page = page_numbers[-1] if len(page_numbers) == 2 else no_page_counter
+    return last_page

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -14,6 +14,7 @@ from tests.functional.features.steps.fab_then_impl import (
     fas_no_links_to_online_profiles_are_visible,
     fas_pages_should_be_in_selected_language,
     fas_should_be_on_profile_page,
+    fas_should_find_all_sought_companies,
     fas_should_find_with_company_details,
     fas_should_see_all_case_studies,
     fas_should_see_company_details,
@@ -224,3 +225,8 @@ def then_should_be_told_about_empty_search_results(context, buyer_alias):
 def then_buyer_should_be_told_about_feedback_request_confirmation(
         context, buyer_alias):
     fas_feedback_request_should_be_submitted(context, buyer_alias)
+
+
+@then('"{buyer_alias}" should be able to find all sought companies')
+def then_buyer_should_find_all_sought_companies(context, buyer_alias):
+    fas_should_find_all_sought_companies(context, buyer_alias)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -508,3 +508,24 @@ def fas_pages_should_be_in_selected_language(
                        for idx in results
                        for lang in results[idx]
                        if lang.lang == expected_language)
+
+
+def fas_should_find_all_sought_companies(context: Context, buyer_alias: str):
+    """Check if all Buyer was able to find Supplier using all provided terms.
+
+    :param context: behave `context` object
+    :param buyer_alias: alias of the Actor used in the scope of the scenario
+    """
+    with assertion_msg(
+            "Context has no required `search_details` dict. Please check if "
+            "one of previous steps sets it correctly."):
+        assert hasattr(context, "search_results")
+    for company, results in context.search_results.items():
+        for result in results:
+            term = result["term"]
+            term_type = result["type"]
+            context.response = result["response"]
+            with assertion_msg(
+                    "%s could not find Supplier '%s' using '%s' term '%s'",
+                    buyer_alias, company, term_type, term):
+                assert result["found"]

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -10,6 +10,7 @@ from tests.functional.features.steps.fab_when_impl import (
     fab_update_case_study,
     fas_search_using_company_details,
     fas_search_with_empty_query,
+    fas_search_with_product_service_keyword,
     fas_send_feedback_request,
     fas_view_pages_in_selected_language,
     prof_add_case_study,
@@ -203,3 +204,9 @@ def when_buyer_searches_with_emtpy_search_query(context, buyer_alias):
       '"{page_name}" FAS page')
 def when_buyer_sends_feedback_request(context, buyer_alias, page_name):
     fas_send_feedback_request(context, buyer_alias, page_name)
+
+
+@when('"{buyer_alias}" searches for Suppliers using product name, service name'
+      ' and a keyword')
+def when_buyer_search_using_product_servive_keyword(context, buyer_alias):
+    fas_search_with_product_service_keyword(context, buyer_alias, context.table)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1191,6 +1191,10 @@ def can_find_supplier_by_term(
     """
 
     response = fas_ui_find_supplier.go_to(session, term=term)
+    with assertion_msg(
+            "Couldn't find any Supplier using '%s': '%s'", term_type, term):
+        no_match = ["Your search", "did not match any UK trade profiles"]
+        check_response(response, 200, unexpected_strings=no_match)
     number_of_pages = get_number_of_search_result_pages(response)
     found = False
     for page_number in range(1, number_of_pages + 1):

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1189,14 +1189,11 @@ def can_find_supplier_by_term(
     :param term_type: type of the term, e.g.: product, service, keyword etc.
     :return: a tuple with search result (True/False) and last search Response
     """
-
-    response = fas_ui_find_supplier.go_to(session, term=term)
-    with assertion_msg(
-            "Couldn't find any Supplier using '%s': '%s'", term_type, term):
-        no_match = ["Your search", "did not match any UK trade profiles"]
-        check_response(response, 200, unexpected_strings=no_match)
-    number_of_pages = get_number_of_search_result_pages(response)
     found = False
+    response = fas_ui_find_supplier.go_to(session, term=term)
+    number_of_pages = get_number_of_search_result_pages(response)
+    if number_of_pages == 0:
+        return found, response
     for page_number in range(1, number_of_pages + 1):
         found = fas_ui_find_supplier.should_see_company(response, name)
         if found:


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2020)

```gherkin
  @ED-2020
  @search
  Scenario: Buyers should be able to find Suppliers by product, service or company keyword
    Given "Annette Geissinger" is a buyer

    When "Annette Geissinger" searches for Suppliers using product name, service name and a keyword
      | product                      | service                                  | keyword                    | company                                                  |
      | Aerosol Paints               | Supply all types of Aerosols             | vanishing spray            | KING OF PAINTS                                           |
      | LINSIG traffic signal models | management of transport                  | drainage civil engineering | CALLIDUS TRANSPORT & ENGINEERING LTD                     |
      | peristaltic pump             | deliver the maximum possible performance | brushless                  | ZIKODRIVE MOTOR CONTROLLERS (ROUND BANK ENGINEERING LTD) |

    Then "Annette Geissinger" should be able to find all sought companies
```