### PR TITLE
ED-2141 only alphanumerics are allowed in profile keywords

### DIFF
--- a/tests/functional/features/fab/profile.feature
+++ b/tests/functional/features/fab/profile.feature
@@ -87,11 +87,11 @@ Feature: Trade Profile
         |unchanged     |empty string |bus, ferry, plane|full stop |501-1000|You can only enter letters, numbers and commas.|
         |500 characters|valid https  |sand, dunes, bird|comma     |1-10    |You can only enter letters, numbers and commas.|
         |unchanged     |valid https  |sand, dunes, bird|comma     |unset   |This field is required.                        |
-        |unchanged     |invalid http |sand, dunes, bird|comma     |unset   |This field is required.                        |
-        |unchanged     |invalid https|sand, dunes, bird|comma     |unset   |This field is required.                        |
-        |unchanged     |valid http   |empty string     |comma     |unset   |This field is required.                        |
+        |unchanged     |invalid http |sand, dunes, bird|comma     |1-10    |This field is required.                        |
+        |unchanged     |invalid https|sand, dunes, bird|comma     |11-50   |This field is required.                        |
+        |unchanged     |valid http   |empty string     |comma     |51-200  |This field is required.                        |
 
-      Then "Annette Geissinger" should see expected error message
+      Then "Annette Geissinger" should see expected error messages
 
 
     @ED-1722

--- a/tests/functional/features/fab/profile.feature
+++ b/tests/functional/features/fab/profile.feature
@@ -70,6 +70,30 @@ Feature: Trade Profile
       And "Annette Geissinger" should be told that her company has no description
 
 
+    @wip
+    @ED-2141
+    @profile
+    Scenario: Supplier should not be able to use other characters than alphanumerics and commas in profile keywords
+      Given "Annette Geissinger" is an unauthenticated supplier
+      And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
+      And "Annette Geissinger" confirmed her email address
+
+      When "Annette Geissinger" provides company details using following values
+        |company name  |website      |keywords         |separator |size    |error                                          |
+        |empty string  |empty string |book, keys, food |comma     |1-10    |This field is required.                        |
+        |unchanged     |empty string |book, keys, food |pipe      |11-50   |You can only enter letters, numbers and commas.|
+        |unchanged     |valid http   |sky, sea, blues  |semi-colon|51-200  |You can only enter letters, numbers and commas.|
+        |unchanged     |valid https  |sand, dunes, bird|colon     |201-500 |You can only enter letters, numbers and commas.|
+        |unchanged     |empty string |bus, ferry, plane|full stop |501-1000|You can only enter letters, numbers and commas.|
+        |500 characters|valid https  |sand, dunes, bird|comma     |1-10    |You can only enter letters, numbers and commas.|
+        |unchanged     |valid https  |sand, dunes, bird|comma     |unset   |This field is required.                        |
+        |unchanged     |invalid http |sand, dunes, bird|comma     |unset   |This field is required.                        |
+        |unchanged     |invalid https|sand, dunes, bird|comma     |unset   |This field is required.                        |
+        |unchanged     |valid http   |empty string     |comma     |unset   |This field is required.                        |
+
+      Then "Annette Geissinger" should see expected error message
+
+
     @ED-1722
     @verification
     @letter

--- a/tests/functional/features/fab/profile.feature
+++ b/tests/functional/features/fab/profile.feature
@@ -70,7 +70,6 @@ Feature: Trade Profile
       And "Annette Geissinger" should be told that her company has no description
 
 
-    @wip
     @ED-2141
     @profile
     Scenario: Supplier should not be able to use other characters than alphanumerics and commas in profile keywords
@@ -79,17 +78,35 @@ Feature: Trade Profile
       And "Annette Geissinger" confirmed her email address
 
       When "Annette Geissinger" provides company details using following values
-        |company name  |website      |keywords         |separator |size    |error                                          |
-        |empty string  |empty string |book, keys, food |comma     |1-10    |This field is required.                        |
-        |unchanged     |empty string |book, keys, food |pipe      |11-50   |You can only enter letters, numbers and commas.|
-        |unchanged     |valid http   |sky, sea, blues  |semi-colon|51-200  |You can only enter letters, numbers and commas.|
-        |unchanged     |valid https  |sand, dunes, bird|colon     |201-500 |You can only enter letters, numbers and commas.|
-        |unchanged     |empty string |bus, ferry, plane|full stop |501-1000|You can only enter letters, numbers and commas.|
-        |500 characters|valid https  |sand, dunes, bird|comma     |1-10    |You can only enter letters, numbers and commas.|
-        |unchanged     |valid https  |sand, dunes, bird|comma     |unset   |This field is required.                        |
-        |unchanged     |invalid http |sand, dunes, bird|comma     |1-10    |This field is required.                        |
-        |unchanged     |invalid https|sand, dunes, bird|comma     |11-50   |This field is required.                        |
-        |unchanged     |valid http   |empty string     |comma     |51-200  |This field is required.                        |
+        |company name  |website       |keywords         |separator |size    |error                                                       |
+        |empty string  |empty string  |book, keys, food |comma     |1-10    |This field is required.                                     |
+        |unchanged     |empty string  |book, keys, food |pipe      |11-50   |You can only enter letters, numbers and commas.             |
+        |unchanged     |valid http    |sky, sea, blues  |semi-colon|51-200  |You can only enter letters, numbers and commas.             |
+        |unchanged     |valid https   |sand, dunes, bird|colon     |201-500 |You can only enter letters, numbers and commas.             |
+        |unchanged     |empty string  |bus, ferry, plane|full stop |501-1000|You can only enter letters, numbers and commas.             |
+        |unchanged     |valid https   |sand, dunes, bird|comma     |unset   |This field is required.                                     |
+        |unchanged     |valid http    |empty string     |comma     |51-200  |This field is required.                                     |
+        |256 characters|valid https   |sand, dunes, bird|comma     |1-10    |Ensure this value has at most 255 characters (it has 256).  |
+        |unchanged     |empty string  |1001 characters  |comma     |1-10    |Ensure this value has at most 1000 characters (it has 1001).|
+
+      Then "Annette Geissinger" should see expected error messages
+
+
+    @ED-2141
+    @profile
+    @bug
+    @ED-2170
+    @fixme
+    Scenario: Supplier should not be able to use other characters than alphanumerics and commas in profile keywords
+      Given "Annette Geissinger" is an unauthenticated supplier
+      And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
+      And "Annette Geissinger" confirmed her email address
+
+      When "Annette Geissinger" provides company details using following values
+        |company name  |website       |keywords         |separator |size  |error                                                     |
+        |unchanged     |256 characters|sand, dunes, bird|comma     |1-10  |Ensure this value has at most 255 characters (it has 256).|
+        |unchanged     |invalid http  |sand, dunes, bird|comma     |1-10  |Enter a valid URL.                                        |
+        |unchanged     |invalid https |sand, dunes, bird|comma     |11-50 |Enter a valid URL.                                        |
 
       Then "Annette Geissinger" should see expected error messages
 

--- a/tests/functional/features/pages/fab_ui_build_profile_basic.py
+++ b/tests/functional/features/pages/fab_ui_build_profile_basic.py
@@ -46,12 +46,16 @@ def submit(actor: Actor, company: Company) -> Response:
     """
     data = {
         "csrfmiddlewaretoken": actor.csrfmiddlewaretoken,
-        "company_profile_edit_view-current_step": "basic",
-        "basic-name": company.title,
-        "basic-website": company.website,
-        "basic-keywords": company.keywords,
-        "basic-employees": company.no_employees
+        "company_profile_edit_view-current_step": "basic"
     }
+    if company.title is not None:
+        data.update({"basic-name": company.title})
+    if company.website is not None:
+        data.update({"basic-website": company.website})
+    if company.keywords is not None:
+        data.update({"basic-keywords": company.keywords})
+    if company.no_employees is not None:
+        data.update({"basic-employees": company.no_employees})
     headers = {"Referer": URL}
     response = make_request(
         Method.POST, URL, session=actor.session, headers=headers, data=data)

--- a/tests/functional/features/pages/fas_ui_contact.py
+++ b/tests/functional/features/pages/fas_ui_contact.py
@@ -6,6 +6,7 @@ from requests import Response, Session
 
 from tests import get_absolute_url
 from tests.functional.features.context_utils import Company, Message
+from tests.functional.features.pages.utils import escape_html
 from tests.functional.features.utils import Method, check_response, make_request
 
 LANDING = get_absolute_url("ui-supplier:landing")
@@ -41,7 +42,7 @@ def go_to(session: Session, company_number: str, company_name: str) -> Response:
 
 
 def should_be_here(response, *, name=None):
-    expected = EXPECTED_STRINGS + [name] if name else EXPECTED_STRINGS
+    expected = EXPECTED_STRINGS + [escape_html(name)] if name else EXPECTED_STRINGS
     check_response(response, 200, body_contains=expected)
     logging.debug("Supplier is on FAS Contact Company page")
 
@@ -66,6 +67,6 @@ def submit(session: Session, message: Message, company_number: str):
 
 
 def should_see_that_message_has_been_sent(company: Company, response: Response):
-    expected = EXPECTED_STRINGS_MESSAGE_SENT + [company.title]
+    expected = EXPECTED_STRINGS_MESSAGE_SENT + [escape_html(company.title)]
     check_response(response, 200, body_contains=expected)
     logging.debug("Buyer was told that the message has been sent")

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -16,15 +16,15 @@ from langdetect import DetectorFactory, detect_langs
 from requests import Response
 
 from tests import get_absolute_url
-from tests.functional.features.db_cleanup import (
-    delete_supplier_data,
-    get_company_email
-)
 from tests.functional.features.context_utils import (
     CaseStudy,
     Company,
     Feedback,
     Message
+)
+from tests.functional.features.db_cleanup import (
+    delete_supplier_data,
+    get_company_email
 )
 from tests.functional.features.pages import int_api_ch_search
 from tests.functional.features.utils import (

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -8,6 +8,7 @@ from tests.functional.features.steps.fab_then_impl import (
     fab_profile_is_verified,
     fab_should_see_all_case_studies,
     fab_should_see_company_details,
+    fab_should_see_expected_error_messages,
     fab_should_see_online_profiles,
     fas_check_profiles,
     fas_find_supplier_using_case_study_details,
@@ -259,3 +260,8 @@ def then_buyer_should_see_logo_on_fas_profile_page(context, actor_alias):
       'FAS Company\'s Directory Profile page')
 def then_actor_should_see_different_logo_on_fas(context, actor_alias):
     fas_should_see_different_png_logo_thumbnail(context, actor_alias)
+
+
+@then('"{supplier_alias}" should see expected error messages')
+def then_supplier_should_see_expected_error_messages(context, supplier_alias):
+    fab_should_see_expected_error_messages(context, supplier_alias)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -583,3 +583,14 @@ def fas_supplier_should_receive_message_from_buyer(
         context, service=MailGunService.DIRECTORY, recipient=supplier.email,
         event=MailGunEvent.ACCEPTED, subject=FAS_MESSAGE_FROM_BUYER_SUBJECT)
     context.response = response
+
+
+def fab_should_see_expected_error_messages(context, supplier_alias):
+    results = context.results
+    logging.debug(results)
+    for company, response, error in results:
+        context.response = response
+        with assertion_msg(
+                "Could not find error message: '%s' in the response",
+                error):
+            assert error in response  #.content.decode("utf-8")

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -591,6 +591,10 @@ def fab_should_see_expected_error_messages(context, supplier_alias):
     for company, response, error in results:
         context.response = response
         with assertion_msg(
-                "Could not find error message: '%s' in the response",
-                error):
-            assert error in response  #.content.decode("utf-8")
+                "Could not find expected error message: '%s' in the response, "
+                "after submitting the form with following company details: "
+                "title='%s' website='%s' keywords='%s' number of employees="
+                "'%s'", error, company.title, company.website,
+                company.keywords, company.no_employees):
+            assert error in response.content.decode("utf-8")
+    logging.debug("%s has seen all expected form errors", supplier_alias)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -26,16 +26,17 @@ from tests.functional.features.pages.utils import (
 )
 from tests.functional.features.utils import (
     MailGunEvent,
+    MailGunService,
     assertion_msg,
     check_hash_of_remote_file,
     extract_csrf_middleware_token,
     extract_logo_url,
     find_mailgun_events,
-    get_verification_link,
-    MailGunService)
+    get_verification_link
+)
 from tests.settings import (
-    FAS_MESSAGE_FROM_BUYER_SUBJECT,
     FAS_LOGO_PLACEHOLDER_IMAGE,
+    FAS_MESSAGE_FROM_BUYER_SUBJECT,
     SEARCHABLE_CASE_STUDY_DETAILS
 )
 

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -6,6 +6,7 @@ from tests.functional.features.steps.fab_when_impl import (
     bp_provide_company_details,
     bp_provide_full_name,
     bp_select_random_sector_and_export_to_country,
+    fab_provide_company_details,
     fab_update_case_study,
     fas_search_using_company_details,
     fas_search_with_empty_query,
@@ -211,3 +212,8 @@ def when_buyer_search_using_product_servive_keyword(context, buyer_alias):
 @when('"{buyer_alias}" sends a message to company "{company_alias}"')
 def when_buyer_sends_message_to_supplier(context, buyer_alias, company_alias):
     fas_send_message_to_supplier(context, buyer_alias, company_alias)
+
+
+@when('"{supplier_alias}" provides company details using following values')
+def when_supplier_provide_company_details(context, supplier_alias):
+    fab_provide_company_details(context, supplier_alias, context.table)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -40,6 +40,7 @@ from tests.functional.features.pages import (
 )
 from tests.functional.features.pages.common import DETAILS, PROFILES
 from tests.functional.features.pages.utils import (
+    escape_html,
     extract_and_set_csrf_middleware_token,
     get_active_company_without_fas_profile,
     get_fas_page_url,
@@ -1162,7 +1163,7 @@ def fas_get_company_profile_url(response: Response, name: str) -> str:
     links_to_profiles = Selector(text=content).css(links_to_profiles_selector).extract()
     profile_url = None
     for link in links_to_profiles:
-        if name in link:
+        if escape_html(name).lower() in link.lower():
             profile_url = Selector(text=link).css(href_selector).extract()[0]
     with assertion_msg(
             "Couldn't find link to '%s' company profile page in the response",

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1281,9 +1281,23 @@ def fas_send_message_to_supplier(
 
 def fab_provide_company_details(
         context: Context, supplier_alias: str, table: Table):
+    """Submit company details with specific values in order to verify data
+     validation.
+
+    NOTE:
+    This will store a list of `results` tuples in context. Each tuple will
+    contain:
+    * Company namedtuple (with details used in the request)
+    * response object
+    * expected error message
+
+    :param context: behave `context` object
+    :param supplier_alias: alias of the Supplier Actor
+    :param table: a table with company details to update & expected error msg
+    """
     actor = context.get_actor(supplier_alias)
     original_details = context.get_company(actor.company_alias)
-    responses = []
+    results = []
     for row in table:
         if row["company name"] == "unchanged":
             title = original_details.title
@@ -1328,8 +1342,7 @@ def fab_provide_company_details(
         new_details = Company(
             title=title, website=website, keywords=keywords, no_employees=size)
 
-        # Step 1 - submit the details
         response = fab_ui_build_profile_basic.submit(actor, new_details)
-        responses.append(response)
+        results.append((new_details, response, row["error"]))
 
-    context.responses = responses
+    context.results = results

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1319,9 +1319,15 @@ def fab_provide_company_details(
             website = "http:{}.{}".format(rare_word(), rare_word())
         elif row["website"] == "invalid https":
             website = "https:{}.{}".format(rare_word(), rare_word())
+        elif row["website"].endswith(" characters"):
+            number = [int(word) for word in row["website"].split() if word.isdigit()][0]
+            website = random_chars(number)
 
         if row["keywords"] == "empty string":
             keywords = ""
+        elif row["keywords"].endswith(" characters"):
+            number = [int(word) for word in row["keywords"].split() if word.isdigit()][0]
+            keywords = random_chars(number)
         else:
             keywords = row["keywords"]
             separate_keywords = keywords.split(", ")

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -802,6 +802,7 @@ def find_mailgun_events(
 
 
 def random_chars(size, *, chars=ascii_uppercase):
-    selection = iter(lambda: random.choice(chars), object())
-    while True:
-        yield ''.join(islice(selection, size))
+    res = ""
+    while len(res) < size:
+        res += random.choice(chars)
+    return res

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -4,13 +4,16 @@
 import hashlib
 import logging
 import os
+import random
 import sys
 import traceback
 from collections import namedtuple
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from enum import Enum
+from itertools import islice
 from pprint import pprint
+from string import ascii_uppercase
 
 import requests
 from behave.runner import Context
@@ -796,3 +799,9 @@ def find_mailgun_events(
         "Found {} event(s) that matched following criteria: {}"
         .format(number_of_events, params))
     return response
+
+
+def random_chars(size, *, chars=ascii_uppercase):
+    selection = iter(lambda: random.choice(chars), object())
+    while True:
+        yield ''.join(islice(selection, size))


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2141)

Apart from the regular scenario I've also included:
* an extra one for bug https://uktrade.atlassian.net/browse/ED-2170
* tiny improvement to handle companies with `&` and `'` in their names

```gherkin
    @ED-2141
    @profile
    Scenario: Supplier should not be able to use other characters than alphanumerics and commas in profile keywords
      Given "Annette Geissinger" is an unauthenticated supplier
      And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
      And "Annette Geissinger" confirmed her email address

      When "Annette Geissinger" provides company details using following values
        |company name  |website       |keywords         |separator |size    |error                                                       |
        |empty string  |empty string  |book, keys, food |comma     |1-10    |This field is required.                                     |
        |unchanged     |empty string  |book, keys, food |pipe      |11-50   |You can only enter letters, numbers and commas.             |
        |unchanged     |valid http    |sky, sea, blues  |semi-colon|51-200  |You can only enter letters, numbers and commas.             |
        |unchanged     |valid https   |sand, dunes, bird|colon     |201-500 |You can only enter letters, numbers and commas.             |
        |unchanged     |empty string  |bus, ferry, plane|full stop |501-1000|You can only enter letters, numbers and commas.             |
        |unchanged     |valid https   |sand, dunes, bird|comma     |unset   |This field is required.                                     |
        |unchanged     |valid http    |empty string     |comma     |51-200  |This field is required.                                     |
        |256 characters|valid https   |sand, dunes, bird|comma     |1-10    |Ensure this value has at most 255 characters (it has 256).  |
        |unchanged     |empty string  |1001 characters  |comma     |1-10    |Ensure this value has at most 1000 characters (it has 1001).|

      Then "Annette Geissinger" should see expected error messages


    @ED-2141
    @profile
    @bug
    @ED-2170
    @fixme
    Scenario: Supplier should not be able to use other characters than alphanumerics and commas in profile keywords
      Given "Annette Geissinger" is an unauthenticated supplier
      And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
      And "Annette Geissinger" confirmed her email address

      When "Annette Geissinger" provides company details using following values
        |company name  |website       |keywords         |separator |size  |error                                                     |
        |unchanged     |256 characters|sand, dunes, bird|comma     |1-10  |Ensure this value has at most 255 characters (it has 256).|
        |unchanged     |invalid http  |sand, dunes, bird|comma     |1-10  |Enter a valid URL.                                        |
        |unchanged     |invalid https |sand, dunes, bird|comma     |11-50 |Enter a valid URL.                                        |

      Then "Annette Geissinger" should see expected error messages
```