### PR TITLE
ED-2013 view industries

### DIFF
--- a/tests/functional/features/fas/industries.feature
+++ b/tests/functional/features/fas/industries.feature
@@ -1,0 +1,36 @@
+Feature: Promoted industries
+
+  @ED-2013
+  @industries
+  Scenario: Buyers should be able to view page with promoted Industries
+    Given "Annette Geissinger" is a buyer
+
+    When "Annette Geissinger" visits "Industries" page on FAS
+
+    Then "Annette Geissinger" should see sections with selected industries
+      | industry       |
+      | Health         |
+      | Tech           |
+      | Creative       |
+      | Food and drink |
+
+
+  @ED-2015
+  @industries
+  Scenario Outline: Buyers should be able to find out more about every promoted industry - visit "<selected>" page
+    Given "Annette Geissinger" is a buyer
+
+    When "Annette Geissinger" visits "<selected>" page on FAS
+
+    Then "Annette Geissinger" should be presented with "<selected>" FAS page
+
+    Examples:
+      | selected                        |
+      | Health Industry                 |
+      | Tech Industry                   |
+      | Creative Industry               |
+      | Food and drink Industry         |
+      | Health Industry Summary         |
+      | Tech Industry Summary           |
+      | Creative Industry Summary       |
+      | Food and drink Industry Summary |

--- a/tests/functional/features/pages/common.py
+++ b/tests/functional/features/pages/common.py
@@ -1,5 +1,18 @@
 # -*- coding: utf-8 -*-
 """Common data used across the functional tests"""
+from enum import Enum
+
+from tests.functional.features.pages import (
+    fas_ui_creative_industry,
+    fas_ui_creative_industry_summary,
+    fas_ui_food_and_drink_industry,
+    fas_ui_food_and_drink_industry_summary,
+    fas_ui_health_industry,
+    fas_ui_health_industry_summary,
+    fas_ui_industries,
+    fas_ui_tech_industry,
+    fas_ui_tech_industry_summary
+)
 
 DETAILS = {
     "TITLE": "business name",
@@ -17,3 +30,31 @@ PROFILES = {
     "LINKEDIN": "LinkedIn",
     "TWITTER": "Twitter"
 }
+
+
+class FAS_PAGE(Enum):
+    """Selected FAS pages in a handy Enum form"""
+    INDUSTRIES = (fas_ui_industries, "industries")
+    HEALTH_INDUSTRY = (fas_ui_health_industry, "health industry")
+    CREATIVE_INDUSTRY = (fas_ui_creative_industry, "creative industry")
+    TECH_INDUSTRY = (fas_ui_tech_industry, "tech industry")
+    FOOD_AND_DRINK_INDUSTRY = (fas_ui_food_and_drink_industry,
+                               "food and drink industry")
+    HEALTH_INDUSTRY_SUMMARY = (fas_ui_health_industry_summary,
+                               "health industry summary")
+    CREATIVE_INDUSTRY_SUMMARY = (fas_ui_creative_industry_summary,
+                                 "creative industry summary")
+    TECH_INDUSTRY_SUMMARY = (fas_ui_tech_industry_summary,
+                             "tech industry summary")
+    FOOD_AND_DRINK_INDUSTRY_SUMMARY = (fas_ui_food_and_drink_industry_summary,
+                                       "food and drink industry summary")
+
+    def __str__(self):
+        return self.value[0]
+
+    def __eq__(self, y: str):
+        return self.value[1] == y.lower()
+
+    @property
+    def po(self):
+        return self.value[0]

--- a/tests/functional/features/pages/fas_ui_creative_industry.py
+++ b/tests/functional/features/pages/fas_ui_creative_industry.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""FAS - Creative Industry page"""
+import logging
+
+from requests import Response, Session
+
+from tests import get_absolute_url
+from tests.functional.features.utils import Method, check_response, make_request
+
+URL = get_absolute_url("ui-supplier:industries-creative")
+EXPECTED_STRINGS = [
+    "Delivering exceptional creative services", "Key facts",
+    "Work with the best in film, TV and visual effects",
+    "See the UK's creative services providers on the Find a supplier service",
+    "Immersive", "Blippar", "Find other great UK companies",
+    "Read more about the company", "Company showcase", "Read case study"
+]
+
+
+def go_to(session: Session) -> Response:
+    """Go to Creative Industry Page on FAS
+
+    :param session: Supplier session object
+    :return: response object
+    """
+    headers = {"Referer": get_absolute_url("ui-supplier:industries")}
+    return make_request(Method.GET, URL, session=session, headers=headers)
+
+
+def should_be_here(response: Response):
+    """Check if User is on the correct page.
+
+    :param response: response object
+    """
+    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+    logging.debug("Supplier is on FAS Creative Industry page")

--- a/tests/functional/features/pages/fas_ui_creative_industry_summary.py
+++ b/tests/functional/features/pages/fas_ui_creative_industry_summary.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""FAS - Creative Industry page"""
+import logging
+
+from requests import Response, Session
+
+from tests import get_absolute_url
+from tests.functional.features.utils import Method, check_response, make_request
+
+URL = get_absolute_url("ui-supplier:industries-creative-summary")
+EXPECTED_STRINGS = [
+    "Delivering exceptional creative services", "Find your UK trade partner",
+    "See the UK's creative services providers on the Find a supplier service",
+    "Immersive", "Blippar", "Find other great UK companies",
+    "Read more about the company", "Company showcase", "Read case study"
+]
+
+
+def go_to(session: Session) -> Response:
+    """Go to Creative Industry Page on FAS
+
+    :param session: Supplier session object
+    :return: response object
+    """
+    headers = {"Referer": get_absolute_url("ui-supplier:industries")}
+    return make_request(Method.GET, URL, session=session, headers=headers)
+
+
+def should_be_here(response: Response):
+    """Check if User is on the correct page.
+
+    :param response: response object
+    """
+    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+    logging.debug("Supplier is on FAS Creative Industry page")

--- a/tests/functional/features/pages/fas_ui_food_and_drink_industry.py
+++ b/tests/functional/features/pages/fas_ui_food_and_drink_industry.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""FAS - Food and Drink Industry page"""
+import logging
+
+from requests import Response, Session
+
+from tests import get_absolute_url
+from tests.functional.features.utils import Method, check_response, make_request
+
+URL = get_absolute_url("ui-supplier:industries-food")
+EXPECTED_STRINGS = [
+    "UK food and drink", "Key facts", "British heritage shared globally",
+    "See the UK's food and drink companies on the Find a supplier service",
+    "Joe &amp; Seph&#39;s", "Fever-Tree", "Find other great UK companies",
+    "Read more about the company", "Company showcase", "Read case study"
+]
+
+
+def go_to(session: Session) -> Response:
+    """Go to Food and Drink Industry Page on FAS
+
+    :param session: Supplier session object
+    :return: response object
+    """
+    headers = {"Referer": get_absolute_url("ui-supplier:industries")}
+    return make_request(Method.GET, URL, session=session, headers=headers)
+
+
+def should_be_here(response: Response):
+    """Check if User is on the correct page.
+
+    :param response: response object
+    """
+    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+    logging.debug("Supplier is on FAS Food and Drink Industry page")

--- a/tests/functional/features/pages/fas_ui_food_and_drink_industry_summary.py
+++ b/tests/functional/features/pages/fas_ui_food_and_drink_industry_summary.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""FAS - Food and Drink Industry page"""
+import logging
+
+from requests import Response, Session
+
+from tests import get_absolute_url
+from tests.functional.features.utils import Method, check_response, make_request
+
+URL = get_absolute_url("ui-supplier:industries-food-summary")
+EXPECTED_STRINGS = [
+    "UK food and drink", "Find your UK trade partner",
+    "See the UK's food and drink companies on the Find a supplier service",
+    "Joe &amp; Seph&#39;s", "Fever-Tree", "Find other great UK companies",
+    "Read more about the company", "Company showcase", "Read case study"
+]
+
+
+def go_to(session: Session) -> Response:
+    """Go to Food and Drink Industry Page on FAS
+
+    :param session: Supplier session object
+    :return: response object
+    """
+    headers = {"Referer": get_absolute_url("ui-supplier:industries")}
+    return make_request(Method.GET, URL, session=session, headers=headers)
+
+
+def should_be_here(response: Response):
+    """Check if User is on the correct page.
+
+    :param response: response object
+    """
+    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+    logging.debug("Supplier is on FAS Food and Drink Industry page")

--- a/tests/functional/features/pages/fas_ui_health_industry.py
+++ b/tests/functional/features/pages/fas_ui_health_industry.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""FAS - Health Industry page"""
+import logging
+
+from requests import Response, Session
+
+from tests import get_absolute_url
+from tests.functional.features.utils import Method, check_response, make_request
+
+URL = get_absolute_url("ui-supplier:industries-health")
+EXPECTED_STRINGS = [
+    "Delivering the exceptional in healthcare and life sciences",
+    "Key facts", "Work with the UK to create first-rate healthcare",
+    ("See the UK's healthcare and life sciences providers on the Find a "
+     "supplier service"), "RD Biomed", "Touch Bionics",
+    "Find other great UK companies", "Read more about the company",
+    "Company showcase", "Read case study"
+]
+
+
+def go_to(session: Session) -> Response:
+    """Go to Health Industry Page on FAS
+
+    :param session: Supplier session object
+    :return: response object
+    """
+    headers = {"Referer": get_absolute_url("ui-supplier:industries")}
+    return make_request(Method.GET, URL, session=session, headers=headers)
+
+
+def should_be_here(response: Response):
+    """Check if User is on the correct page.
+
+    :param response: response object
+    """
+    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+    logging.debug("Supplier is on FAS Health Industry page")

--- a/tests/functional/features/pages/fas_ui_health_industry_summary.py
+++ b/tests/functional/features/pages/fas_ui_health_industry_summary.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""FAS - Health Industry page"""
+import logging
+
+from requests import Response, Session
+
+from tests import get_absolute_url
+from tests.functional.features.utils import Method, check_response, make_request
+
+URL = get_absolute_url("ui-supplier:industries-health-summary")
+EXPECTED_STRINGS = [
+    "Buy UK healthcare and life sciences products and services",
+    "Delivering the exceptional in healthcare and life sciences",
+    "Find your UK trade partner",
+    "Read more about healthcare and life sciences",
+    ("See the UK's healthcare and life sciences providers on the Find a "
+     "supplier service"), "RD Biomed", "Touch Bionics",
+    "Find other great UK companies", "Read more about the company",
+    "Company showcase", "Read case study"
+]
+
+
+def go_to(session: Session) -> Response:
+    """Go to Health Industry Page on FAS
+
+    :param session: Supplier session object
+    :return: response object
+    """
+    headers = {"Referer": get_absolute_url("ui-supplier:industries")}
+    return make_request(Method.GET, URL, session=session, headers=headers)
+
+
+def should_be_here(response: Response):
+    """Check if User is on the correct page.
+
+    :param response: response object
+    """
+    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+    logging.debug("Supplier is on FAS Health Industry page")

--- a/tests/functional/features/pages/fas_ui_industries.py
+++ b/tests/functional/features/pages/fas_ui_industries.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""FAS - Industries page"""
+import logging
+
+from requests import Response, Session
+
+from tests import get_absolute_url
+from tests.functional.features.utils import Method, check_response, make_request
+
+URL = get_absolute_url("ui-supplier:industries")
+EXPECTED_STRINGS = [
+    "Discover the UK's capability in these key industries", "UK industries"
+]
+EXPECTED_STRINGS_HEALTH = [
+    "Healthcare and life sciences in the UK",
+    ("Get access to the UK health and life sciences supply-chain, delivering "
+     "high quality, innovative services to the world."),
+    "Find out more about the UK’s healthcare and life sciences"
+]
+EXPECTED_STRINGS_TECH = [
+    "The UK's advanced technology",
+    ("Check out the cutting-edge technological innovations that the UK is "
+     "bringing to the world."),
+    "Find out more about UK technology"
+]
+EXPECTED_STRINGS_CREATIVE = [
+    "The UK's creative services",
+    ("Whether you need buildings designed, films made or a fresh approach to "
+     "marketing, the UK is the first place to look."),
+    "Find out more about the UK’s creative services"
+]
+EXPECTED_STRINGS_FOOD_AND_DRINK = [
+    "The UK's food and drink",
+    ("Whether you want the best food brands or exceptional quality drinks, the"
+     " UK should be first on your list."),
+    "Find out more about UK food and drink"
+]
+
+
+def go_to(session: Session) -> Response:
+    """Go to Industries Page on FAS
+
+    :param session: Supplier session object
+    :return: response object
+    """
+    headers = {"Referer": get_absolute_url("ui-supplier:landing")}
+    return make_request(Method.GET, URL, session=session, headers=headers)
+
+
+def should_be_here(response: Response):
+    """Check if User is on the correct page.
+
+    :param response: response object
+    """
+    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+    logging.debug("Supplier is on FAS Industries page")
+
+
+def should_see_industry_section(response: Response, industry: str):
+    if industry == "health":
+        expected = EXPECTED_STRINGS_HEALTH
+    elif industry == "tech":
+        expected = EXPECTED_STRINGS_TECH
+    elif industry == "creative":
+        expected = EXPECTED_STRINGS_CREATIVE
+    elif industry == "food and drink":
+        expected = EXPECTED_STRINGS_FOOD_AND_DRINK
+    else:
+        raise KeyError("Couldn't recognize '{}' as industry".format(industry))
+    check_response(response, 200, body_contains=expected)

--- a/tests/functional/features/pages/fas_ui_tech_industry.py
+++ b/tests/functional/features/pages/fas_ui_tech_industry.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""FAS - Tech Industry page"""
+import logging
+
+from requests import Response, Session
+
+from tests import get_absolute_url
+from tests.functional.features.utils import Method, check_response, make_request
+
+URL = get_absolute_url("ui-supplier:industries-tech")
+EXPECTED_STRINGS = [
+    "UK technology",
+    "See the UK's technology providers on the Find a supplier service",
+    "EVRYTHNG", "Arkessa", "Find other great UK companies", "Key facts",
+    "UK technology firms are global success stories",
+    "Read more about the company", "Company showcase", "Read case study"
+]
+
+
+def go_to(session: Session) -> Response:
+    """Go to Tech Industry Page on FAS
+
+    :param session: Supplier session object
+    :return: response object
+    """
+    headers = {"Referer": get_absolute_url("ui-supplier:industries")}
+    return make_request(Method.GET, URL, session=session, headers=headers)
+
+
+def should_be_here(response: Response):
+    """Check if User is on the correct page.
+
+    :param response: response object
+    """
+    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+    logging.debug("Supplier is on FAS Tech Industry page")

--- a/tests/functional/features/pages/fas_ui_tech_industry_summary.py
+++ b/tests/functional/features/pages/fas_ui_tech_industry_summary.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""FAS - Tech Industry page"""
+import logging
+
+from requests import Response, Session
+
+from tests import get_absolute_url
+from tests.functional.features.utils import Method, check_response, make_request
+
+URL = get_absolute_url("ui-supplier:industries-tech-summary")
+EXPECTED_STRINGS = [
+    "UK technology", "Find your UK trade partner",
+    "See the UK's technology providers on the Find a supplier service",
+    "EVRYTHNG", "Arkessa", "Find other great UK companies",
+    "Read more about the company", "Company showcase", "Read case study"
+]
+
+
+def go_to(session: Session) -> Response:
+    """Go to Tech Industry Page on FAS
+
+    :param session: Supplier session object
+    :return: response object
+    """
+    headers = {"Referer": get_absolute_url("ui-supplier:industries")}
+    return make_request(Method.GET, URL, session=session, headers=headers)
+
+
+def should_be_here(response: Response):
+    """Check if User is on the correct page.
+
+    :param response: response object
+    """
+    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+    logging.debug("Supplier is on FAS Tech Industry page")

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -442,6 +442,31 @@ def get_fas_page_url(page_name: str, *, language_code: str = None):
     return url
 
 
+def get_fas_page_object(page_name: str):
+    if page_name == FAS_PAGE.CREATIVE_INDUSTRY:
+        page = FAS_PAGE.CREATIVE_INDUSTRY.po
+    elif page_name == FAS_PAGE.FOOD_AND_DRINK_INDUSTRY:
+        page = FAS_PAGE.FOOD_AND_DRINK_INDUSTRY.po
+    elif page_name == FAS_PAGE.HEALTH_INDUSTRY:
+        page = FAS_PAGE.HEALTH_INDUSTRY.po
+    elif page_name == FAS_PAGE.TECH_INDUSTRY:
+        page = FAS_PAGE.TECH_INDUSTRY.po
+    elif page_name == FAS_PAGE.CREATIVE_INDUSTRY_SUMMARY:
+        page = FAS_PAGE.CREATIVE_INDUSTRY_SUMMARY.po
+    elif page_name == FAS_PAGE.FOOD_AND_DRINK_INDUSTRY_SUMMARY:
+        page = FAS_PAGE.FOOD_AND_DRINK_INDUSTRY_SUMMARY.po
+    elif page_name == FAS_PAGE.HEALTH_INDUSTRY_SUMMARY:
+        page = FAS_PAGE.HEALTH_INDUSTRY_SUMMARY.po
+    elif page_name == FAS_PAGE.TECH_INDUSTRY_SUMMARY:
+        page = FAS_PAGE.TECH_INDUSTRY_SUMMARY.po
+    elif page_name == FAS_PAGE.INDUSTRIES:
+        page = FAS_PAGE.INDUSTRIES.po
+    else:
+        raise KeyError("Unknown FAS page: '{}'".format(page_name))
+
+    return page
+
+
 def extract_main_error(content: str) -> str:
     """Extract error from page `main` block.
 

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -27,6 +27,7 @@ from tests.functional.features.db_cleanup import (
     get_company_email
 )
 from tests.functional.features.pages import int_api_ch_search
+from tests.functional.features.pages.common import FAS_PAGE
 from tests.functional.features.utils import (
     Method,
     assertion_msg,

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -15,6 +15,7 @@ from tests.functional.features.steps.fab_then_impl import (
     fas_no_links_to_online_profiles_are_visible,
     fas_pages_should_be_in_selected_language,
     fas_should_be_on_profile_page,
+    fas_should_be_on_selected_page,
     fas_should_be_told_that_message_has_been_sent,
     fas_should_find_all_sought_companies,
     fas_should_find_with_company_details,
@@ -265,3 +266,8 @@ def then_actor_should_see_different_logo_on_fas(context, actor_alias):
 @then('"{supplier_alias}" should see expected error messages')
 def then_supplier_should_see_expected_error_messages(context, supplier_alias):
     fab_should_see_expected_error_messages(context, supplier_alias)
+
+
+@then('"{actor_alias}" should be presented with "{page_name}" FAS page')
+def actor_should_be_on_specific_fas_page(context, actor_alias, page_name):
+    fas_should_be_on_selected_page(context, actor_alias, page_name)

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -23,6 +23,7 @@ from tests.functional.features.steps.fab_then_impl import (
     fas_should_see_company_details,
     fas_should_see_different_png_logo_thumbnail,
     fas_should_see_png_logo_thumbnail,
+    fas_should_see_promoted_industries,
     fas_supplier_cannot_be_found_using_case_study_details,
     fas_supplier_should_receive_message_from_buyer,
     prof_all_unsupported_files_should_be_rejected,
@@ -271,3 +272,8 @@ def then_supplier_should_see_expected_error_messages(context, supplier_alias):
 @then('"{actor_alias}" should be presented with "{page_name}" FAS page')
 def actor_should_be_on_specific_fas_page(context, actor_alias, page_name):
     fas_should_be_on_selected_page(context, actor_alias, page_name)
+
+
+@then('"{actor_alias}" should see sections with selected industries')
+def then_actor_should_see_sections_with_industries(context, actor_alias):
+    fas_should_see_promoted_industries(context, actor_alias, context.table)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -15,6 +15,7 @@ from tests.functional.features.pages import (
     fab_ui_try_other_services,
     fas_ui_contact,
     fas_ui_find_supplier,
+    fas_ui_industries,
     fas_ui_profile,
     profile_ui_landing,
     sso_ui_verify_your_email
@@ -608,3 +609,13 @@ def fas_should_be_on_selected_page(context, actor_alias, page_name):
     page_object.should_be_here(response)
     logging.debug(
         "%s successfully got to the %s FAS page", actor_alias, page_name)
+
+
+def fas_should_see_promoted_industries(context, actor_alias, table):
+    industries = [row['industry'].lower() for row in table]
+    response = context.response
+    for industry in industries:
+        fas_ui_industries.should_see_industry_section(response, industry)
+    logging.debug(
+        "%s can see all expected industry sections '%s'", actor_alias,
+        industries)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -21,6 +21,7 @@ from tests.functional.features.pages import (
 )
 from tests.functional.features.pages.utils import (
     detect_page_language,
+    get_fas_page_object,
     get_language_code,
     get_number_of_search_result_pages
 )
@@ -599,3 +600,11 @@ def fab_should_see_expected_error_messages(context, supplier_alias):
                 company.keywords, company.no_employees):
             assert error in response.content.decode("utf-8")
     logging.debug("%s has seen all expected form errors", supplier_alias)
+
+
+def fas_should_be_on_selected_page(context, actor_alias, page_name):
+    response = context.response
+    page_object = get_fas_page_object(page_name)
+    page_object.should_be_here(response)
+    logging.debug(
+        "%s successfully got to the %s FAS page", actor_alias, page_name)

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -13,6 +13,7 @@ from tests.functional.features.steps.fab_when_impl import (
     fas_search_with_product_service_keyword,
     fas_send_feedback_request,
     fas_send_message_to_supplier,
+    fas_view_page,
     fas_view_pages_in_selected_language,
     prof_add_case_study,
     prof_add_invalid_online_profiles,
@@ -217,3 +218,8 @@ def when_buyer_sends_message_to_supplier(context, buyer_alias, company_alias):
 @when('"{supplier_alias}" provides company details using following values')
 def when_supplier_provide_company_details(context, supplier_alias):
     fab_provide_company_details(context, supplier_alias, context.table)
+
+
+@when('"{actor_alias}" visits "{page_name}" page on FAS')
+def when_actor_visits_page_on_fas(context, actor_alias, page_name):
+    fas_view_page(context, actor_alias, page_name)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -43,6 +43,7 @@ from tests.functional.features.pages.utils import (
     escape_html,
     extract_and_set_csrf_middleware_token,
     get_active_company_without_fas_profile,
+    get_fas_page_object,
     get_fas_page_url,
     get_language_code,
     get_number_of_search_result_pages,
@@ -1118,6 +1119,13 @@ def fas_view_pages_in_selected_language(
         response = make_request(Method.GET, page_url, session=session)
         views[page_name] = response
     context.views = views
+
+
+def fas_view_page(context, actor_alias, page_name):
+    actor = context.get_actor(actor_alias)
+    session = actor.session
+    page_object = get_fas_page_object(page_name)
+    context.response = page_object.go_to(session)
 
 
 def fas_search_with_empty_query(context, buyer_alias):


### PR DESCRIPTION
These 2 tickets: [ED-2013](https://uktrade.atlassian.net/browse/ED-2013) & [ED-2015](https://uktrade.atlassian.net/browse/ED-2015)

This adds 2 new scenarios:
```gherkin

  @ED-2013
  @industries
  Scenario: Buyers should be able to view page with promoted Industries
    Given "Annette Geissinger" is a buyer

    When "Annette Geissinger" visits "Industries" page on FAS

    Then "Annette Geissinger" should see sections with selected industries
      | industry       |
      | Health         |
      | Tech           |
      | Creative       |
      | Food and drink |


  @ED-2015
  @industries
  Scenario Outline: Buyers should be able to find out more about every promoted industry - visit "<selected>" page
    Given "Annette Geissinger" is a buyer

    When "Annette Geissinger" visits "<selected>" page on FAS

    Then "Annette Geissinger" should be presented with "<selected>" FAS page

    Examples:
      | selected                        |
      | Health Industry                 |
      | Tech Industry                   |
      | Creative Industry               |
      | Food and drink Industry         |
      | Health Industry Summary         |
      | Tech Industry Summary           |
      | Creative Industry Summary       |
      | Food and drink Industry Summary |
```