### PR TITLE
ED-2016 find suppliers by showcase case study industries

### DIFF
--- a/tests/functional/features/fas/industries.feature
+++ b/tests/functional/features/fas/industries.feature
@@ -34,3 +34,25 @@ Feature: Promoted industries
       | Tech Industry Summary           |
       | Creative Industry Summary       |
       | Food and drink Industry Summary |
+
+
+  @ED-2016
+  @industries
+  Scenario Outline: Buyers should be able to find UK Suppliers by keywords associated with promoted Case Study on "<selected>" page
+    Given "Annette Geissinger" is a buyer
+    And "Annette Geissinger" is on the "<selected>" page on FAS
+
+    When "Annette Geissinger" follows all the links to industries associated with the case study from the Company Showcase
+
+    Then "Annette Geissinger" should see search results filtered by appropriate industries
+
+    Examples:
+      | selected                        |
+      | Health Industry                 |
+      | Tech Industry                   |
+      | Creative Industry               |
+      | Food and drink Industry         |
+      | Health Industry Summary         |
+      | Tech Industry Summary           |
+      | Creative Industry Summary       |
+      | Food and drink Industry Summary |

--- a/tests/functional/features/fas/industries.feature
+++ b/tests/functional/features/fas/industries.feature
@@ -38,7 +38,7 @@ Feature: Promoted industries
 
   @ED-2016
   @industries
-  Scenario Outline: Buyers should be able to find UK Suppliers by keywords associated with promoted Case Study on "<selected>" page
+  Scenario Outline: Buyers should be able to find UK Suppliers by industries associated with promoted Case Study on "<selected>" page
     Given "Annette Geissinger" is a buyer
     And "Annette Geissinger" is on the "<selected>" page on FAS
 

--- a/tests/functional/features/steps/fab_given_def.py
+++ b/tests/functional/features/steps/fab_given_def.py
@@ -23,6 +23,7 @@ from tests.functional.features.steps.fab_then_impl import (
     sso_should_be_signed_in_to_sso_account
 )
 from tests.functional.features.steps.fab_when_impl import (
+    fas_view_page,
     prof_add_case_study,
     prof_add_online_profiles,
     prof_set_company_description,
@@ -147,3 +148,8 @@ def given_buyer_finds_company_by_name(context, buyer_alias, company_alias):
        'Directory Profile page')
 def given_actor_can_see_logo_on_fas_profile_page(context, actor_alias):
     fas_should_see_png_logo_thumbnail(context, actor_alias)
+
+
+@given('"{actor_alias}" is on the "{page_name}" page on FAS')
+def step_impl(context, actor_alias, page_name):
+    fas_view_page(context, actor_alias, page_name)

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -22,6 +22,7 @@ from tests.functional.features.steps.fab_then_impl import (
     fas_should_see_all_case_studies,
     fas_should_see_company_details,
     fas_should_see_different_png_logo_thumbnail,
+    fas_should_see_filtered_search_results,
     fas_should_see_png_logo_thumbnail,
     fas_should_see_promoted_industries,
     fas_supplier_cannot_be_found_using_case_study_details,
@@ -277,3 +278,9 @@ def actor_should_be_on_specific_fas_page(context, actor_alias, page_name):
 @then('"{actor_alias}" should see sections with selected industries')
 def then_actor_should_see_sections_with_industries(context, actor_alias):
     fas_should_see_promoted_industries(context, actor_alias, context.table)
+
+
+@then('"{actor_alias}" should see search results filtered by appropriate '
+      'industries')
+def then_actor_should_see_filtered_search_results(context, actor_alias):
+    fas_should_see_filtered_search_results(context, actor_alias)

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -8,6 +8,7 @@ from tests.functional.features.steps.fab_when_impl import (
     bp_select_random_sector_and_export_to_country,
     fab_provide_company_details,
     fab_update_case_study,
+    fas_follow_case_study_links_to_related_sectors,
     fas_search_using_company_details,
     fas_search_with_empty_query,
     fas_search_with_product_service_keyword,
@@ -223,3 +224,9 @@ def when_supplier_provide_company_details(context, supplier_alias):
 @when('"{actor_alias}" visits "{page_name}" page on FAS')
 def when_actor_visits_page_on_fas(context, actor_alias, page_name):
     fas_view_page(context, actor_alias, page_name)
+
+
+@when('"{actor_alias}" follows all the links to industries associated with the'
+      ' case study from the Company Showcase')
+def when_actor_follows_case_study_links_to_sectors(context, actor_alias):
+    fas_follow_case_study_links_to_related_sectors(context, actor_alias)


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2016)

```gherkin
  @ED-2016
  @industries
  Scenario Outline: Buyers should be able to find UK Suppliers by industries associated with promoted Case Study on "<selected>" page
    Given "Annette Geissinger" is a buyer
    And "Annette Geissinger" is on the "<selected>" page on FAS

    When "Annette Geissinger" follows all the links to industries associated with the case study from the Company Showcase

    Then "Annette Geissinger" should see search results filtered by appropriate industries

    Examples:
      | selected                        |
      | Health Industry                 |
      | Tech Industry                   |
      | Creative Industry               |
      | Food and drink Industry         |
      | Health Industry Summary         |
      | Tech Industry Summary           |
      | Creative Industry Summary       |
      | Food and drink Industry Summary |
```