### PR TITLE
ED-2018 filter by multiple sectors

### DIFF
--- a/tests/functional/features/fas/search.feature
+++ b/tests/functional/features/fas/search.feature
@@ -131,3 +131,15 @@ Feature: Find a Supplier
     When "Annette Geissinger" browse Suppliers by every available sector filter
 
     Then "Annette Geissinger" should see search results filtered by appropriate sector
+
+
+  @ED-2018
+  @filter
+  @sector
+  @search
+  Scenario: Buyers should be able to browse UK Suppliers by multiple sectors at once
+    Given "Annette Geissinger" is a buyer
+
+    When "Annette Geissinger" browse Suppliers by multiple sector filters
+
+    Then "Annette Geissinger" should see search results filtered by appropriate sectors

--- a/tests/functional/features/fas/search.feature
+++ b/tests/functional/features/fas/search.feature
@@ -143,3 +143,16 @@ Feature: Find a Supplier
     When "Annette Geissinger" browse Suppliers by multiple sector filters
 
     Then "Annette Geissinger" should see search results filtered by appropriate sectors
+
+
+  @ED-2018
+  @filter
+  @sector
+  @search
+  @invalid
+  Scenario: Buyers should NOT be able to browse UK Suppliers by invalid sectors
+    Given "Annette Geissinger" is a buyer
+
+    When "Annette Geissinger" attempts to browse Suppliers by invalid sector filter
+
+    Then "Annette Geissinger" should be told that the search did not match any UK trade profiles

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -8,6 +8,7 @@ from tests.functional.features.steps.fab_when_impl import (
     bp_verify_identity_with_letter,
     fab_provide_company_details,
     fab_update_case_study,
+    fas_browse_suppliers_by_invalid_sectors,
     fas_browse_suppliers_by_multiple_sectors,
     fas_browse_suppliers_using_every_sector_filter,
     fas_follow_case_study_links_to_related_sectors,
@@ -242,3 +243,8 @@ def when_actor_browse_suppliers_using_every_sector_filter(context, actor_alias):
 @when('"{actor_alias}" browse Suppliers by multiple sector filters')
 def when_actor_browse_suppliers_by_multiple_sectors(context, actor_alias):
     fas_browse_suppliers_by_multiple_sectors(context, actor_alias)
+
+
+@when('"{actor_alias}" attempts to browse Suppliers by invalid sector filter')
+def when_actor_browse_suppliers_by_invalid_sectors(context, actor_alias):
+    fas_browse_suppliers_by_invalid_sectors(context, actor_alias)

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -235,7 +235,7 @@ def when_actor_follows_case_study_links_to_sectors(context, actor_alias):
 
 
 @when('"{actor_alias}" browse Suppliers by every available sector filter')
-def when_actor_checks_every_industry_filter(context, actor_alias):
+def when_actor_browse_suppliers_using_every_sector_filter(context, actor_alias):
     fas_browse_suppliers_using_every_sector_filter(context, actor_alias)
 
 

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -8,6 +8,7 @@ from tests.functional.features.steps.fab_when_impl import (
     bp_verify_identity_with_letter,
     fab_provide_company_details,
     fab_update_case_study,
+    fas_browse_suppliers_by_multiple_sectors,
     fas_browse_suppliers_using_every_sector_filter,
     fas_follow_case_study_links_to_related_sectors,
     fas_search_using_company_details,
@@ -236,3 +237,8 @@ def when_actor_follows_case_study_links_to_sectors(context, actor_alias):
 @when('"{actor_alias}" browse Suppliers by every available sector filter')
 def when_actor_checks_every_industry_filter(context, actor_alias):
     fas_browse_suppliers_using_every_sector_filter(context, actor_alias)
+
+
+@when('"{actor_alias}" browse Suppliers by multiple sector filters')
+def when_actor_browse_suppliers_by_multiple_sectors(context, actor_alias):
+    fas_browse_suppliers_by_multiple_sectors(context, actor_alias)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1424,3 +1424,31 @@ def fas_browse_suppliers_using_every_sector_filter(
             "response": response
         }
     context.results = results
+
+
+def fas_browse_suppliers_by_multiple_sectors(
+        context: Context, actor_alias: str):
+    actor = context.get_actor(actor_alias)
+    session = actor.session
+
+    response = fas_ui_find_supplier.go_to(session, term="")
+    context.response = response
+
+    sector_selector = "#id_sectors input::attr(value)"
+    content = response.content.decode("utf-8")
+    filters = Selector(text=content).css(sector_selector).extract()
+
+    sectors = list(set(random.choice(filters)
+                       for _ in range(random.randrange(1, len(filters)))))
+    results = {}
+    logging.debug(
+        "%s will browse Suppliers by multiple Industry sector filters '%s'",
+        actor_alias, ", ".join(sectors)
+    )
+    response = fas_ui_find_supplier.go_to(session, sectors=sectors)
+    results["multiple choice"] = {
+        "url": response.request.url,
+        "sectors": sectors,
+        "response": response
+    }
+    context.results = results

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1452,3 +1452,27 @@ def fas_browse_suppliers_by_multiple_sectors(
         "response": response
     }
     context.results = results
+
+
+def fas_browse_suppliers_by_invalid_sectors(
+        context: Context, actor_alias: str):
+    actor = context.get_actor(actor_alias)
+    session = actor.session
+
+    response = fas_ui_find_supplier.go_to(session, term="")
+    context.response = response
+
+    sector_selector = "#id_sectors input::attr(value)"
+    content = response.content.decode("utf-8")
+    filters = Selector(text=content).css(sector_selector).extract()
+
+    sectors = list(set(random.choice(filters)
+                       for _ in range(random.randrange(1, len(filters)))))
+
+    sectors.append("this_is_an_invalid_sector_filter")
+    logging.debug(
+        "%s will browse Suppliers by multiple Industry sector filters and will"
+        " inject an invalid filter: '%s'",
+        actor_alias, ", ".join(sectors)
+    )
+    context.response = fas_ui_find_supplier.go_to(session, sectors=sectors)


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2018)

```gherkin
  @ED-2018
  @filter
  @sector
  @search
  Scenario: Buyers should be able to browse UK Suppliers by multiple sectors at once
    Given "Annette Geissinger" is a buyer

    When "Annette Geissinger" browse Suppliers by multiple sector filters

    Then "Annette Geissinger" should see search results filtered by appropriate sectors

  @ED-2018
  @filter
  @sector
  @search
  @invalid
  Scenario: Buyers should NOT be able to browse UK Suppliers by invalid sectors
    Given "Annette Geissinger" is a buyer

    When "Annette Geissinger" attempts to browse Suppliers by invalid sector filter

    Then "Annette Geissinger" should be told that the search did not match any UK trade profiles
```