### PR TITLE
ED-2019 Buyers should be able to clear the filter results

### DIFF
--- a/tests/functional/features/fas/search.feature
+++ b/tests/functional/features/fas/search.feature
@@ -156,3 +156,17 @@ Feature: Find a Supplier
     When "Annette Geissinger" attempts to browse Suppliers by invalid sector filter
 
     Then "Annette Geissinger" should be told that the search did not match any UK trade profiles
+
+
+  @ED-2019
+  @filter
+  @sector
+  @search
+  Scenario: Buyers should be able to clear search results filters
+    Given "Annette Geissinger" is a buyer
+
+    When "Annette Geissinger" browse Suppliers by multiple sector filters
+    And "Annette Geissinger" clears the search filters
+
+    Then "Annette Geissinger" should be told that the search did not match any UK trade profiles
+    And "Annette Geissinger" should see that search results are not filtered by any sector

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -25,6 +25,7 @@ from tests.functional.features.steps.fab_then_impl import (
     fas_should_see_filtered_search_results,
     fas_should_see_png_logo_thumbnail,
     fas_should_see_promoted_industries,
+    fas_should_see_unfiltered_search_results,
     fas_supplier_cannot_be_found_using_case_study_details,
     fas_supplier_should_receive_message_from_buyer,
     prof_all_unsupported_files_should_be_rejected,
@@ -286,3 +287,9 @@ def then_actor_should_see_sections_with_industries(context, actor_alias):
       'sectors')
 def then_actor_should_see_filtered_search_results(context, actor_alias):
     fas_should_see_filtered_search_results(context, actor_alias)
+
+
+@then('"{actor_alias}" should see that search results are not filtered by any '
+      'sector')
+def then_actor_should_see_unfiltered_search_results(context, actor_alias):
+    fas_should_see_unfiltered_search_results(context, actor_alias)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -647,3 +647,19 @@ def fas_should_see_filtered_search_results(context, actor_alias):
             "%s was presented with '%s' industry search results correctly "
             "filtered by following sectors: '%s'", actor_alias, industry,
             ", ".join(result['sectors']))
+
+
+def fas_should_see_unfiltered_search_results(context, actor_alias):
+    response = context.response
+    content = response.content.decode("utf-8")
+    sector_filters_selector = "#id_sectors input"
+    filters = Selector(text=content).css(sector_filters_selector).extract()
+    for fil in filters:
+        sector = Selector(text=fil).css("input::attr(value)").extract()[0]
+        selector = "input::attr(checked)"
+        checked = True if Selector(text=fil).css(selector).extract() else False
+        with assertion_msg(
+                "Expected search results to be unfiltered but this "
+                "filter was checked: '%s'", sector):
+            assert not checked
+    logging.debug("%s was shown with unfiltered search results", actor_alias)

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -11,6 +11,7 @@ from tests.functional.features.steps.fab_when_impl import (
     fas_browse_suppliers_by_invalid_sectors,
     fas_browse_suppliers_by_multiple_sectors,
     fas_browse_suppliers_using_every_sector_filter,
+    fas_clear_search_filters,
     fas_follow_case_study_links_to_related_sectors,
     fas_search_using_company_details,
     fas_search_with_empty_query,
@@ -248,3 +249,8 @@ def when_actor_browse_suppliers_by_multiple_sectors(context, actor_alias):
 @when('"{actor_alias}" attempts to browse Suppliers by invalid sector filter')
 def when_actor_browse_suppliers_by_invalid_sectors(context, actor_alias):
     fas_browse_suppliers_by_invalid_sectors(context, actor_alias)
+
+
+@when('"{actor_alias}" clears the search filters')
+def when_actor_clears_search_filters(context, actor_alias):
+    fas_clear_search_filters(context, actor_alias)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1476,3 +1476,12 @@ def fas_browse_suppliers_by_invalid_sectors(
         actor_alias, ", ".join(sectors)
     )
     context.response = fas_ui_find_supplier.go_to(session, sectors=sectors)
+
+
+def fas_clear_search_filters(context: Context, actor_alias: str):
+    actor = context.get_actor(actor_alias)
+    session = actor.session
+
+    logging.debug("%s will clear the search filter", actor_alias)
+    response = fas_ui_find_supplier.go_to(session, term="")
+    context.response = response


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2019)

```gherkin
  @ED-2019
  @filter
  @sector
  @search
  Scenario: Buyers should be able to clear search results filters
    Given "Annette Geissinger" is a buyer

    When "Annette Geissinger" browse Suppliers by multiple sector filters
    And "Annette Geissinger" clears the search filters

    Then "Annette Geissinger" should be told that the search did not match any UK trade profiles
    And "Annette Geissinger" should see that search results are not filtered by any sector
```