### PR TITLE
ED-2142 case study input data validation

### DIFF
--- a/tests/functional/features/fab/case_studies.feature
+++ b/tests/functional/features/fab/case_studies.feature
@@ -1,0 +1,35 @@
+Feature: Case Studies
+
+
+  @ED-2142
+  @fab
+  @case-study
+  @profile
+  Scenario: Supplier should not be able to use invalid values when adding a case study
+    Given "Peter Alder" created an unverified profile for randomly selected company "Y"
+
+    When "Peter Alder" attempts to add a case study using following values
+      |field         |value type      |separator |error                                                   |
+      |title         |61 characters   |          |Ensure this value has at most 60 characters (it has 61).|
+      |summary       |51 words        |          |Ensure this value has at most 60 characters (it has 61).|
+      |description   |101 characters  |          |Ensure this value has at most 60 characters (it has 61).|
+      |sector        |invalid sector  |          |Ensure this value has at most 60 characters (it has 61).|
+      |website       |invalid http    |          |Ensure this value has at most 60 characters (it has 61).|
+      |keywords      |book, keys, food|pipe      |Ensure this value has at most 60 characters (it has 61).|
+      |keywords      |book, keys, food|semi-colon|Ensure this value has at most 60 characters (it has 61).|
+      |keywords      |book, keys, food|colon     |Ensure this value has at most 60 characters (it has 61).|
+      |keywords      |book, keys, food|full stop |Ensure this value has at most 60 characters (it has 61).|
+      |keywords      |empty string    |          |Ensure this value has at most 60 characters (it has 61).|
+      |image_1       |invalid image   |          |Ensure this value has at most 60 characters (it has 61).|
+      |caption_1     |999 characters  |          |Ensure this value has at most 60 characters (it has 61).|
+      |caption_1     |empty string    |          |Ensure this value has at most 60 characters (it has 61).|
+      |image_2       |invalid image   |          |Ensure this value has at most 60 characters (it has 61).|
+      |caption_2     |999 characters  |          |Ensure this value has at most 60 characters (it has 61).|
+      |image_3       |invalid image   |          |Ensure this value has at most 60 characters (it has 61).|
+      |caption_3     |999 characters  |          |Ensure this value has at most 60 characters (it has 61).|
+      |testimonial   |999 characters  |          |Ensure this value has at most 60 characters (it has 61).|
+      |source_name   |999 characters  |          |Ensure this value has at most 60 characters (it has 61).|
+      |source_job    |999 characters  |          |Ensure this value has at most 60 characters (it has 61).|
+      |source_company|999 characters  |          |Ensure this value has at most 60 characters (it has 61).|
+
+    Then "Peter Alder" should see expected case study error message

--- a/tests/functional/features/fab/case_studies.feature
+++ b/tests/functional/features/fab/case_studies.feature
@@ -9,30 +9,31 @@ Feature: Case Studies
     Given "Peter Alder" created an unverified profile for randomly selected company "Y"
 
     When "Peter Alder" attempts to add a case study using following values
-      |field         |value type      |separator |error                                                       |
-      |title         |61 characters   |          |Ensure this value has at most 60 characters (it has 61).    |
-      |title         |empty string    |          |This field is required.                                     |
-      |summary       |201 characters  |          |Ensure this value has at most 200 characters (it has 201).  |
-      |summary       |empty string    |          |This field is required.                                     |
-      |description   |1001 characters |          |Ensure this value has at most 1000 characters (it has 1001).|
-      |description   |empty string    |          |This field is required.                                     |
-      |sector        |invalid sector  |          |Ensure this value has at most 60 characters (it has 61).    |
-      |website       |invalid http    |          |Ensure this value has at most 60 characters (it has 61).    |
-      |keywords      |book, keys, food|pipe      |You can only enter letters, numbers and commas.             |
-      |keywords      |book, keys, food|semi-colon|You can only enter letters, numbers and commas.             |
-      |keywords      |book, keys, food|colon     |You can only enter letters, numbers and commas.             |
-      |keywords      |book, keys, food|full stop |You can only enter letters, numbers and commas.             |
-      |keywords      |empty string    |          |Ensure this value has at most 60 characters (it has 61).    |
-      |image_1       |invalid image   |          |Invalid image format, allowed formats: PNG, JPG, JPEG       |
-      |caption_1     |121 characters  |          |Ensure this value has at most 120 characters (it has 121).  |
-      |caption_1     |empty string    |          |This field is required.                                     |
-      |image_2       |invalid image   |          |Invalid image format, allowed formats: PNG, JPG, JPEG       |
-      |caption_2     |121 characters  |          |Ensure this value has at most 120 characters (it has 121).  |
-      |image_3       |invalid image   |          |Invalid image format, allowed formats: PNG, JPG, JPEG       |
-      |caption_3     |121 characters  |          |Ensure this value has at most 120 characters (it has 121).  |
-      |testimonial   |1001 characters |          |Ensure this value has at most 1000 characters (it has 1001).|
-      |source_name   |256 characters  |          |Ensure this value has at most 255 characters (it has 256).  |
-      |source_job    |256 characters  |          |Ensure this value has at most 255 characters (it has 256).  |
-      |source_company|256 characters  |          |Ensure this value has at most 255 characters (it has 256).  |
+      |field         |value type      |separator |error                                                                                |
+      |title         |61 characters   |          |Ensure this value has at most 60 characters (it has 61).                             |
+      |title         |empty string    |          |This field is required.                                                              |
+      |summary       |201 characters  |          |Ensure this value has at most 200 characters (it has 201).                           |
+      |summary       |empty string    |          |This field is required.                                                              |
+      |description   |1001 characters |          |Ensure this value has at most 1000 characters (it has 1001).                         |
+      |description   |empty string    |          |This field is required.                                                              |
+      |sector        |invalid sector  |          |Select a valid choice. this is an invalid sector is not one of the available choices.|
+      |website       |invalid http    |          |Ensure this value has at most 60 characters (it has 61).                             |
+      |keywords      |book, keys, food|pipe      |You can only enter letters, numbers and commas.                                      |
+      |keywords      |book, keys, food|semi-colon|You can only enter letters, numbers and commas.                                      |
+      |keywords      |book, keys, food|colon     |You can only enter letters, numbers and commas.                                      |
+      |keywords      |book, keys, food|full stop |You can only enter letters, numbers and commas.                                      |
+      |keywords      |empty string    |          |Ensure this value has at most 60 characters (it has 61).                             |
+      |image_1       |invalid image   |          |Invalid image format, allowed formats: PNG, JPG, JPEG                                |
+      |image_1       |no image        |          |This field is required.                                                              |
+      |caption_1     |121 characters  |          |Ensure this value has at most 120 characters (it has 121).                           |
+      |caption_1     |empty string    |          |This field is required.                                                              |
+      |image_2       |invalid image   |          |Invalid image format, allowed formats: PNG, JPG, JPEG                                |
+      |caption_2     |121 characters  |          |Ensure this value has at most 120 characters (it has 121).                           |
+      |image_3       |invalid image   |          |Invalid image format, allowed formats: PNG, JPG, JPEG                                |
+      |caption_3     |121 characters  |          |Ensure this value has at most 120 characters (it has 121).                           |
+      |testimonial   |1001 characters |          |Ensure this value has at most 1000 characters (it has 1001).                         |
+      |source_name   |256 characters  |          |Ensure this value has at most 255 characters (it has 256).                           |
+      |source_job    |256 characters  |          |Ensure this value has at most 255 characters (it has 256).                           |
+      |source_company|256 characters  |          |Ensure this value has at most 255 characters (it has 256).                           |
 
     Then "Peter Alder" should see expected case study error message

--- a/tests/functional/features/fab/case_studies.feature
+++ b/tests/functional/features/fab/case_studies.feature
@@ -17,14 +17,15 @@ Feature: Case Studies
       |description   |1001 characters |          |Ensure this value has at most 1000 characters (it has 1001).                         |
       |description   |empty string    |          |This field is required.                                                              |
       |sector        |invalid sector  |          |Select a valid choice. this is an invalid sector is not one of the available choices.|
-      |website       |invalid http    |          |Ensure this value has at most 60 characters (it has 61).                             |
+#      |website       |invalid http    |          |Enter a valid URL.                                                                   |
+      |website       |256 characters  |          |Enter a valid URL.                                                                   |
       |keywords      |book, keys, food|pipe      |You can only enter letters, numbers and commas.                                      |
       |keywords      |book, keys, food|semi-colon|You can only enter letters, numbers and commas.                                      |
       |keywords      |book, keys, food|colon     |You can only enter letters, numbers and commas.                                      |
       |keywords      |book, keys, food|full stop |You can only enter letters, numbers and commas.                                      |
-      |keywords      |empty string    |          |Ensure this value has at most 60 characters (it has 61).                             |
+      |keywords      |empty string    |          |This field is required.                                                              |
       |image_1       |invalid image   |          |Invalid image format, allowed formats: PNG, JPG, JPEG                                |
-      |image_1       |no image        |          |This field is required.                                                              |
+#      |image_1       |no image        |          |This field is required.                                                              |
       |caption_1     |121 characters  |          |Ensure this value has at most 120 characters (it has 121).                           |
       |caption_1     |empty string    |          |This field is required.                                                              |
       |image_2       |invalid image   |          |Invalid image format, allowed formats: PNG, JPG, JPEG                                |
@@ -35,5 +36,23 @@ Feature: Case Studies
       |source_name   |256 characters  |          |Ensure this value has at most 255 characters (it has 256).                           |
       |source_job    |256 characters  |          |Ensure this value has at most 255 characters (it has 256).                           |
       |source_company|256 characters  |          |Ensure this value has at most 255 characters (it has 256).                           |
+
+    Then "Peter Alder" should see expected case study error message
+
+
+  @ED-2142a
+  @fab
+  @case-study
+  @profile
+  @bug
+  @ED-
+  @fixme
+  Scenario: Supplier should not be able to use invalid values when adding a case study
+    Given "Peter Alder" created an unverified profile for randomly selected company "Y"
+
+    When "Peter Alder" attempts to add a case study using following values
+      |field         |value type      |separator |error             |
+      |website       |invalid http    |          |Enter a valid URL.|
+      |website       |invalid https   |          |Enter a valid URL.|
 
     Then "Peter Alder" should see expected case study error message

--- a/tests/functional/features/fab/case_studies.feature
+++ b/tests/functional/features/fab/case_studies.feature
@@ -44,7 +44,7 @@ Feature: Case Studies
   @case-study
   @profile
   @bug
-  @ED-
+  @ED-2248
   @fixme
   Scenario: Supplier should not be able to use invalid values when adding a case study
     Given "Peter Alder" created an unverified profile for randomly selected company "Y"

--- a/tests/functional/features/fab/case_studies.feature
+++ b/tests/functional/features/fab/case_studies.feature
@@ -18,10 +18,10 @@ Feature: Case Studies
       |description   |empty string    |          |This field is required.                                                              |
       |sector        |invalid sector  |          |Select a valid choice. this is an invalid sector is not one of the available choices.|
       |website       |256 characters  |          |Enter a valid URL.                                                                   |
-      |keywords      |book, keys, food|pipe      |You can only enter letters, numbers and commas.                                      |
-      |keywords      |book, keys, food|semi-colon|You can only enter letters, numbers and commas.                                      |
-      |keywords      |book, keys, food|colon     |You can only enter letters, numbers and commas.                                      |
-      |keywords      |book, keys, food|full stop |You can only enter letters, numbers and commas.                                      |
+      |keywords      |3 words         |pipe      |You can only enter letters, numbers and commas.                                      |
+      |keywords      |3 words         |semi-colon|You can only enter letters, numbers and commas.                                      |
+      |keywords      |3 words         |colon     |You can only enter letters, numbers and commas.                                      |
+      |keywords      |3 words         |full stop |You can only enter letters, numbers and commas.                                      |
       |keywords      |empty string    |          |This field is required.                                                              |
       |image_1       |invalid image   |          |Invalid image format, allowed formats: PNG, JPG, JPEG                                |
       |image_1       |no image        |          |This field is required.                                                              |

--- a/tests/functional/features/fab/case_studies.feature
+++ b/tests/functional/features/fab/case_studies.feature
@@ -14,7 +14,7 @@ Feature: Case Studies
       |title         |empty string    |          |This field is required.                                     |
       |summary       |201 characters  |          |Ensure this value has at most 200 characters (it has 201).  |
       |summary       |empty string    |          |This field is required.                                     |
-      |description   |101 characters  |          |Ensure this value has at most 60 characters (it has 61).    |
+      |description   |1001 characters |          |Ensure this value has at most 1000 characters (it has 10-1).|
       |description   |empty string    |          |This field is required.                                     |
       |sector        |invalid sector  |          |Ensure this value has at most 60 characters (it has 61).    |
       |website       |invalid http    |          |Ensure this value has at most 60 characters (it has 61).    |

--- a/tests/functional/features/fab/case_studies.feature
+++ b/tests/functional/features/fab/case_studies.feature
@@ -14,7 +14,7 @@ Feature: Case Studies
       |title         |empty string    |          |This field is required.                                     |
       |summary       |201 characters  |          |Ensure this value has at most 200 characters (it has 201).  |
       |summary       |empty string    |          |This field is required.                                     |
-      |description   |1001 characters |          |Ensure this value has at most 1000 characters (it has 10-1).|
+      |description   |1001 characters |          |Ensure this value has at most 1000 characters (it has 1001).|
       |description   |empty string    |          |This field is required.                                     |
       |sector        |invalid sector  |          |Ensure this value has at most 60 characters (it has 61).    |
       |website       |invalid http    |          |Ensure this value has at most 60 characters (it has 61).    |

--- a/tests/functional/features/fab/case_studies.feature
+++ b/tests/functional/features/fab/case_studies.feature
@@ -9,27 +9,30 @@ Feature: Case Studies
     Given "Peter Alder" created an unverified profile for randomly selected company "Y"
 
     When "Peter Alder" attempts to add a case study using following values
-      |field         |value type      |separator |error                                                   |
-      |title         |61 characters   |          |Ensure this value has at most 60 characters (it has 61).|
-      |summary       |51 words        |          |Ensure this value has at most 60 characters (it has 61).|
-      |description   |101 characters  |          |Ensure this value has at most 60 characters (it has 61).|
-      |sector        |invalid sector  |          |Ensure this value has at most 60 characters (it has 61).|
-      |website       |invalid http    |          |Ensure this value has at most 60 characters (it has 61).|
-      |keywords      |book, keys, food|pipe      |Ensure this value has at most 60 characters (it has 61).|
-      |keywords      |book, keys, food|semi-colon|Ensure this value has at most 60 characters (it has 61).|
-      |keywords      |book, keys, food|colon     |Ensure this value has at most 60 characters (it has 61).|
-      |keywords      |book, keys, food|full stop |Ensure this value has at most 60 characters (it has 61).|
-      |keywords      |empty string    |          |Ensure this value has at most 60 characters (it has 61).|
-      |image_1       |invalid image   |          |Ensure this value has at most 60 characters (it has 61).|
-      |caption_1     |999 characters  |          |Ensure this value has at most 60 characters (it has 61).|
-      |caption_1     |empty string    |          |Ensure this value has at most 60 characters (it has 61).|
-      |image_2       |invalid image   |          |Ensure this value has at most 60 characters (it has 61).|
-      |caption_2     |999 characters  |          |Ensure this value has at most 60 characters (it has 61).|
-      |image_3       |invalid image   |          |Ensure this value has at most 60 characters (it has 61).|
-      |caption_3     |999 characters  |          |Ensure this value has at most 60 characters (it has 61).|
-      |testimonial   |999 characters  |          |Ensure this value has at most 60 characters (it has 61).|
-      |source_name   |999 characters  |          |Ensure this value has at most 60 characters (it has 61).|
-      |source_job    |999 characters  |          |Ensure this value has at most 60 characters (it has 61).|
-      |source_company|999 characters  |          |Ensure this value has at most 60 characters (it has 61).|
+      |field         |value type      |separator |error                                                       |
+      |title         |61 characters   |          |Ensure this value has at most 60 characters (it has 61).    |
+      |title         |empty string    |          |This field is required.                                     |
+      |summary       |201 characters  |          |Ensure this value has at most 200 characters (it has 201).  |
+      |summary       |empty string    |          |This field is required.                                     |
+      |description   |101 characters  |          |Ensure this value has at most 60 characters (it has 61).    |
+      |description   |empty string    |          |This field is required.                                     |
+      |sector        |invalid sector  |          |Ensure this value has at most 60 characters (it has 61).    |
+      |website       |invalid http    |          |Ensure this value has at most 60 characters (it has 61).    |
+      |keywords      |book, keys, food|pipe      |You can only enter letters, numbers and commas.             |
+      |keywords      |book, keys, food|semi-colon|You can only enter letters, numbers and commas.             |
+      |keywords      |book, keys, food|colon     |You can only enter letters, numbers and commas.             |
+      |keywords      |book, keys, food|full stop |You can only enter letters, numbers and commas.             |
+      |keywords      |empty string    |          |Ensure this value has at most 60 characters (it has 61).    |
+      |image_1       |invalid image   |          |Invalid image format, allowed formats: PNG, JPG, JPEG       |
+      |caption_1     |121 characters  |          |Ensure this value has at most 120 characters (it has 121).  |
+      |caption_1     |empty string    |          |This field is required.                                     |
+      |image_2       |invalid image   |          |Invalid image format, allowed formats: PNG, JPG, JPEG       |
+      |caption_2     |121 characters  |          |Ensure this value has at most 120 characters (it has 121).  |
+      |image_3       |invalid image   |          |Invalid image format, allowed formats: PNG, JPG, JPEG       |
+      |caption_3     |121 characters  |          |Ensure this value has at most 120 characters (it has 121).  |
+      |testimonial   |1001 characters |          |Ensure this value has at most 1000 characters (it has 1001).|
+      |source_name   |256 characters  |          |Ensure this value has at most 255 characters (it has 256).  |
+      |source_job    |256 characters  |          |Ensure this value has at most 255 characters (it has 256).  |
+      |source_company|256 characters  |          |Ensure this value has at most 255 characters (it has 256).  |
 
     Then "Peter Alder" should see expected case study error message

--- a/tests/functional/features/fab/case_studies.feature
+++ b/tests/functional/features/fab/case_studies.feature
@@ -17,7 +17,6 @@ Feature: Case Studies
       |description   |1001 characters |          |Ensure this value has at most 1000 characters (it has 1001).                         |
       |description   |empty string    |          |This field is required.                                                              |
       |sector        |invalid sector  |          |Select a valid choice. this is an invalid sector is not one of the available choices.|
-#      |website       |invalid http    |          |Enter a valid URL.                                                                   |
       |website       |256 characters  |          |Enter a valid URL.                                                                   |
       |keywords      |book, keys, food|pipe      |You can only enter letters, numbers and commas.                                      |
       |keywords      |book, keys, food|semi-colon|You can only enter letters, numbers and commas.                                      |
@@ -25,7 +24,7 @@ Feature: Case Studies
       |keywords      |book, keys, food|full stop |You can only enter letters, numbers and commas.                                      |
       |keywords      |empty string    |          |This field is required.                                                              |
       |image_1       |invalid image   |          |Invalid image format, allowed formats: PNG, JPG, JPEG                                |
-#      |image_1       |no image        |          |This field is required.                                                              |
+      |image_1       |no image        |          |This field is required.                                                              |
       |caption_1     |121 characters  |          |Ensure this value has at most 120 characters (it has 121).                           |
       |caption_1     |empty string    |          |This field is required.                                                              |
       |image_2       |invalid image   |          |Invalid image format, allowed formats: PNG, JPG, JPEG                                |
@@ -40,7 +39,7 @@ Feature: Case Studies
     Then "Peter Alder" should see expected case study error message
 
 
-  @ED-2142a
+  @ED-2142
   @fab
   @case-study
   @profile

--- a/tests/functional/features/fas/search.feature
+++ b/tests/functional/features/fas/search.feature
@@ -69,7 +69,6 @@ Feature: Find a Supplier
     And "Peter Alder" created an unverified profile for randomly selected company "Y"
 
     When "Peter Alder" adds a complete case study called "no 1"
-    And "Peter Alder" gets the slug for case study "no 1"
 
     Then "Annette Geissinger" should NOT be able to find company "Y" on FAS by using any part of case study "no 1"
 

--- a/tests/functional/features/fas/search.feature
+++ b/tests/functional/features/fas/search.feature
@@ -49,6 +49,9 @@ Feature: Find a Supplier
     When "Peter Alder" adds a complete case study called "no 1"
     And "Peter Alder" adds a complete case study called "no 2"
     And "Peter Alder" adds a complete case study called "no 3"
+    And "Peter Alder" gets the slug for case study "no 1"
+    And "Peter Alder" gets the slug for case study "no 2"
+    And "Peter Alder" gets the slug for case study "no 3"
 
     Then "Annette Geissinger" should be able to find company "Y" on FAS using any part of case study "no 1"
     And "Annette Geissinger" should be able to find company "Y" on FAS using any part of case study "no 2"
@@ -66,6 +69,7 @@ Feature: Find a Supplier
     And "Peter Alder" created an unverified profile for randomly selected company "Y"
 
     When "Peter Alder" adds a complete case study called "no 1"
+    And "Peter Alder" gets the slug for case study "no 1"
 
     Then "Annette Geissinger" should NOT be able to find company "Y" on FAS by using any part of case study "no 1"
 

--- a/tests/functional/features/pages/fab_ui_case_study_images.py
+++ b/tests/functional/features/pages/fab_ui_case_study_images.py
@@ -49,10 +49,6 @@ def prepare_form_data(token: str, case_study: CaseStudy) -> (dict, dict):
     :param case_study: a CaseStudy namedtuple with random data
     :return: a tuple consisting of form data and files to upload
     """
-    def read_image(file_path: str):
-        with open(file_path, "rb") as f:
-            return f.read()
-
     data = {
         "csrfmiddlewaretoken": token,
         "supplier_case_study_wizard_view-current_step": "rich-media",
@@ -66,8 +62,31 @@ def prepare_form_data(token: str, case_study: CaseStudy) -> (dict, dict):
     }
 
     paths = [case_study.image_1, case_study.image_2, case_study.image_3]
-    name_1, name_2, name_3 = (basename(path) for path in paths)
-    mime_1, mime_2, mime_3 = (MimeTypes().guess_type(path)[0] for path in paths)
+
+    def get_basename(path):
+        if path is not None:
+            res = basename(path)
+        else:
+            res = ""
+        return res
+
+    def get_mimetype(path):
+        if path is not None:
+            res = MimeTypes().guess_type(path)[0]
+        else:
+            res = ""
+        return res
+
+    def read_image(file_path: str):
+        if file_path is not None:
+            with open(file_path, "rb") as f:
+                res = f.read()
+        else:
+            res = ""
+        return res
+
+    name_1, name_2, name_3 = (get_basename(path) for path in paths)
+    mime_1, mime_2, mime_3 = (get_mimetype(path) for path in paths)
     file_1, file_2, file_3 = (read_image(path) for path in paths)
     files = {
         "rich-media-image_one": (name_1, file_1, mime_1),

--- a/tests/functional/features/pages/fab_ui_case_study_images.py
+++ b/tests/functional/features/pages/fab_ui_case_study_images.py
@@ -64,25 +64,16 @@ def prepare_form_data(token: str, case_study: CaseStudy) -> (dict, dict):
     paths = [case_study.image_1, case_study.image_2, case_study.image_3]
 
     def get_basename(path):
-        if path is not None:
-            res = basename(path)
-        else:
-            res = ""
-        return res
+        return basename(path) if path is not None else ""
 
     def get_mimetype(path):
-        if path is not None:
-            res = MimeTypes().guess_type(path)[0]
-        else:
-            res = ""
-        return res
+        return MimeTypes().guess_type(path)[0] if path is not None else ""
 
-    def read_image(file_path: str):
-        if file_path is not None:
-            with open(file_path, "rb") as f:
+    def read_image(path: str):
+        res = ""
+        if path is not None:
+            with open(path, "rb") as f:
                 res = f.read()
-        else:
-            res = ""
         return res
 
     name_1, name_2, name_3 = (get_basename(path) for path in paths)

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -160,7 +160,8 @@ def random_case_study_data(alias: str) -> CaseStudy:
 
 def random_feedback_data(
         *, name: str = None, email: str = None, company_name: str = None,
-        country: str = None, comment: str = None, terms: str = None) -> Feedback:
+        country: str = None, comment: str = None,
+        terms: str = None) -> Feedback:
     name = name or rare_word(min_length=12)
     email = email or ("test+buyer_{}@directory.uktrade.io"
                       .format(rare_word(min_length=15)))
@@ -322,7 +323,8 @@ def get_companies(*, number: int = 100) -> CompaniesList:
     :param number: (optional) expected number of companies to find
     :return: a list of Company named tuples (all with "test" alias)
     """
-    return [find_active_company_without_fas_profile("test") for _ in range(number)]
+    return [find_active_company_without_fas_profile("test") for _ in
+            range(number)]
 
 
 def save_companies(companies: CompaniesList):
@@ -333,7 +335,8 @@ def save_companies(companies: CompaniesList):
     # convert `Company` named tuples into dictionaries
     list_dict = []
     for company in companies:
-        list_dict.append({key: getattr(company, key) for key in company._fields})
+        list_dict.append(
+            {key: getattr(company, key) for key in company._fields})
 
     path = os.path.join(TEST_IMAGES_DIR, 'companies.json')
     with open(path, 'w', encoding='utf8') as f:

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -187,7 +187,7 @@ def random_message_data(
     country = country or rare_word(min_length=12)
     email_address = email_address or ("test+buyer_{}@directory.uktrade.io"
                                       .format(rare_word(min_length=15)))
-    full_name = full_name or sentence(max_words=2)
+    full_name = full_name or sentence(min_words=2, max_words=2)
     sector = sector or random.choice(SECTORS)
     subject = subject or sentence(max_length=200)
     g_recaptcha_response = g_recaptcha_response or "test mode"

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -94,7 +94,9 @@ def extract_and_set_csrf_middleware_token(
     context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
 
 
-def sentence(*, max_length: int = 60, min_word_length: int = 9, max_words: int = 10):
+def sentence(
+        *, max_length: int = 60, min_word_length: int = 9, max_words: int = 10,
+        min_words: int = 3) -> str:
     """Generate a random string consisting of rare english words.
 
     NOTE:
@@ -104,11 +106,13 @@ def sentence(*, max_length: int = 60, min_word_length: int = 9, max_words: int =
     :return: a sentence consisting of rare english words
     """
     words = []
-    while len(words) < max_words:
+    assert min_words <= max_words
+    number_of_words = random.randint(min_words, max_words)
+    while len(words) < number_of_words:
         word = random.choice(RARE_WORDS)
         if len(word) > min_word_length:
             words.append(word)
-    while len(" ".join(words)) > max_length:
+    while 0 < max_length < len(" ".join(words)):
         words.pop()
     return " ".join(words)
 

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -8,6 +8,7 @@ from tests.functional.features.steps.fab_then_impl import (
     fab_no_links_to_online_profiles_are_visible,
     fab_profile_is_verified,
     fab_should_see_all_case_studies,
+    fab_should_see_case_study_error_message,
     fab_should_see_company_details,
     fab_should_see_expected_error_messages,
     fab_should_see_online_profiles,
@@ -315,3 +316,9 @@ def then_should_see_highlighted_search_term(context, actor_alias, search_term):
 @then('"{supplier_alias}" should be told that company has been verified')
 def then_company_should_be_verified(context, supplier_alias):
     fab_company_should_be_verified(context, supplier_alias)
+
+
+@then('"{supplier_alias}" should see expected case study error message')
+def then_supplier_should_see_expected_case_study_error_message(
+        context, supplier_alias):
+    fab_should_see_case_study_error_message(context, supplier_alias)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -418,6 +418,7 @@ def fas_find_supplier_using_case_study_details(
         response = fas_ui_find_supplier.go_to(session, term=term)
         context.response = response
         number_of_pages = get_number_of_search_result_pages(response)
+        found = False
         for page_number in range(1, number_of_pages + 1):
             found = fas_ui_find_supplier.should_see_company(response, company.title)
             if found:

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -725,7 +725,8 @@ def fab_should_see_case_study_error_message(context, supplier_alias):
         context.response = response
         with assertion_msg(
                 "Could not find expected error message: '%s' in the response, "
-                "after submitting the add case study form with following "
-                "details: '%s'", error, case_study):
+                "after submitting the add case study form with '%s' value being"
+                " '%s' following and other details: '%s'", error, field,
+                value_type, case_study):
             assert error in response.content.decode("utf-8")
     logging.debug("%s has seen all expected case study errors", supplier_alias)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -716,3 +716,16 @@ def fas_should_see_highlighted_search_term(context, actor_alias, search_term):
 def fab_company_should_be_verified(context, supplier_alias):
     response = context.response
     fab_ui_verify_company.should_see_company_is_verified(response)
+
+
+def fab_should_see_case_study_error_message(context, supplier_alias):
+    results = context.results
+    logging.debug(results)
+    for field, value_type, case_study, response, error in results:
+        context.response = response
+        with assertion_msg(
+                "Could not find expected error message: '%s' in the response, "
+                "after submitting the add case study form with following "
+                "details: '%s'", error, case_study):
+            assert error in response.content.decode("utf-8")
+    logging.debug("%s has seen all expected case study errors", supplier_alias)

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -6,6 +6,7 @@ from tests.functional.features.steps.fab_when_impl import (
     bp_provide_company_details,
     bp_select_random_sector_and_export_to_country,
     bp_verify_identity_with_letter,
+    fab_attempt_to_add_case_study,
     fab_choose_to_verify_with_code,
     fab_go_to_letter_verification,
     fab_provide_company_details,
@@ -300,3 +301,8 @@ def when_supplier_decides_to_verify_with_address(context, supplier_alias):
 @when('"{supplier_alias}" submits the verification code')
 def when_supplier_submits_verification_code(context, supplier_alias):
     fab_submit_verification_code(context, supplier_alias)
+
+
+@when('"{supplier_alias}" attempts to add a case study using following values')
+def when_supplier_attempts_to_add_case_study(context, supplier_alias):
+    fab_attempt_to_add_case_study(context, supplier_alias, context.table)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1692,8 +1692,11 @@ def fab_attempt_to_add_case_study(
             separator = ","
 
         if field == "keywords":
-            separate_keywords = value_type.split(", ")
-            value = "{} ".format(separator).join(separate_keywords)
+            if value_type == "empty string":
+                value = ""
+            else:
+                separate_keywords = value_type.split(", ")
+                value = "{} ".format(separator).join(separate_keywords)
 
         case_study = case_study._replace(**{field: value})
 

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1637,7 +1637,6 @@ def fab_attempt_to_add_case_study(
         context: Context, supplier_alias: str, table: Table):
     actor = context.get_actor(supplier_alias)
     session = actor.session
-    case_study = random_case_study_data("test")
 
     page_1_fields = [
         "title", "summary", "description", "sector", "website", "keywords"
@@ -1649,6 +1648,7 @@ def fab_attempt_to_add_case_study(
 
     results = []
     for row in table:
+        case_study = random_case_study_data("test")
         field = row["field"]
         value_type = row["value type"]
         separator = row["separator"]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -173,3 +173,11 @@ SEARCHABLE_CASE_STUDY_DETAILS = [
 ]
 
 FAS_LOGO_PLACEHOLDER_IMAGE = "/static/images/placeholder.fc5114289e5b.png"
+
+SEPARATORS = {
+    "pipe": "|",
+    "semi-colon": ";",
+    "colon": ":",
+    "full stop": ".",
+    "comma": ","
+}


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2142) & this [bug ticket](https://uktrade.atlassian.net/browse/ED-2248)

Scenario:
```gherkin

  @ED-2142
  @fab
  @case-study
  @profile
  Scenario: Supplier should not be able to use invalid values when adding a case study
    Given "Peter Alder" created an unverified profile for randomly selected company "Y"

    When "Peter Alder" attempts to add a case study using following values
      |field         |value type      |separator |error                                                                                |
      |title         |61 characters   |          |Ensure this value has at most 60 characters (it has 61).                             |
      |title         |empty string    |          |This field is required.                                                              |
      |summary       |201 characters  |          |Ensure this value has at most 200 characters (it has 201).                           |
      |summary       |empty string    |          |This field is required.                                                              |
      |description   |1001 characters |          |Ensure this value has at most 1000 characters (it has 1001).                         |
      |description   |empty string    |          |This field is required.                                                              |
      |sector        |invalid sector  |          |Select a valid choice. this is an invalid sector is not one of the available choices.|
      |website       |256 characters  |          |Enter a valid URL.                                                                   |
      |keywords      |book, keys, food|pipe      |You can only enter letters, numbers and commas.                                      |
      |keywords      |book, keys, food|semi-colon|You can only enter letters, numbers and commas.                                      |
      |keywords      |book, keys, food|colon     |You can only enter letters, numbers and commas.                                      |
      |keywords      |book, keys, food|full stop |You can only enter letters, numbers and commas.                                      |
      |keywords      |empty string    |          |This field is required.                                                              |
      |image_1       |invalid image   |          |Invalid image format, allowed formats: PNG, JPG, JPEG                                |
      |image_1       |no image        |          |This field is required.                                                              |
      |caption_1     |121 characters  |          |Ensure this value has at most 120 characters (it has 121).                           |
      |caption_1     |empty string    |          |This field is required.                                                              |
      |image_2       |invalid image   |          |Invalid image format, allowed formats: PNG, JPG, JPEG                                |
      |caption_2     |121 characters  |          |Ensure this value has at most 120 characters (it has 121).                           |
      |image_3       |invalid image   |          |Invalid image format, allowed formats: PNG, JPG, JPEG                                |
      |caption_3     |121 characters  |          |Ensure this value has at most 120 characters (it has 121).                           |
      |testimonial   |1001 characters |          |Ensure this value has at most 1000 characters (it has 1001).                         |
      |source_name   |256 characters  |          |Ensure this value has at most 255 characters (it has 256).                           |
      |source_job    |256 characters  |          |Ensure this value has at most 255 characters (it has 256).                           |
      |source_company|256 characters  |          |Ensure this value has at most 255 characters (it has 256).                           |

    Then "Peter Alder" should see expected case study error message


  @ED-2142
  @fab
  @case-study
  @profile
  @bug
  @ED-2248
  @fixme
  Scenario: Supplier should not be able to use invalid values when adding a case study
    Given "Peter Alder" created an unverified profile for randomly selected company "Y"

    When "Peter Alder" attempts to add a case study using following values
      |field         |value type      |separator |error             |
      |website       |invalid http    |          |Enter a valid URL.|
      |website       |invalid https   |          |Enter a valid URL.|

    Then "Peter Alder" should see expected case study error message
```
