### PR TITLE
ED-2145 can't register with the same email address

### DIFF
--- a/tests/functional/features/sso/profile.feature
+++ b/tests/functional/features/sso/profile.feature
@@ -24,3 +24,21 @@ Feature: SSO profile
 
       Then "Peter Alder" should be on Welcome to your great.gov.uk profile page
       And "Peter Alder" should be signed in to SSO/great.gov.uk account
+
+
+    @ED-2145
+    @sso
+    @account
+    Scenario: Suppliers should not be able to register with the same email again
+      # No error should be displayed when Supplier attempts to register with an
+      # existing email address (intended behaviour) yet no verification email
+      # should be sent. Moreover there's no point in checking in DB whether
+      # there's only 1 account with the same email address as there's `unique`
+      # constraint configured on the `email` column.
+      Given "Peter Alder" is an unauthenticated supplier
+
+      When "Peter Alder" creates a SSO/great.gov.uk account
+      Then "Peter Alder" should be told about the verification email
+
+      When "Peter Alder" creates a SSO/great.gov.uk account
+      Then "Peter Alder" should be told about the verification email


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2145)

Scenario:
```gherkin
    @ED-2145
    @sso
    @account
    Scenario: Suppliers should not be able to register with the same email again
      # No error should be displayed when Supplier attempts to register with an
      # existing email address (intended behaviour) yet no verification email
      # should be sent. Moreover there's no point in checking in DB whether
      # there's only 1 account with the same email address as there's `unique`
      # constraint configured on the `email` column.
      Given "Peter Alder" is an unauthenticated supplier

      When "Peter Alder" creates a SSO/great.gov.uk account
      Then "Peter Alder" should be told about the verification email

      When "Peter Alder" creates a SSO/great.gov.uk account
      Then "Peter Alder" should be told about the verification email
```
