### PR TITLE
ED-2146 reset password for users with just SSO account

### DIFF
--- a/tests/functional/features/context_utils.py
+++ b/tests/functional/features/context_utils.py
@@ -128,16 +128,6 @@ def set_actor_email_confirmation_link(self, alias, link):
         logging.debug("Could not find an actor aliased '%s'", alias)
 
 
-def set_actor_has_sso_account(self, alias, has_sso_account: bool):
-    if alias in self.scenario_data.actors:
-        actors = self.scenario_data.actors
-        actors[alias] = actors[alias]._replace(has_sso_account=has_sso_account)
-        logging.debug("Successfully set has_sso_account=%s for "
-                      "Actor: %s", has_sso_account, alias)
-    else:
-        logging.debug("Could not find an actor aliased '%s'", alias)
-
-
 def update_actor(
         self, alias, *, password_reset_link: str = None,
         company_alias: str = None, has_sso_account: bool = None,
@@ -302,8 +292,6 @@ def patch_context(context):
         set_actor_csrfmiddlewaretoken, context)
     context.set_actor_email_confirmation_link = MethodType(
         set_actor_email_confirmation_link, context)
-    context.set_actor_has_sso_account = MethodType(
-        set_actor_has_sso_account, context)
     context.add_company = MethodType(add_company, context)
     context.get_company = MethodType(get_company, context)
     context.add_case_study = MethodType(add_case_study, context)

--- a/tests/functional/features/context_utils.py
+++ b/tests/functional/features/context_utils.py
@@ -138,15 +138,24 @@ def set_actor_has_sso_account(self, alias, has_sso_account: bool):
         logging.debug("Could not find an actor aliased '%s'", alias)
 
 
-def set_company_for_actor(self, actor_alias, company_alias):
-    if actor_alias in self.scenario_data.actors:
-        actors = self.scenario_data.actors
-        actors[actor_alias] = actors[actor_alias]._replace(
-            company_alias=company_alias)
-        logging.debug("Successfully set company_alias=%s for "
-                      "Actor: %s", company_alias, actor_alias)
-    else:
-        logging.debug("Could not find an actor aliased '%s'", actor_alias)
+def update_actor(
+        self, alias, *, password_reset_link: str = None,
+        company_alias: str = None, has_sso_account: bool = None,
+        email_confirmation_link: str = None, csrfmiddlewaretoken: str = None):
+    actors = self.scenario_data.actors
+    if password_reset_link:
+        actors[alias] = actors[alias]._replace(password_reset_link=password_reset_link)
+    if company_alias:
+        actors[alias] = actors[alias]._replace(company_alias=company_alias)
+    if has_sso_account:
+        actors[alias] = actors[alias]._replace(has_sso_account=has_sso_account)
+    if email_confirmation_link:
+        actors[alias] = actors[alias]._replace(email_confirmation_link=email_confirmation_link)
+    if csrfmiddlewaretoken:
+        actors[alias] = actors[alias]._replace(csrfmiddlewaretoken=csrfmiddlewaretoken)
+
+    logging.debug(
+        "Successfully updated Actors's details %s: %s", alias, actors[alias])
 
 
 def set_company_logo_detail(self, alias, *, picture=None, url=None, hash=None):
@@ -287,6 +296,7 @@ def patch_context(context):
     """
     context.add_actor = MethodType(add_actor, context)
     context.get_actor = MethodType(get_actor, context)
+    context.update_actor = MethodType(update_actor, context)
     context.reset_actor_session = MethodType(reset_actor_session, context)
     context.set_actor_csrfmiddlewaretoken = MethodType(
         set_actor_csrfmiddlewaretoken, context)
@@ -294,7 +304,6 @@ def patch_context(context):
         set_actor_email_confirmation_link, context)
     context.set_actor_has_sso_account = MethodType(
         set_actor_has_sso_account, context)
-    context.set_company_for_actor = MethodType(set_company_for_actor, context)
     context.add_company = MethodType(add_company, context)
     context.get_company = MethodType(get_company, context)
     context.add_case_study = MethodType(add_case_study, context)

--- a/tests/functional/features/context_utils.py
+++ b/tests/functional/features/context_utils.py
@@ -17,7 +17,8 @@ Actor = namedtuple(
     'Actor',
     [
         'alias', 'email', 'password', 'session', 'csrfmiddlewaretoken',
-        'email_confirmation_link', 'company_alias', 'has_sso_account', 'type'
+        'email_confirmation_link', 'company_alias', 'has_sso_account', 'type',
+        'password_reset_link'
     ]
 )
 CaseStudy = namedtuple(

--- a/tests/functional/features/context_utils.py
+++ b/tests/functional/features/context_utils.py
@@ -118,16 +118,6 @@ def set_actor_csrfmiddlewaretoken(self, alias, token):
         logging.debug("Could not find an actor aliased '%s'", alias)
 
 
-def set_actor_email_confirmation_link(self, alias, link):
-    if alias in self.scenario_data.actors:
-        actors = self.scenario_data.actors
-        actors[alias] = actors[alias]._replace(email_confirmation_link=link)
-        logging.debug("Successfully set email_confirmation_link=%s for "
-                      "Actor: %s", link, alias)
-    else:
-        logging.debug("Could not find an actor aliased '%s'", alias)
-
-
 def update_actor(
         self, alias, *, password_reset_link: str = None,
         company_alias: str = None, has_sso_account: bool = None,
@@ -290,8 +280,6 @@ def patch_context(context):
     context.reset_actor_session = MethodType(reset_actor_session, context)
     context.set_actor_csrfmiddlewaretoken = MethodType(
         set_actor_csrfmiddlewaretoken, context)
-    context.set_actor_email_confirmation_link = MethodType(
-        set_actor_email_confirmation_link, context)
     context.add_company = MethodType(add_company, context)
     context.get_company = MethodType(get_company, context)
     context.add_case_study = MethodType(add_case_study, context)

--- a/tests/functional/features/context_utils.py
+++ b/tests/functional/features/context_utils.py
@@ -108,16 +108,6 @@ def get_actor(self, alias):
     return self.scenario_data.actors.get(alias)
 
 
-def set_actor_csrfmiddlewaretoken(self, alias, token):
-    if alias in self.scenario_data.actors:
-        actors = self.scenario_data.actors
-        actors[alias] = actors[alias]._replace(csrfmiddlewaretoken=token)
-        logging.debug("Successfully set csrfmiddlewaretoken=%s for Actor: "
-                      "%s", token, alias)
-    else:
-        logging.debug("Could not find an actor aliased '%s'", alias)
-
-
 def update_actor(
         self, alias, *, password_reset_link: str = None,
         company_alias: str = None, has_sso_account: bool = None,
@@ -278,8 +268,6 @@ def patch_context(context):
     context.get_actor = MethodType(get_actor, context)
     context.update_actor = MethodType(update_actor, context)
     context.reset_actor_session = MethodType(reset_actor_session, context)
-    context.set_actor_csrfmiddlewaretoken = MethodType(
-        set_actor_csrfmiddlewaretoken, context)
     context.add_company = MethodType(add_company, context)
     context.get_company = MethodType(get_company, context)
     context.add_case_study = MethodType(add_case_study, context)

--- a/tests/functional/features/fas/languages.feature
+++ b/tests/functional/features/fas/languages.feature
@@ -11,7 +11,7 @@ Feature: View FAS in various languages
 
     When "Annette Geissinger" chooses to view specific FAS page in "<selected>" language
       | page                            |
-      | Landing                         |
+      | FAS Landing                     |
       | Industries                      |
       | Health Industry                 |
       | Tech Industry                   |
@@ -24,7 +24,7 @@ Feature: View FAS in various languages
 
     Then the "main" part of the viewed FAS page should be presented in "<expected>" language with probability greater than "0.98"
       | page                            |
-      | Landing                         |
+      | FAS Landing                     |
       | Industries                      |
       | Health Industry                 |
       | Tech Industry                   |

--- a/tests/functional/features/pages/profile_ui_landing.py
+++ b/tests/functional/features/pages/profile_ui_landing.py
@@ -2,7 +2,7 @@
 """SSO - Verify your email page"""
 from requests import Response
 
-from tests.functional.features.utils import check_response
+from tests.functional.features.utils import assertion_msg, check_response
 
 EXPECTED_STRINGS = [
     "Welcome to your great.gov.uk profile",
@@ -29,3 +29,18 @@ def should_be_here(response: Response):
     :param response: response object
     """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
+
+
+def should_be_logged_out(response: Response):
+    """Check if Supplier is logged out by checking the cookies.
+
+    :param response: response object
+    """
+    with assertion_msg(
+            "Found sso_display_logged_in cookie in the response. Maybe user is "
+            "still logged in?"):
+        assert "sso_display_logged_in" not in response.cookies
+    with assertion_msg(
+            "Found directory_sso_dev_session cookie in the response. Maybe user"
+            " is still logged in?"):
+        assert "directory_sso_dev_session" not in response.cookies

--- a/tests/functional/features/pages/sso_ui_logout.py
+++ b/tests/functional/features/pages/sso_ui_logout.py
@@ -13,14 +13,15 @@ EXPECTED_STRINGS = [
 ]
 
 
-def go_to(session: Session) -> Response:
+def go_to(session: Session, *, next_param: str = None) -> Response:
     """Go to the SSO Logout page.
 
     :param session: Supplier session object
+    :param next_param: (optional) URL to redirect to after successful login
     :return: response object
     """
     fab_landing = get_absolute_url("ui-buyer:landing")
-    params = {"next": fab_landing}
+    params = {"next": next_param or fab_landing}
     headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
     response = make_request(
         Method.GET, URL, session=session, params=params, headers=headers)
@@ -36,17 +37,18 @@ def should_be_here(response: Response):
     logging.debug("Successfully got to the SSO logout page")
 
 
-def logout(session: Session, token: str) -> Response:
+def logout(session: Session, token: str, *, next_param: str = None) -> Response:
     """Sign out from SSO/FAB.
 
     :param session: Supplier session object
     :param token: CSRF token required to submit the login form
+    :param next_param: (optional) URL to redirect to after logging out
     :return: response object
     """
     fab_landing = get_absolute_url("ui-buyer:landing")
     data = {
         "csrfmiddlewaretoken": token,
-        "next": fab_landing
+        "next": next_param or fab_landing
     }
     headers = {"Referer": "{}/?next={}".format(URL, fab_landing)}
     response = make_request(

--- a/tests/functional/features/pages/sso_ui_password_reset.py
+++ b/tests/functional/features/pages/sso_ui_password_reset.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""SSO - Verify your email page"""
+import logging
+
+from requests import Response, Session
+
+from tests import get_absolute_url
+from tests.functional.features.context_utils import Actor
+from tests.functional.features.utils import Method, check_response, make_request
+
+URL = get_absolute_url("sso:password_reset")
+EXPECTED_STRINGS = [
+    "Password reset",
+    "Enter the email address you used to register to get a password reset link",
+    "E-mail:", "Reset my password",
+    "Please", "contact us", "if you have any trouble resetting your password."
+]
+
+EXPECTED_STRINGS_PASSWORD_RESET = [
+    "Password reset",
+    ("We will send a password reset link by email if there is an account "
+     "registered for this address. Please"),
+    "contact us", "if you do not receive it within a few minutes."
+]
+
+
+def go_to(session: Session, *, next_param: str = None) -> Response:
+    fab_landing = get_absolute_url("ui-buyer:landing")
+    params = {"next": next_param or fab_landing}
+    headers = {"Referer": fab_landing}
+    response = make_request(
+        Method.GET, URL, session=session, params=params, headers=headers)
+    return response
+
+
+def should_be_here(response: Response):
+    """Check if Supplier is on SSO Password Reset Page.
+
+    :param response: response object
+    """
+    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+    logging.debug("Successfully got to the SSO Password Reset page")
+
+
+def should_see_that_password_was_reset(response: Response):
+    """Check if Supplier is on SSO Password Reset confirmation Page.
+
+    :param response: response object
+    """
+    check_response(response, 200, body_contains=EXPECTED_STRINGS_PASSWORD_RESET)
+    logging.debug("Successfully Reset Password")
+
+
+def reset(
+        actor: Actor, token: str, *, referer: str = None,
+        next_param: str = None) -> Response:
+    """Try to reset the password to the SSO account.
+
+    :param actor: a namedtuple with Actor details
+    :param token: CSRF token required to submit the password reset form
+    :param referer: (optional) referer URL
+    :param next_param: (optional) URL to go to after successful password reset
+    :return: response object
+    """
+    session = actor.session
+    fab_landing = get_absolute_url("ui-buyer:landing")
+
+    data = {
+        "next": next_param or fab_landing,
+        "csrfmiddlewaretoken": token,
+        "email": actor.email
+    }
+    # Referer is the same as the final URL from the previous request
+    referer = referer or "{}?next={}".format(URL, next_param or fab_landing)
+    headers = {"Referer": referer}
+
+    response = make_request(
+        Method.POST, URL, session=session, data=data, headers=headers)
+
+    return response

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -483,6 +483,17 @@ def get_fas_page_url(page_name: str, *, language_code: str = None):
     return url
 
 
+def get_fabs_page_url(page_name: str, *, language_code: str = None):
+    selectors = {}
+    selectors.update(FAB_PAGE_SELECTORS)
+    selectors.update(FAS_PAGE_SELECTORS)
+    selectors.update(SSO_PAGE_SELECTORS)
+    url = get_absolute_url(selectors[page_name.lower()])
+    if language_code:
+        url += "?lang={}".format(language_code)
+    return url
+
+
 def extract_main_error(content: str) -> str:
     """Extract error from page `main` block.
 

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -125,7 +125,7 @@ def extract_and_set_csrf_middleware_token(
     :param response: request with HTML content containing CSRF middleware token
     """
     token = extract_csrf_middleware_token(response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
 
 def sentence(

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -80,6 +80,40 @@ FAS_PAGE_SELECTORS = {
     'terms-and-conditions': 'ui-supplier:terms',
     'privacy-policy': 'ui-supplier:privacy',
 }
+SSO_PAGE_SELECTORS = {
+    "sso landing": 'sso:landing',
+    "login": 'sso:login',
+    "register": 'sso:signup',
+    "logout": 'sso:logout',
+    "password change": 'sso:password_change',
+    "password set": 'sso:password_set',
+    "password reset": 'sso:password_reset',
+    "confirm email": 'sso:email_confirm',
+    "inactive": 'sso:inactive',
+    "health": 'sso:health',
+    "session user": 'sso:user'
+}
+FAB_PAGE_SELECTORS = {
+    "fab landing": "ui-buyer:landing",
+    "fab register": "ui-buyer:register",
+    "confirm company selection": "ui-buyer:register-confirm-company",
+    "confirm export status": "ui-buyer:register-confirm-export-status",
+    "finish registration": "ui-buyer:register-finish",
+    "submit account details": "ui-buyer:register-submit-account-details",
+    "upload logo": "ui-buyer:upload-logo",
+    "add case study": "ui-buyer:case-study-add",
+    "company company address": "ui-buyer:confirm-company-address",
+    "company identity": "ui-buyer:confirm-identity",
+    "company identity via letter": "ui-buyer:confirm-identity-letter",
+    "fab company profile": "ui-buyer:company-profile",
+    "edit company profile": "ui-buyer:company-edit",
+    "edit company address": "ui-buyer:company-edit-address",
+    "edit company description": "ui-buyer:company-edit-description",
+    "edit company key facts": "ui-buyer:company-edit-key-facts",
+    "edit company sectors": "ui-buyer:company-edit-sectors",
+    "edit company contact": "ui-buyer:company-edit-contact",
+    "edit social media links": "ui-buyer:company-edit-social-media",
+}
 
 
 def extract_and_set_csrf_middleware_token(

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -66,7 +66,7 @@ FAS_SUPPORTED_LANGUAGES = {
     "spanish": "es"
 }
 FAS_PAGE_SELECTORS = {
-    "landing": "ui-supplier:landing",
+    "fas landing": "ui-supplier:landing",
     'industries': 'ui-supplier:industries',
     'search': 'ui-supplier:search',
     'health industry': 'ui-supplier:industries-health',

--- a/tests/functional/features/sso/password.feature
+++ b/tests/functional/features/sso/password.feature
@@ -1,0 +1,16 @@
+Feature: SSO profile
+
+
+    @ED-2146
+    @sso
+    @account
+    @manage
+    @password
+    Scenario: Suppliers without FAB profile should be able to reset password
+      Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
+      And "Peter Alder" is signed out from SSO/great.gov.uk account
+
+      When "Peter Alder" resets the password
+
+      Then "Peter Alder" should be told that password was reset
+      And "Peter Alder" should receive a password reset email

--- a/tests/functional/features/steps/fab_given_def.py
+++ b/tests/functional/features/steps/fab_given_def.py
@@ -23,7 +23,8 @@ from tests.functional.features.steps.fab_then_impl import (
     fas_should_see_png_logo_thumbnail,
     prof_should_see_logo_picture,
     reg_should_get_verification_email,
-    sso_should_be_signed_in_to_sso_account
+    sso_should_be_signed_in_to_sso_account,
+    sso_should_be_signed_out_from_sso_account
 )
 from tests.functional.features.steps.fab_when_impl import (
     fas_view_page,
@@ -98,6 +99,11 @@ def given_verified_standalone_sso_account(context, supplier_alias):
 @given('"{supplier_alias}" is signed in to SSO/great.gov.uk account')
 def given_supplier_is_signed_in_to_sso(context, supplier_alias):
     sso_should_be_signed_in_to_sso_account(context, supplier_alias)
+
+
+@given('"{supplier_alias}" is signed out from SSO/great.gov.uk account')
+def given_supplier_is_signed_out_from_sso(context, supplier_alias):
+    sso_should_be_signed_out_from_sso_account(context, supplier_alias)
 
 
 @given('"{supplier_alias}" selected an active company without a Directory '

--- a/tests/functional/features/steps/fab_given_impl.py
+++ b/tests/functional/features/steps/fab_given_impl.py
@@ -103,7 +103,7 @@ def reg_create_sso_account_associated_with_company(
     reg_confirm_export_status(context, supplier_alias, exported=True)
     reg_create_sso_account(context, supplier_alias, company_alias)
     reg_sso_account_should_be_created(context.response, supplier_alias)
-    context.set_actor_has_sso_account(supplier_alias, True)
+    context.update_actor(supplier_alias, has_sso_account=True)
 
 
 def reg_confirm_email_address(context: Context, supplier_alias: str):

--- a/tests/functional/features/steps/fab_given_impl.py
+++ b/tests/functional/features/steps/fab_given_impl.py
@@ -226,7 +226,7 @@ def fab_find_published_company(
         twitter=company_dict['twitter_url'],
         linkedin=company_dict['linkedin_url']
     )
-    context.set_company_for_actor(actor_alias, company_alias)
+    context.update_actor(actor_alias, company_alias=company_alias)
     context.add_company(company)
     logging.debug("%s found a published company: %s", actor_alias, company)
 

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -42,7 +42,8 @@ from tests.functional.features.steps.fab_then_impl import (
     reg_sso_account_should_be_created,
     reg_supplier_has_to_verify_email_first,
     reg_supplier_is_not_appropriate_for_fab,
-    sso_should_be_signed_in_to_sso_account
+    sso_should_be_signed_in_to_sso_account,
+    sso_should_be_told_about_password_reset,
 )
 from tests.functional.features.steps.fab_when_impl import (
     fas_feedback_request_should_be_submitted,
@@ -322,3 +323,8 @@ def then_company_should_be_verified(context, supplier_alias):
 def then_supplier_should_see_expected_case_study_error_message(
         context, supplier_alias):
     fab_should_see_case_study_error_message(context, supplier_alias)
+
+
+@then('"{supplier_alias}" should be told that password was reset')
+def then_should_be_told_that_password_was_reset(context, supplier_alias):
+    sso_should_be_told_about_password_reset(context, supplier_alias)

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -44,6 +44,7 @@ from tests.functional.features.steps.fab_then_impl import (
     reg_supplier_is_not_appropriate_for_fab,
     sso_should_be_signed_in_to_sso_account,
     sso_should_be_told_about_password_reset,
+    sso_should_get_password_reset_email
 )
 from tests.functional.features.steps.fab_when_impl import (
     fas_feedback_request_should_be_submitted,
@@ -328,3 +329,8 @@ def then_supplier_should_see_expected_case_study_error_message(
 @then('"{supplier_alias}" should be told that password was reset')
 def then_should_be_told_that_password_was_reset(context, supplier_alias):
     sso_should_be_told_about_password_reset(context, supplier_alias)
+
+
+@then('"{supplier_alias}" should receive a password reset email')
+def then_supplier_should_receive_password_reset_email(context, supplier_alias):
+    sso_should_get_password_reset_email(context, supplier_alias)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -22,6 +22,7 @@ from tests.functional.features.pages import (
     fas_ui_profile,
     profile_ui_landing,
     sso_ui_logout,
+    sso_ui_password_reset,
     sso_ui_verify_your_email
 )
 from tests.functional.features.pages.common import FAS_PAGE_OBJECTS
@@ -763,3 +764,9 @@ def fab_should_see_case_study_error_message(context, supplier_alias):
                 value_type, case_study):
             assert error in response.content.decode("utf-8")
     logging.debug("%s has seen all expected case study errors", supplier_alias)
+
+
+def sso_should_be_told_about_password_reset(
+        context: Context, supplier_alias: str):
+    sso_ui_password_reset.should_see_that_password_was_reset(context.response)
+    logging.debug("%s was told that the password was reset", supplier_alias)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -82,7 +82,7 @@ def bp_should_be_prompted_to_build_your_profile(
     logging.debug(
         "%s is on the 'Build and improve your profile' page", supplier_alias)
     token = extract_csrf_middleware_token(context.response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
 
 def prof_should_be_on_profile_page(response: Response, supplier_alias: str):
@@ -160,7 +160,7 @@ def sso_should_be_signed_out_from_sso_account(
     # Step 2 - check if Supplier is on Log Out page & extract CSRF token
     sso_ui_logout.should_be_here(response)
     token = extract_csrf_middleware_token(response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
     # Step 3 - log out
     next_param = get_absolute_url("profile:landing")

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -39,6 +39,7 @@ from tests.functional.features.utils import (
     extract_csrf_middleware_token,
     extract_logo_url,
     find_mailgun_events,
+    get_password_reset_link,
     get_verification_link,
     surround
 )
@@ -770,3 +771,15 @@ def sso_should_be_told_about_password_reset(
         context: Context, supplier_alias: str):
     sso_ui_password_reset.should_see_that_password_was_reset(context.response)
     logging.debug("%s was told that the password was reset", supplier_alias)
+
+
+def sso_should_get_password_reset_email(context: Context, supplier_alias: str):
+    """Will check if the Supplier received an email verification message.
+
+    :param context: behave `context` object
+    :param supplier_alias: alias of the Actor used in the scope of the scenario
+    """
+    logging.debug("Searching for a password reset email...")
+    actor = context.get_actor(supplier_alias)
+    link = get_password_reset_link(context, actor.email)
+    context.update_actor(supplier_alias, password_reset_link=link)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -73,7 +73,7 @@ def reg_should_get_verification_email(context: Context, alias: str):
     logging.debug("Searching for an email verification message...")
     actor = context.get_actor(alias)
     link = get_verification_link(context, actor.email)
-    context.set_actor_email_confirmation_link(alias, link)
+    context.update_actor(alias, email_confirmation_link=link)
 
 
 def bp_should_be_prompted_to_build_your_profile(

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -65,9 +65,6 @@ def reg_sso_account_should_be_created(response: Response, supplier_alias: str):
 def reg_should_get_verification_email(context: Context, alias: str):
     """Will check if the Supplier received an email verification message.
 
-    NOTE:
-    The check is done by attempting to find a file with the email is Amazon S3.
-
     :param context: behave `context` object
     :param alias: alias of the Actor used in the scope of the scenario
     """

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -46,6 +46,7 @@ from tests.functional.features.steps.fab_when_impl import (
     reg_supplier_confirms_email_address,
     select_random_company,
     sso_go_to_create_trade_profile,
+    sso_reset_password,
     sso_supplier_confirms_email_address
 )
 

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -306,3 +306,8 @@ def when_supplier_submits_verification_code(context, supplier_alias):
 @when('"{supplier_alias}" attempts to add a case study using following values')
 def when_supplier_attempts_to_add_case_study(context, supplier_alias):
     fab_attempt_to_add_case_study(context, supplier_alias, context.table)
+
+
+@when('"{supplier_alias}" resets the password')
+def when_supplier_resets_password(context, supplier_alias):
+    sso_reset_password(context, supplier_alias)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -132,7 +132,7 @@ def select_random_company(
     context.add_company(company)
     token = extract_csrf_middleware_token(response)
     context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
-    context.set_company_for_actor(supplier_alias, company_alias)
+    context.update_actor(supplier_alias, company_alias=company_alias)
 
 
 def reg_confirm_company_selection(

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -133,7 +133,7 @@ def select_random_company(
     # Step 4 - store Company, CSRF token & associate Actor with Company
     context.add_company(company)
     token = extract_csrf_middleware_token(response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
     context.update_actor(supplier_alias, company_alias=company_alias)
 
 
@@ -165,7 +165,7 @@ def reg_confirm_company_selection(
 
     # Step 3 - extract & store CSRF token
     token = extract_csrf_middleware_token(response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
 
 def reg_supplier_is_not_ready_to_export(context, supplier_alias):
@@ -213,7 +213,7 @@ def reg_confirm_export_status(
         logging.debug("Supplier doesn't have a SSO account")
         sso_ui_register.should_be_here(response)
         token = extract_csrf_middleware_token(response)
-        context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+        context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
 
 def reg_create_sso_account(context, supplier_alias, alias):
@@ -262,7 +262,7 @@ def reg_open_email_confirmation_link(context, supplier_alias):
     # Step 4 - extract & store CSRF token & form action value
     # Form Action Value is required to successfully confirm email
     token = extract_csrf_middleware_token(response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
     form_action_value = extract_confirm_email_form_action(response)
     context.form_action_value = form_action_value
 
@@ -318,7 +318,7 @@ def bp_provide_company_details(context, supplier_alias):
     # Step 3 - extract CSRF token
     logging.debug("Supplier is on the Select Sector page")
     token = extract_csrf_middleware_token(response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
 
 def bp_select_random_sector_and_export_to_country(context, supplier_alias):
@@ -368,7 +368,7 @@ def bp_verify_identity_with_letter(context: Context, supplier_alias: str):
 
     # Step 3 - extract & store CSRF token
     token = extract_csrf_middleware_token(response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
     # Step 4 - check if Supplier is on the We've sent you a verification letter
     fab_ui_confirm_identity_letter.submit(actor)
@@ -405,7 +405,7 @@ def prof_set_company_description(context, supplier_alias):
     response = fab_ui_edit_description.go_to(session)
 
     token = extract_csrf_middleware_token(response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
     logging.debug("Supplier is on the Set Company Description page")
 
     # Step 2 - Submit company description
@@ -446,7 +446,7 @@ def prof_verify_company(context, supplier_alias):
 
     # STEP 2 - extract CSRF token
     token = extract_csrf_middleware_token(response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
     # STEP 3 - Submit the verification code
     response = fab_ui_verify_company.submit(session, token, verification_code)
@@ -504,7 +504,7 @@ def prof_attempt_to_sign_in_to_fab(context, supplier_alias):
             "sso_display_logged_in cookie is not equal to False"):
         assert response.cookies.get("sso_display_logged_in") == "false"
     token = extract_csrf_middleware_token(response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
     # Step 3 - submit the login form
     response = sso_ui_login.login(actor, token)
@@ -529,7 +529,7 @@ def prof_sign_out_from_fab(context, supplier_alias):
     # Step 2 - check if Supplier is on Log Out page & extract CSRF token
     sso_ui_logout.should_be_here(response)
     token = extract_csrf_middleware_token(response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
     # Step 3 - log out
     response = sso_ui_logout.logout(session, token)
@@ -567,7 +567,7 @@ def prof_sign_in_to_fab(context, supplier_alias):
 
     # Step 3 - extract CSRF token
     token = extract_csrf_middleware_token(response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
     # Step 4 - submit the login form
     response = sso_ui_login.login(actor, token)
@@ -754,7 +754,7 @@ def prof_supplier_uploads_logo(context, supplier_alias, picture):
 
     # Step 2 - extract CSRF token
     token = extract_csrf_middleware_token(response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
     # Step 3 - upload the logo
     prof_upload_logo(context, supplier_alias, picture)
@@ -815,7 +815,7 @@ def prof_update_company_details(
 
     # Step 2 - extract CSRF token
     token = extract_csrf_middleware_token(response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
     # Step 3 - Update company's details
     response, new_details = fab_ui_edit_details.update_details(
@@ -832,7 +832,7 @@ def prof_update_company_details(
 
     # Step 5 - extract CSRF token
     token = extract_csrf_middleware_token(response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
     # Step 6 - Update company's sector
     response, new_sector, new_countries = fab_ui_edit_sector.update(
@@ -1596,7 +1596,7 @@ def fab_go_to_letter_verification(
         sso_ui_login.should_be_here(response)
 
         token = extract_csrf_middleware_token(response)
-        context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+        context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
         sso_login_url = get_absolute_url("sso:login")
         fab_verify_url = quote(get_absolute_url("ui-buyer:confirm-identity"))
@@ -1737,7 +1737,7 @@ def sso_reset_password(
     sso_ui_password_reset.should_be_here(response)
 
     token = extract_csrf_middleware_token(response)
-    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
     response = sso_ui_password_reset.reset(actor, token, next_param=next_param)
     context.response = response

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -639,7 +639,7 @@ def sso_supplier_confirms_email_address(context, supplier_alias):
     profile_ui_landing.should_be_here(response)
 
     # STEP 3 - Update Actor's data
-    context.set_actor_has_sso_account(supplier_alias, True)
+    context.update_actor(supplier_alias, has_sso_account=True)
 
 
 def sso_go_to_create_trade_profile(context, supplier_alias):

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -40,6 +40,7 @@ from tests.functional.features.pages import (
     sso_ui_confim_your_email,
     sso_ui_login,
     sso_ui_logout,
+    sso_ui_password_reset,
     sso_ui_register,
     sso_ui_verify_your_email
 )
@@ -52,6 +53,7 @@ from tests.functional.features.pages.utils import (
     escape_html,
     extract_and_set_csrf_middleware_token,
     get_active_company_without_fas_profile,
+    get_fabs_page_url,
     get_fas_page_url,
     get_language_code,
     get_number_of_search_result_pages,
@@ -1720,3 +1722,22 @@ def fab_attempt_to_add_case_study(
         results.append((field, value_type, case_study, response, error))
 
     context.results = results
+
+
+def sso_reset_password(
+        context: Context, supplier_alias: str, *, next_page: str = None):
+    actor = context.get_actor(supplier_alias)
+    next_param = None
+    if next_page is not None:
+        next_param = get_fabs_page_url(page_name=next_page)
+
+    response = sso_ui_password_reset.go_to(actor.session, next_param=next_param)
+    context.response = response
+
+    sso_ui_password_reset.should_be_here(response)
+
+    token = extract_csrf_middleware_token(response)
+    context.set_actor_csrfmiddlewaretoken(supplier_alias, token)
+
+    response = sso_ui_password_reset.reset(actor, token, next_param=next_param)
+    context.response = response

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -260,6 +260,9 @@ def log_response(response: Response, *, trim: bool = True):
     request = response.request
     trim_offset = 1024  # define the length of logged response content
 
+    logging.debug(
+        "RESPONSE TIME | %s | %s %s", str(response.elapsed), request.method,
+        request.url)
     if response.history:
         logging.debug("REQ was redirected")
         for r in response.history:

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -480,6 +480,23 @@ def extract_email_confirmation_link(payload):
     return activation_link
 
 
+def extract_password_reset_link(payload: str) -> str:
+    """Find password reset link inside the plain text email payload.
+
+    :param payload: plain text email message payload
+    :return: password reset link
+    """
+    start = payload.find("http")
+    end = payload.find("\n", start) - 1  # `- 1` to skip the newline char
+    password_reset_link = payload[start:end]
+    with assertion_msg(
+            "Extracted link is not a correct password reset link: %s",
+            password_reset_link):
+        assert "accounts/password/reset/key/" in password_reset_link
+    logging.debug("Found password reset link: %s", password_reset_link)
+    return password_reset_link
+
+
 def check_response(response: Response, status_code: int, *,
                    location: str = None, locations: list = None,
                    location_starts_with: str = None, body_contains: list = None,

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -640,7 +640,8 @@ def mailgun_get_message(context: Context, url: str) -> dict:
     return response.json()
 
 
-def mailgun_get_message_url(context: Context, recipient: str) -> str:
+def mailgun_get_message_url(
+        context: Context, recipient: str, *, subject: str = None) -> str:
     """Will try to find the message URL among 100 emails sent in last 1 hour.
 
     NOTE:
@@ -657,7 +658,8 @@ def mailgun_get_message_url(context: Context, recipient: str) -> str:
 
     response = find_mailgun_events(
         context, MailGunService.SSO, limit=message_limit, recipient=recipient,
-        event=MailGunEvent.ACCEPTED, begin=begin, ascending="yes"
+        event=MailGunEvent.ACCEPTED, begin=begin, ascending="yes",
+        subject=subject
     )
     context.response = response
     logging.debug("Found event with recipient: {}".format(recipient))

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -48,6 +48,8 @@ EMAIL_VERIFICATION_MSG_SUBJECT = ("Your great.gov.uk account: Please Confirm "
                                   "Your E-mail Address")
 FAS_MESSAGE_FROM_BUYER_SUBJECT = ("Someone is interested in your Find a Buyer "
                                   "profile")
+SSO_PASSWORD_RESET_MSG_SUBJECT = ("Your great.gov.uk account: Password Reset "
+                                  "E-mail")
 NO_OF_EMPLOYEES = ["1-10", "11-50", "51-200", "201-500", "501-1000",
                    "1001-10000", "10001+"]
 SECTORS = [


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2146)

Scenario:
```gherkin
    @ED-2146
    @sso
    @account
    @manage
    @password
    Scenario: Suppliers without FAB profile should be able to reset password
      Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
      And "Peter Alder" is signed out from SSO/great.gov.uk account

      When "Peter Alder" resets the password

      Then "Peter Alder" should be told that password was reset
      And "Peter Alder" should receive a password reset email
```
