### PR TITLE
ED-2147 Users with just SSO account should be able to sign back in

### DIFF
--- a/tests/functional/features/pages/sso_ui_login.py
+++ b/tests/functional/features/pages/sso_ui_login.py
@@ -36,30 +36,28 @@ def should_be_here(response: Response):
 
 
 def login(
-        actor: Actor, token: str, *, referer: str = None,
-        next: str = None) -> Response:
+        actor: Actor, *, token: str = None, referer: str = None,
+        next_param: str = None) -> Response:
     """Try to sign in to FAB as a Supplier without verified email address.
 
     :param actor: a namedtuple with Actor details
-    :param token: CSRF token required to submit the login form
-    :param referer: (optional) referer URL
-    :param next: (optional) URL to go to after successful login
+    :param token: (optional) CSRF token required to submit the login form
+    :param referer: (optional) referer URL. Defaults to FAB Landing page
+    :param next_param: (optional) URL to go to after successful login.
+                       Defaults to FAB Landing page
     :return: response object
     """
     session = actor.session
     fab_landing = get_absolute_url("ui-buyer:landing")
 
     data = {
-        "next": fab_landing,
-        "csrfmiddlewaretoken": token,
+        "next": next_param or fab_landing,
+        "csrfmiddlewaretoken": token or actor.csrfmiddlewaretoken,
         "login": actor.email,
         "password": actor.password,
         "remember": "on"
     }
-    if next:
-        data.update({"next": next})
-    # Referer is the same as the final URL from the previous request
-    referer = referer or "{}?next={}".format(URL, fab_landing)
+    referer = "{}?next={}".format(URL, referer or fab_landing)
     headers = {"Referer": referer}
 
     response = make_request(

--- a/tests/functional/features/pages/sso_ui_login.py
+++ b/tests/functional/features/pages/sso_ui_login.py
@@ -16,10 +16,11 @@ EXPECTED_STRINGS = [
 ]
 
 
-def go_to(session: Session) -> Response:
+def go_to(
+        session: Session, *, next_param: str = None, referer: str = None)-> Response:
     fab_landing = get_absolute_url("ui-buyer:landing")
-    params = {"next": fab_landing}
-    headers = {"Referer": fab_landing}
+    params = {"next": next_param or fab_landing}
+    headers = {"Referer": referer or fab_landing}
     response = make_request(
         Method.GET, URL, session=session, params=params, headers=headers)
     return response

--- a/tests/functional/features/sso/profile.feature
+++ b/tests/functional/features/sso/profile.feature
@@ -42,3 +42,15 @@ Feature: SSO profile
 
       When "Peter Alder" creates a SSO/great.gov.uk account
       Then "Peter Alder" should be told about the verification email
+
+
+    @ED-2147
+    @sso
+    @account
+    Scenario: Suppliers should be able to sign out and sign back in
+      Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
+      And "Peter Alder" is signed out from SSO/great.gov.uk account
+
+      When "Peter Alder" signs in to SSO/great.gov.uk account
+
+      Then "Peter Alder" should be signed in to SSO/great.gov.uk account

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -334,8 +334,3 @@ def then_should_be_told_that_password_was_reset(context, supplier_alias):
 @then('"{supplier_alias}" should receive a password reset email')
 def then_supplier_should_receive_password_reset_email(context, supplier_alias):
     sso_should_get_password_reset_email(context, supplier_alias)
-
-
-@then('"{supplier_alias}" should be told that password was reset')
-def then_should_be_told_that_password_was_reset(context, supplier_alias):
-    sso_should_be_told_about_password_reset(context, supplier_alias)

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -334,3 +334,8 @@ def then_should_be_told_that_password_was_reset(context, supplier_alias):
 @then('"{supplier_alias}" should receive a password reset email')
 def then_supplier_should_receive_password_reset_email(context, supplier_alias):
     sso_should_get_password_reset_email(context, supplier_alias)
+
+
+@then('"{supplier_alias}" should be told that password was reset')
+def then_should_be_told_that_password_was_reset(context, supplier_alias):
+    sso_should_be_told_about_password_reset(context, supplier_alias)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -139,7 +139,7 @@ def sso_should_be_signed_in_to_sso_account(
     with assertion_msg("Response doesn't contain 'Sign out' button. It looks "
                        "like user is not logged in"):
         assert "Sign out" in response.content.decode("utf-8")
-    logging.debug("%s is logged in to the SSO account".format(supplier_alias))
+    logging.debug("%s is logged in to the SSO account", supplier_alias)
 
 
 def sso_should_be_signed_out_from_sso_account(

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -47,6 +47,7 @@ from tests.functional.features.steps.fab_when_impl import (
     select_random_company,
     sso_go_to_create_trade_profile,
     sso_reset_password,
+    sso_sign_in,
     sso_supplier_confirms_email_address
 )
 
@@ -312,3 +313,8 @@ def when_supplier_attempts_to_add_case_study(context, supplier_alias):
 @when('"{supplier_alias}" resets the password')
 def when_supplier_resets_password(context, supplier_alias):
     sso_reset_password(context, supplier_alias)
+
+
+@when('"{supplier_alias}" signs in to SSO/great.gov.uk account')
+def step_impl(context, supplier_alias):
+    sso_sign_in(context, supplier_alias)

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -316,5 +316,5 @@ def when_supplier_resets_password(context, supplier_alias):
 
 
 @when('"{supplier_alias}" signs in to SSO/great.gov.uk account')
-def step_impl(context, supplier_alias):
+def when_supplier_signs_in_to_sso_account(context, supplier_alias):
     sso_sign_in(context, supplier_alias)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1741,3 +1741,23 @@ def sso_reset_password(
 
     response = sso_ui_password_reset.reset(actor, token, next_param=next_param)
     context.response = response
+
+
+def sso_sign_in(context: Context, supplier_alias: str):
+    """Sign in to standalone SSO account.
+
+    :param context: behave `context` object
+    :param supplier_alias: alias of the Supplier Actor
+    """
+    actor = context.get_actor(supplier_alias)
+    next_param = get_absolute_url("profile:about")
+    referer = get_absolute_url("profile:about")
+    response = sso_ui_login.go_to(
+        actor.session, next_param=next_param, referer=referer)
+    context.response = response
+
+    token = extract_csrf_middleware_token(response)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
+
+    context.response = sso_ui_login.login(
+        actor, next_param=next_param, referer=referer)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -507,7 +507,7 @@ def prof_attempt_to_sign_in_to_fab(context, supplier_alias):
     context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
     # Step 3 - submit the login form
-    response = sso_ui_login.login(actor, token)
+    response = sso_ui_login.login(actor)
     context.response = response
 
 
@@ -570,7 +570,7 @@ def prof_sign_in_to_fab(context, supplier_alias):
     context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
     # Step 4 - submit the login form
-    response = sso_ui_login.login(actor, token)
+    response = sso_ui_login.login(actor)
     context.response = response
 
     # Step 5 - check if Supplier is on the FAB profile page
@@ -1607,7 +1607,7 @@ def fab_go_to_letter_verification(
         logging.debug(
             "After successful login %s should be redirected to: %s",
             supplier_alias, referer)
-        response = sso_ui_login.login(actor, token, referer=referer, next=next)
+        response = sso_ui_login.login(actor, referer=referer, next_param=next)
         context.response = response
 
         fab_ui_confirm_identity.should_be_here(


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2147)

Scenario:
```gherkin
    @ED-2147
    @sso
    @account
    Scenario: Suppliers should be able to sign out and sign back in
      Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
      And "Peter Alder" is signed out from SSO/great.gov.uk account

      When "Peter Alder" signs in to SSO/great.gov.uk account

      Then "Peter Alder" should be signed in to SSO/great.gov.uk account
```
