### PR TITLE
ED-2251 reset password for users with FAB profile

### DIFF
--- a/tests/functional/features/context_utils.py
+++ b/tests/functional/features/context_utils.py
@@ -112,7 +112,8 @@ def get_actor(self, alias):
 def update_actor(
         self, alias, *, password_reset_link: str = None,
         company_alias: str = None, has_sso_account: bool = None,
-        email_confirmation_link: str = None, csrfmiddlewaretoken: str = None):
+        email_confirmation_link: str = None, csrfmiddlewaretoken: str = None,
+        password: str = None):
     actors = self.scenario_data.actors
     if password_reset_link:
         actors[alias] = actors[alias]._replace(password_reset_link=password_reset_link)
@@ -124,6 +125,8 @@ def update_actor(
         actors[alias] = actors[alias]._replace(email_confirmation_link=email_confirmation_link)
     if csrfmiddlewaretoken:
         actors[alias] = actors[alias]._replace(csrfmiddlewaretoken=csrfmiddlewaretoken)
+    if password:
+        actors[alias] = actors[alias]._replace(password=password)
 
     logging.debug(
         "Successfully updated Actors's details %s: %s", alias, actors[alias])

--- a/tests/functional/features/fas/search.feature
+++ b/tests/functional/features/fas/search.feature
@@ -186,7 +186,7 @@ Feature: Find a Supplier
   @search
   Scenario: Buyers should not see the same company multiple times in the search results even if all associated sector filters are used
     Given "Annette Geissinger" is a buyer
-    And "Annette Geissinger" finds a Supplier "Y" with a published profile associated with at least "5" different sectors
+    And "Annette Geissinger" finds a Supplier "Y" with a published profile associated with at least "4" different sectors
 
     When "Annette Geissinger" browse first "10" pages of Suppliers filtered by all sectors associated with company "Y"
 

--- a/tests/functional/features/pages/sso_ui_change_password.py
+++ b/tests/functional/features/pages/sso_ui_change_password.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""SSO - Change password page"""
+import logging
+from urllib.parse import urljoin
+
+from requests import Response, Session
+
+from tests import get_absolute_url
+from tests.functional.features.context_utils import Actor
+from tests.functional.features.utils import (
+    Method,
+    assertion_msg,
+    check_response,
+    make_request
+)
+
+EXPECTED_STRINGS = [
+    "Change Password",
+    "New Password:",
+    "New Password (again):", "change password"
+]
+
+
+def should_be_here(response: Response):
+    """Check if Supplier is on SSO Change Password Page.
+
+    :param response: response object
+    """
+    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+    logging.debug("Successfully got to the SSO Change Password page")
+
+
+def submit(
+        actor: Actor, action: str, *, password: str = None,
+        password_again: str = None, referer: str = None) -> Response:
+    """Try to change the password to the SSO account.
+
+    :param actor: a namedtuple with Actor details
+    :param action: target form action
+    :param password: (optional) new password
+    :param password_again: (optional) password confirmation
+    :param referer: (optional) referer URL
+    :return: response object
+    """
+    session = actor.session
+    URL = urljoin(get_absolute_url("sso:landing"), action)
+    profile_about = get_absolute_url("profile:about")
+
+    data = {
+        "action": "change password",
+        "csrfmiddlewaretoken": actor.csrfmiddlewaretoken,
+        "password1": password or actor.password,
+        "password2": password_again or password or actor.password
+    }
+    # Referer is the same as the final URL from the previous request
+    referer = "{}?next={}".format(URL, referer or profile_about)
+    headers = {"Referer": referer}
+
+    response = make_request(
+        Method.POST, URL, session=session, data=data, headers=headers)
+
+    return response
+
+
+def open_password_reset_link(session: Session, link: str) -> Response:
+    with assertion_msg("Expected a non-empty password reset email link"):
+        assert link
+    return make_request(Method.GET, link, session=session)

--- a/tests/functional/features/pages/sso_ui_confim_your_email.py
+++ b/tests/functional/features/pages/sso_ui_confim_your_email.py
@@ -38,8 +38,7 @@ def open_confirmation_link(session: Session, link: str) -> Response:
     """
     with assertion_msg("Expected a non-empty email confirmation link"):
         assert link
-    response = make_request(Method.GET, link, session=session)
-    return response
+    return make_request(Method.GET, link, session=session)
 
 
 def confirm(actor: Actor, form_action_value: str) -> Response:

--- a/tests/functional/features/pages/sso_ui_invalid_password_reset_link.py
+++ b/tests/functional/features/pages/sso_ui_invalid_password_reset_link.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""SSO - Invalid password reset link page"""
+import logging
+
+from requests import Response
+
+from tests.functional.features.utils import check_response
+
+EXPECTED_STRINGS = [
+    "Bad Token", "Please request a", "new password reset",
+    ("The password reset link was invalid, possibly because it has already been"
+     " used.")
+]
+
+
+def should_be_here(response: Response):
+    """Check if Supplier is on SSO Change Password Page.
+
+    :param response: response object
+    """
+    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+    logging.debug("Got to the SSO Invalid Password Reset Link page")

--- a/tests/functional/features/pages/sso_ui_password_reset.py
+++ b/tests/functional/features/pages/sso_ui_password_reset.py
@@ -6,7 +6,12 @@ from requests import Response, Session
 
 from tests import get_absolute_url
 from tests.functional.features.context_utils import Actor
-from tests.functional.features.utils import Method, check_response, make_request
+from tests.functional.features.utils import (
+    Method,
+    assertion_msg,
+    check_response,
+    make_request
+)
 
 URL = get_absolute_url("sso:password_reset")
 EXPECTED_STRINGS = [
@@ -78,3 +83,9 @@ def reset(
         Method.POST, URL, session=session, data=data, headers=headers)
 
     return response
+
+
+def open_link(session: Session, link: str) -> Response:
+    with assertion_msg("Expected a non-empty password reset email link"):
+        assert link
+    return make_request(Method.GET, link, session=session)

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -114,6 +114,15 @@ FAB_PAGE_SELECTORS = {
     "edit company contact": "ui-buyer:company-edit-contact",
     "edit social media links": "ui-buyer:company-edit-social-media",
 }
+PROFILE_PAGE_SELECTORS = {
+    "profile selling online overseas": "profile:soo",
+    "profile find a buyer": "profile:fab",
+    "exops alerts": "profile:exops-alerts",
+    "exops applications": "profile:exops-applications",
+    "profile landing": "profile:landing",
+    "profile about": "profile:about",
+    "profile directory supplier": "profile:directory-supplier"
+}
 
 
 def extract_and_set_csrf_middleware_token(

--- a/tests/functional/features/pages/utils.py
+++ b/tests/functional/features/pages/utils.py
@@ -497,6 +497,7 @@ def get_fabs_page_url(page_name: str, *, language_code: str = None):
     selectors.update(FAB_PAGE_SELECTORS)
     selectors.update(FAS_PAGE_SELECTORS)
     selectors.update(SSO_PAGE_SELECTORS)
+    selectors.update(PROFILE_PAGE_SELECTORS)
     url = get_absolute_url(selectors[page_name.lower()])
     if language_code:
         url += "?lang={}".format(language_code)

--- a/tests/functional/features/sso/password.feature
+++ b/tests/functional/features/sso/password.feature
@@ -14,3 +14,83 @@ Feature: SSO password management
 
       Then "Peter Alder" should be told that password was reset
       And "Peter Alder" should receive a password reset email
+
+
+    @ED-2251
+    @sso
+    @account
+    @manage
+    @password
+    Scenario: Suppliers with verified FAB profile should receive a message with password reset link
+      Given "Peter Alder" has created and verified profile for randomly selected company "Y"
+      And "Peter Alder" signed out from Find a Buyer service
+
+      When "Peter Alder" resets the password
+
+      Then "Peter Alder" should be told that password was reset
+      And "Peter Alder" should receive a password reset email
+
+
+    @ED-2251
+    @sso
+    @account
+    @manage
+    @password
+    Scenario: Suppliers with unverified FAB profile should receive a message with password reset link
+      Given "Peter Alder" created an unverified profile for randomly selected company "Y"
+      And "Peter Alder" signed out from Find a Buyer service
+
+      When "Peter Alder" resets the password
+
+      Then "Peter Alder" should be told that password was reset
+      And "Peter Alder" should receive a password reset email
+
+
+    @wip
+    @ED-2146
+    @sso
+    @account
+    @manage
+    @password
+    Scenario: Suppliers with FAB profile should be able to reset password
+      Given "Peter Alder" created an unverified profile for randomly selected company "Y"
+      And "Peter Alder" received a password reset email
+
+      When "Peter Alder" changes the password to a new one using the password reset link
+
+
+    @wip
+    @ED-2146
+    @sso
+    @account
+    @manage
+    @password
+    Scenario: Suppliers without FAB profile should be able to reset password
+      Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
+      And "Peter Alder" received a password reset email
+
+      When "Peter Alder" changes the password to a new one using the password reset link
+
+
+    @wip
+    @ED-2146
+    @sso
+    @account
+    @manage
+    @password
+    Scenario: Suppliers should be able to reset (change) the password to the same one
+      Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
+      And "Peter Alder" is signed out from SSO/great.gov.uk account
+
+      When "Peter Alder" changes the password to the same one using the password reset link
+
+      Then "Peter Alder" should be told that password was reset
+
+
+    @wip
+    @ED-2146
+    @sso
+    @account
+    @manage
+    @password
+    Scenario: Suppliers should not be to use the password reset link more than once

--- a/tests/functional/features/sso/password.feature
+++ b/tests/functional/features/sso/password.feature
@@ -8,7 +8,7 @@ Feature: SSO password management
     @password
     Scenario: Suppliers without FAB profile should receive a message with password reset link
       Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
-      And "Peter Alder" is signed out from SSO/great.gov.uk account
+      And "Peter Alder" signed out from SSO/great.gov.uk account
 
       When "Peter Alder" resets the password
 
@@ -80,7 +80,7 @@ Feature: SSO password management
     @password
     Scenario: Suppliers should be able to reset (change) the password to the same one
       Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
-      And "Peter Alder" is signed out from SSO/great.gov.uk account
+      And "Peter Alder" signed out from SSO/great.gov.uk account
 
       When "Peter Alder" changes the password to the same one using the password reset link
 

--- a/tests/functional/features/sso/password.feature
+++ b/tests/functional/features/sso/password.feature
@@ -1,4 +1,4 @@
-Feature: SSO profile
+Feature: SSO password management
 
 
     @ED-2146
@@ -6,7 +6,7 @@ Feature: SSO profile
     @account
     @manage
     @password
-    Scenario: Suppliers without FAB profile should be able to reset password
+    Scenario: Suppliers without FAB profile should receive a message with password reset link
       Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
       And "Peter Alder" is signed out from SSO/great.gov.uk account
 

--- a/tests/functional/features/sso/password.feature
+++ b/tests/functional/features/sso/password.feature
@@ -10,7 +10,7 @@ Feature: SSO password management
       Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
       And "Peter Alder" signed out from SSO/great.gov.uk account
 
-      When "Peter Alder" resets the password
+      When "Peter Alder" requests password reset
 
       Then "Peter Alder" should be told that password was reset
       And "Peter Alder" should receive a password reset email
@@ -25,7 +25,7 @@ Feature: SSO password management
       Given "Peter Alder" has created and verified profile for randomly selected company "Y"
       And "Peter Alder" signed out from Find a Buyer service
 
-      When "Peter Alder" resets the password
+      When "Peter Alder" requests password reset
 
       Then "Peter Alder" should be told that password was reset
       And "Peter Alder" should receive a password reset email
@@ -40,7 +40,7 @@ Feature: SSO password management
       Given "Peter Alder" created an unverified profile for randomly selected company "Y"
       And "Peter Alder" signed out from Find a Buyer service
 
-      When "Peter Alder" resets the password
+      When "Peter Alder" requests password reset
 
       Then "Peter Alder" should be told that password was reset
       And "Peter Alder" should receive a password reset email

--- a/tests/functional/features/sso/password.feature
+++ b/tests/functional/features/sso/password.feature
@@ -6,14 +6,14 @@ Feature: SSO password management
     @account
     @manage
     @password
-    Scenario: Suppliers without FAB profile should receive a message with password reset link
+    Scenario: Suppliers with just SSO/great.gov.uk account should be able to reset password
       Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
       And "Peter Alder" signed out from SSO/great.gov.uk account
+      And "Peter Alder" received a password reset email
 
-      When "Peter Alder" requests password reset
+      When "Peter Alder" changes the password to a new one using the password reset link
 
-      Then "Peter Alder" should be told that password was reset
-      And "Peter Alder" should receive a password reset email
+      Then "Peter Alder" should be on Welcome to your great.gov.uk profile page
 
 
     @ED-2251
@@ -21,58 +21,31 @@ Feature: SSO password management
     @account
     @manage
     @password
-    Scenario: Suppliers with verified FAB profile should receive a message with password reset link
+    Scenario: Suppliers with unverified FAB profile should be able to reset password
+      Given "Peter Alder" created an unverified profile for randomly selected company "Y"
+      And "Peter Alder" signed out from Find a Buyer service
+      And "Peter Alder" received a password reset email
+
+      When "Peter Alder" changes the password to a new one using the password reset link
+
+      Then "Peter Alder" should be on Welcome to your great.gov.uk profile page
+
+
+    @ED-2251
+    @sso
+    @account
+    @manage
+    @password
+    Scenario: Suppliers with verified FAB profile should be able to reset password
       Given "Peter Alder" has created and verified profile for randomly selected company "Y"
       And "Peter Alder" signed out from Find a Buyer service
-
-      When "Peter Alder" requests password reset
-
-      Then "Peter Alder" should be told that password was reset
-      And "Peter Alder" should receive a password reset email
-
-
-    @ED-2251
-    @sso
-    @account
-    @manage
-    @password
-    Scenario: Suppliers with unverified FAB profile should receive a message with password reset link
-      Given "Peter Alder" created an unverified profile for randomly selected company "Y"
-      And "Peter Alder" signed out from Find a Buyer service
-
-      When "Peter Alder" requests password reset
-
-      Then "Peter Alder" should be told that password was reset
-      And "Peter Alder" should receive a password reset email
-
-
-    @wip
-    @ED-2146
-    @sso
-    @account
-    @manage
-    @password
-    Scenario: Suppliers with FAB profile should be able to reset password
-      Given "Peter Alder" created an unverified profile for randomly selected company "Y"
       And "Peter Alder" received a password reset email
 
       When "Peter Alder" changes the password to a new one using the password reset link
 
-
-    @wip
-    @ED-2146
-    @sso
-    @account
-    @manage
-    @password
-    Scenario: Suppliers without FAB profile should be able to reset password
-      Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
-      And "Peter Alder" received a password reset email
-
-      When "Peter Alder" changes the password to a new one using the password reset link
+      Then "Peter Alder" should be on Welcome to your great.gov.uk profile page
 
 
-    @wip
     @ED-2146
     @sso
     @account
@@ -80,17 +53,26 @@ Feature: SSO password management
     @password
     Scenario: Suppliers should be able to reset (change) the password to the same one
       Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
-      And "Peter Alder" signed out from SSO/great.gov.uk account
+      And "Peter Alder" received a password reset email
 
       When "Peter Alder" changes the password to the same one using the password reset link
 
-      Then "Peter Alder" should be told that password was reset
+      Then "Peter Alder" should be on Welcome to your great.gov.uk profile page
 
 
-    @wip
     @ED-2146
     @sso
     @account
     @manage
     @password
     Scenario: Suppliers should not be to use the password reset link more than once
+      Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
+      And "Peter Alder" signed out from SSO/great.gov.uk account
+      And "Peter Alder" received a password reset email
+
+      When "Peter Alder" changes the password to a new one using the password reset link
+      Then "Peter Alder" should be on Welcome to your great.gov.uk profile page
+
+      When "Peter Alder" opens the password reset link
+
+      Then "Peter Alder" should be told that password reset link is invalid

--- a/tests/functional/features/sso/profile.feature
+++ b/tests/functional/features/sso/profile.feature
@@ -49,7 +49,7 @@ Feature: SSO profile
     @account
     Scenario: Suppliers should be able to sign out and sign back in
       Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
-      And "Peter Alder" is signed out from SSO/great.gov.uk account
+      And "Peter Alder" signed out from SSO/great.gov.uk account
 
       When "Peter Alder" signs in to SSO/great.gov.uk account
 

--- a/tests/functional/features/steps/fab_given_def.py
+++ b/tests/functional/features/steps/fab_given_def.py
@@ -102,7 +102,7 @@ def given_supplier_is_signed_in_to_sso(context, supplier_alias):
     sso_should_be_signed_in_to_sso_account(context, supplier_alias)
 
 
-@given('"{supplier_alias}" is signed out from SSO/great.gov.uk account')
+@given('"{supplier_alias}" signed out from SSO/great.gov.uk account')
 def given_supplier_is_signed_out_from_sso(context, supplier_alias):
     sso_should_be_signed_out_from_sso_account(context, supplier_alias)
 

--- a/tests/functional/features/steps/fab_given_def.py
+++ b/tests/functional/features/steps/fab_given_def.py
@@ -15,6 +15,7 @@ from tests.functional.features.steps.fab_given_impl import (
     reg_should_get_verification_letter,
     sso_create_standalone_unverified_sso_account,
     sso_create_standalone_verified_sso_account,
+    sso_get_password_reset_link,
     unauthenticated_buyer,
     unauthenticated_supplier
 )
@@ -182,3 +183,8 @@ def given_actor_gets_company_slug(context, actor_alias, company_alias):
 @given('"{supplier_alias}" received the letter with verification code')
 def step_impl(context, supplier_alias):
     reg_should_get_verification_letter(context, supplier_alias)
+
+
+@given('"{supplier_alias}" received a password reset email')
+def given_supplier_received_password_reset_email(context, supplier_alias):
+    sso_get_password_reset_link(context, supplier_alias)

--- a/tests/functional/features/steps/fab_given_impl.py
+++ b/tests/functional/features/steps/fab_given_impl.py
@@ -38,7 +38,6 @@ from tests.functional.features.steps.fab_when_impl import (
     bp_verify_identity_with_letter,
     can_find_supplier_by_term,
     prof_set_company_description,
-    prof_sign_out_from_fab,
     prof_verify_company,
     reg_confirm_company_selection,
     reg_confirm_export_status,

--- a/tests/functional/features/steps/fab_given_impl.py
+++ b/tests/functional/features/steps/fab_given_impl.py
@@ -48,7 +48,7 @@ from tests.functional.features.steps.fab_when_impl import (
     reg_supplier_confirms_email_address,
     select_random_company,
     sso_go_to_create_trade_profile,
-    sso_reset_password,
+    sso_request_password_reset,
     sso_supplier_confirms_email_address
 )
 from tests.functional.features.utils import assertion_msg
@@ -267,7 +267,6 @@ def reg_should_get_verification_letter(context, supplier_alias):
 
 
 def sso_get_password_reset_link(context: Context, supplier_alias: str):
-    prof_sign_out_from_fab(context, supplier_alias)
-    sso_reset_password(context, supplier_alias)
+    sso_request_password_reset(context, supplier_alias)
     sso_should_be_told_about_password_reset(context, supplier_alias)
     sso_should_get_password_reset_email(context, supplier_alias)

--- a/tests/functional/features/steps/fab_given_impl.py
+++ b/tests/functional/features/steps/fab_given_impl.py
@@ -28,7 +28,9 @@ from tests.functional.features.steps.fab_then_impl import (
     prof_should_be_told_about_missing_description,
     reg_should_get_verification_email,
     reg_sso_account_should_be_created,
-    sso_should_be_signed_in_to_sso_account
+    sso_should_be_signed_in_to_sso_account,
+    sso_should_be_told_about_password_reset,
+    sso_should_get_password_reset_email
 )
 from tests.functional.features.steps.fab_when_impl import (
     bp_provide_company_details,
@@ -36,6 +38,7 @@ from tests.functional.features.steps.fab_when_impl import (
     bp_verify_identity_with_letter,
     can_find_supplier_by_term,
     prof_set_company_description,
+    prof_sign_out_from_fab,
     prof_verify_company,
     reg_confirm_company_selection,
     reg_confirm_export_status,
@@ -45,6 +48,7 @@ from tests.functional.features.steps.fab_when_impl import (
     reg_supplier_confirms_email_address,
     select_random_company,
     sso_go_to_create_trade_profile,
+    sso_reset_password,
     sso_supplier_confirms_email_address
 )
 from tests.functional.features.utils import assertion_msg
@@ -260,3 +264,10 @@ def reg_should_get_verification_letter(context, supplier_alias):
     logging.debug(
         "%s received the verification letter with code: %s", supplier_alias,
         verification_code)
+
+
+def sso_get_password_reset_link(context: Context, supplier_alias: str):
+    prof_sign_out_from_fab(context, supplier_alias)
+    sso_reset_password(context, supplier_alias)
+    sso_should_be_told_about_password_reset(context, supplier_alias)
+    sso_should_get_password_reset_email(context, supplier_alias)

--- a/tests/functional/features/steps/fab_then_def.py
+++ b/tests/functional/features/steps/fab_then_def.py
@@ -44,7 +44,8 @@ from tests.functional.features.steps.fab_then_impl import (
     reg_supplier_is_not_appropriate_for_fab,
     sso_should_be_signed_in_to_sso_account,
     sso_should_be_told_about_password_reset,
-    sso_should_get_password_reset_email
+    sso_should_get_password_reset_email,
+    sso_should_see_invalid_password_reset_link_error
 )
 from tests.functional.features.steps.fab_when_impl import (
     fas_feedback_request_should_be_submitted,
@@ -334,3 +335,8 @@ def then_should_be_told_that_password_was_reset(context, supplier_alias):
 @then('"{supplier_alias}" should receive a password reset email')
 def then_supplier_should_receive_password_reset_email(context, supplier_alias):
     sso_should_get_password_reset_email(context, supplier_alias)
+
+
+@then('"{supplier_alias}" should be told that password reset link is invalid')
+def then_should_see_invalid_password_reset_link_error(context, supplier_alias):
+    sso_should_see_invalid_password_reset_link_error(context, supplier_alias)

--- a/tests/functional/features/steps/fab_then_impl.py
+++ b/tests/functional/features/steps/fab_then_impl.py
@@ -21,6 +21,7 @@ from tests.functional.features.pages import (
     fas_ui_industries,
     fas_ui_profile,
     profile_ui_landing,
+    sso_ui_invalid_password_reset_link,
     sso_ui_logout,
     sso_ui_password_reset,
     sso_ui_verify_your_email
@@ -788,3 +789,10 @@ def sso_should_get_password_reset_email(context: Context, supplier_alias: str):
     actor = context.get_actor(supplier_alias)
     link = get_password_reset_link(context, actor.email)
     context.update_actor(supplier_alias, password_reset_link=link)
+
+
+def sso_should_see_invalid_password_reset_link_error(
+        context: Context, supplier_alias: str):
+    sso_ui_invalid_password_reset_link.should_be_here(context.response)
+    logging.debug(
+        "%s was told about invalid password reset link", supplier_alias)

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -47,6 +47,7 @@ from tests.functional.features.steps.fab_when_impl import (
     select_random_company,
     sso_go_to_create_trade_profile,
     sso_sign_in,
+    sso_open_password_reset_link,
     sso_request_password_reset,
     sso_supplier_confirms_email_address
 )
@@ -324,3 +325,8 @@ def when_supplier_signs_in_to_sso_account(context, supplier_alias):
       ' reset link')
 def when_supplier_change_password(context, supplier_alias):
     sso_request_password_reset(context, supplier_alias)
+
+
+@when('"{supplier_alias}" opens the password reset link')
+def when_supplier_opens_password_reset_link(context, supplier_alias):
+    sso_open_password_reset_link(context, supplier_alias)

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -45,6 +45,7 @@ from tests.functional.features.steps.fab_when_impl import (
     reg_open_email_confirmation_link,
     reg_supplier_confirms_email_address,
     select_random_company,
+    sso_change_password_with_password_reset_link,
     sso_go_to_create_trade_profile,
     sso_sign_in,
     sso_open_password_reset_link,
@@ -324,9 +325,17 @@ def when_supplier_signs_in_to_sso_account(context, supplier_alias):
 @when('"{supplier_alias}" changes the password to a new one using the password'
       ' reset link')
 def when_supplier_change_password(context, supplier_alias):
-    sso_request_password_reset(context, supplier_alias)
+    sso_change_password_with_password_reset_link(
+        context, supplier_alias, new=True)
 
 
 @when('"{supplier_alias}" opens the password reset link')
 def when_supplier_opens_password_reset_link(context, supplier_alias):
     sso_open_password_reset_link(context, supplier_alias)
+
+
+@when('"{supplier_alias}" changes the password to the same one using the '
+      'password reset link')
+def when_supplier_changes_password_to_the_same_one(context, supplier_alias):
+    sso_change_password_with_password_reset_link(
+        context, supplier_alias, same=True)

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -318,3 +318,9 @@ def when_supplier_resets_password(context, supplier_alias):
 @when('"{supplier_alias}" signs in to SSO/great.gov.uk account')
 def when_supplier_signs_in_to_sso_account(context, supplier_alias):
     sso_sign_in(context, supplier_alias)
+
+
+@when('"{supplier_alias}" changes the password to a new one using the password'
+      ' reset link')
+def when_supplier_change_password(context, supplier_alias):
+    sso_reset_password(context, supplier_alias)

--- a/tests/functional/features/steps/fab_when_def.py
+++ b/tests/functional/features/steps/fab_when_def.py
@@ -46,8 +46,8 @@ from tests.functional.features.steps.fab_when_impl import (
     reg_supplier_confirms_email_address,
     select_random_company,
     sso_go_to_create_trade_profile,
-    sso_reset_password,
     sso_sign_in,
+    sso_request_password_reset,
     sso_supplier_confirms_email_address
 )
 
@@ -310,9 +310,9 @@ def when_supplier_attempts_to_add_case_study(context, supplier_alias):
     fab_attempt_to_add_case_study(context, supplier_alias, context.table)
 
 
-@when('"{supplier_alias}" resets the password')
+@when('"{supplier_alias}" requests password reset')
 def when_supplier_resets_password(context, supplier_alias):
-    sso_reset_password(context, supplier_alias)
+    sso_request_password_reset(context, supplier_alias)
 
 
 @when('"{supplier_alias}" signs in to SSO/great.gov.uk account')
@@ -323,4 +323,4 @@ def when_supplier_signs_in_to_sso_account(context, supplier_alias):
 @when('"{supplier_alias}" changes the password to a new one using the password'
       ' reset link')
 def when_supplier_change_password(context, supplier_alias):
-    sso_reset_password(context, supplier_alias)
+    sso_request_password_reset(context, supplier_alias)

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1724,7 +1724,7 @@ def fab_attempt_to_add_case_study(
     context.results = results
 
 
-def sso_reset_password(context: Context, supplier_alias: str):
+def sso_request_password_reset(context: Context, supplier_alias: str):
     actor = context.get_actor(supplier_alias)
     if actor.company_alias is None:
         next_param = get_fabs_page_url(page_name="profile about")

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -69,8 +69,8 @@ from tests.functional.features.utils import (
     Method,
     assertion_msg,
     check_response,
-    extract_confirm_email_form_action,
     extract_csrf_middleware_token,
+    extract_form_action,
     extract_logo_url,
     get_absolute_path_of_file,
     get_md5_hash_of_file,
@@ -263,7 +263,7 @@ def reg_open_email_confirmation_link(context, supplier_alias):
     # Form Action Value is required to successfully confirm email
     token = extract_csrf_middleware_token(response)
     context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
-    form_action_value = extract_confirm_email_form_action(response)
+    form_action_value = extract_form_action(response)
     context.form_action_value = form_action_value
 
 

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1724,12 +1724,12 @@ def fab_attempt_to_add_case_study(
     context.results = results
 
 
-def sso_reset_password(
-        context: Context, supplier_alias: str, *, next_page: str = None):
+def sso_reset_password(context: Context, supplier_alias: str):
     actor = context.get_actor(supplier_alias)
-    next_param = None
-    if next_page is not None:
-        next_param = get_fabs_page_url(page_name=next_page)
+    if actor.company_alias is None:
+        next_param = get_fabs_page_url(page_name="profile about")
+    else:
+        next_param = get_fabs_page_url(page_name="fab landing")
 
     response = sso_ui_password_reset.go_to(actor.session, next_param=next_param)
     context.response = response

--- a/tests/functional/features/steps/fab_when_impl.py
+++ b/tests/functional/features/steps/fab_when_impl.py
@@ -1761,3 +1761,10 @@ def sso_sign_in(context: Context, supplier_alias: str):
 
     context.response = sso_ui_login.login(
         actor, next_param=next_param, referer=referer)
+
+
+def sso_open_password_reset_link(context: Context, supplier_alias: str):
+    actor = context.get_actor(supplier_alias)
+    session = actor.session
+    link = actor.password_reset_link
+    context.response = sso_ui_password_reset.open_link(session, link)

--- a/tests/functional/features/utils.py
+++ b/tests/functional/features/utils.py
@@ -421,18 +421,17 @@ def extract_csrf_middleware_token(response: Response):
         assert response.content
     css_selector = '#content input[type="hidden"]::attr(value)'
     token = extract_by_css(response, css_selector)
+    logging.debug("Found CSRF token: %s", token)
     return token
 
 
-def extract_confirm_email_form_action(response: Response):
-    """Extract the form action (endpoint) from the Confirm Email page.
+def extract_form_action(response: Response) -> str:
+    """Extract the form action (endpoint).
 
     Comes in handy when dealing with e.g. Django forms.
 
     :param response: requests response
-    :type  response: requests.models.Response
     :return: for action endpoint
-    :rtype: str
     """
     with assertion_msg("Can't extract form action from an empty response!"):
         assert response.content


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2251)

I've replaced scenarios that only assert password reset email delivery with "fully-bodied" ones that use that link to reset (change) the password.

Scenario:
```gherkin
    @ED-2146
    @sso
    @account
    @manage
    @password
    Scenario: Suppliers with just SSO/great.gov.uk account should be able to reset password
      Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
      And "Peter Alder" signed out from SSO/great.gov.uk account
      And "Peter Alder" received a password reset email

      When "Peter Alder" changes the password to a new one using the password reset link

      Then "Peter Alder" should be on Welcome to your great.gov.uk profile page


    @ED-2251
    @sso
    @account
    @manage
    @password
    Scenario: Suppliers with unverified FAB profile should be able to reset password
      Given "Peter Alder" created an unverified profile for randomly selected company "Y"
      And "Peter Alder" signed out from Find a Buyer service
      And "Peter Alder" received a password reset email

      When "Peter Alder" changes the password to a new one using the password reset link

      Then "Peter Alder" should be on Welcome to your great.gov.uk profile page


    @ED-2251
    @sso
    @account
    @manage
    @password
    Scenario: Suppliers with verified FAB profile should be able to reset password
      Given "Peter Alder" has created and verified profile for randomly selected company "Y"
      And "Peter Alder" signed out from Find a Buyer service
      And "Peter Alder" received a password reset email

      When "Peter Alder" changes the password to a new one using the password reset link

      Then "Peter Alder" should be on Welcome to your great.gov.uk profile page


    @ED-2146
    @sso
    @account
    @manage
    @password
    Scenario: Suppliers should be able to reset (change) the password to the same one
      Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
      And "Peter Alder" received a password reset email

      When "Peter Alder" changes the password to the same one using the password reset link

      Then "Peter Alder" should be on Welcome to your great.gov.uk profile page


    @ED-2146
    @sso
    @account
    @manage
    @password
    Scenario: Suppliers should not be to use the password reset link more than once
      Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
      And "Peter Alder" signed out from SSO/great.gov.uk account
      And "Peter Alder" received a password reset email

      When "Peter Alder" changes the password to a new one using the password reset link
      Then "Peter Alder" should be on Welcome to your great.gov.uk profile page

      When "Peter Alder" opens the password reset link

      Then "Peter Alder" should be told that password reset link is invalid
```
