### PR TITLE
ED-1952 preferred countries

### DIFF
--- a/tests/functional/features/fab/export-preference.feature
+++ b/tests/functional/features/fab/export-preference.feature
@@ -20,33 +20,41 @@ Feature: Export Preferences
       | China, Germany, India, Japan, United States | Canada, Poland, Italy |
 
 
-  @wip
   @ED-1952b
   @profile
   @export-preferences
-  Scenario: Suppliers have to provide preferred country of export when building up the profile
+  Scenario Outline: Suppliers have to provide preferred country of export when building up the profile
     Given "Annette Geissinger" is an unauthenticated supplier
     And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
     And "Annette Geissinger" confirmed her email address
 
     When "Annette Geissinger" provides valid details of selected company
-    And "Annette Geissinger" selects sector the company is in and preferred country of export
-      | predefined countries | other                        | error                   |
-      | none selected        | empty string                 | This field is required. |
-      | none selected        | Canada, Poland, Italy, Kenia | Enter 3 maximum         |
+    And "Annette Geissinger" selects sector the company is in and "<preferred>" & "<other>" countries of export
 
-    Then "Annette Geissinger" should see expected error messages
+    Then "Annette Geissinger" should see "<error>" message
+
+    Examples:
+      | preferred     | other           | error                                                        |
+      | China         | 1001 characters | Ensure this value has at most 1000 characters (it has 1001). |
+      | none selected | empty string    | This field is required.                                      |
 
 
   @wip
   @ED-1952c
   @profile
   @export-preferences
-  Scenario: Suppliers have to use commas to separate other preferred countries of export when building up the profile
+  Scenario Outline: Suppliers have to use commas to separate other preferred countries of export when building up the profile
     Given "Annette Geissinger" is an unauthenticated supplier
     And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
     And "Annette Geissinger" confirmed her email address
 
     When "Annette Geissinger" provides valid details of selected company
-    And "Annette Geissinger" selects sector the company is in and preferred country of export
+    And "Annette Geissinger" selects sector the company is in and "<preferred>" & "<other>" countries of export
+
+    Then "Annette Geissinger" should see "<error>" message
+
+    Examples:
+      | preferred     | other                 | error                   |
+      | none selected | Canada; Poland; Italy | Enter 3 maximum         |
+      | none selected | Canada.Poland.Italy   | Enter 3 maximum         |
 

--- a/tests/functional/features/fab/export-preference.feature
+++ b/tests/functional/features/fab/export-preference.feature
@@ -1,0 +1,51 @@
+Feature: Export Preferences
+
+
+  @wip
+  @ED-1952a
+  @profile
+  @export-preferences
+  Scenario: Suppliers can select preferred countries of export from the given list and provide a list of other countries
+    Given "Annette Geissinger" is an unauthenticated supplier
+    And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
+    And "Annette Geissinger" confirmed her email address
+
+    When "Annette Geissinger" provides valid details of selected company
+    And "Annette Geissinger" selects sector the company is in and preferred countries of export
+      | predefined countries                        | other                 |
+      | China, Germany, India, Japan, United States | empty string          |
+      | China, Germany, India, Japan, United States | Canada, Poland, Italy |
+
+    Then "Annette Geissinger" should be asked to decide how to verify her identity
+
+
+  @wip
+  @ED-1952b
+  @profile
+  @export-preferences
+  Scenario: Suppliers have to provide preferred country of export when building up the profile
+    Given "Annette Geissinger" is an unauthenticated supplier
+    And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
+    And "Annette Geissinger" confirmed her email address
+
+    When "Annette Geissinger" provides valid details of selected company
+    And "Annette Geissinger" selects sector the company is in and preferred country of export
+      | predefined countries | other                        | error                   |
+      | none selected        | empty string                 | This field is required. |
+      | none selected        | Canada, Poland, Italy, Kenia | Enter 3 maximum         |
+
+    Then "Annette Geissinger" should see expected error messages
+
+
+  @wip
+  @ED-1952c
+  @profile
+  @export-preferences
+  Scenario: Suppliers have to use commas to separate other preferred countries of export when building up the profile
+    Given "Annette Geissinger" is an unauthenticated supplier
+    And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
+    And "Annette Geissinger" confirmed her email address
+
+    When "Annette Geissinger" provides valid details of selected company
+    And "Annette Geissinger" selects sector the company is in and preferred country of export
+

--- a/tests/functional/features/fab/export-preference.feature
+++ b/tests/functional/features/fab/export-preference.feature
@@ -1,22 +1,23 @@
 Feature: Export Preferences
 
 
-  @wip
-  @ED-1952a
+  @ED-1952
   @profile
   @export-preferences
-  Scenario: Suppliers can select preferred countries of export from the given list and provide a list of other countries
+  Scenario Outline: Suppliers can select preferred countries of export from the given list and provide a list of other countries
     Given "Annette Geissinger" is an unauthenticated supplier
     And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
     And "Annette Geissinger" confirmed her email address
 
     When "Annette Geissinger" provides valid details of selected company
-    And "Annette Geissinger" selects sector the company is in and preferred countries of export
-      | predefined countries                        | other                 |
-      | China, Germany, India, Japan, United States | empty string          |
-      | China, Germany, India, Japan, United States | Canada, Poland, Italy |
+    And "Annette Geissinger" selects sector the company is in and "<preferred>" & "<other>" countries of export
 
     Then "Annette Geissinger" should be asked to decide how to verify her identity
+
+    Examples:
+      | preferred                                   | other                 |
+      | China, Germany, India, Japan, United States | empty string          |
+      | China, Germany, India, Japan, United States | Canada, Poland, Italy |
 
 
   @wip

--- a/tests/functional/features/fab/export-preference.feature
+++ b/tests/functional/features/fab/export-preference.feature
@@ -10,17 +10,17 @@ Feature: Export Preferences
     And "Annette Geissinger" confirmed her email address
 
     When "Annette Geissinger" provides valid details of selected company
-    And "Annette Geissinger" selects sector the company is in and "<preferred>" & "<other>" countries of export
+    And "Annette Geissinger" selects sector the company is in and "<preferred>" & "<other>" as other countries of export
 
     Then "Annette Geissinger" should be asked to decide how to verify her identity
 
     Examples:
-      | preferred                                   | other                 |
-      | China, Germany, India, Japan, United States | empty string          |
-      | China, Germany, India, Japan, United States | Canada, Poland, Italy |
+      | preferred              | other                 |
+      | 3 predefined countries | empty string          |
+      | 5 predefined countries | Canada, Poland, Italy |
 
 
-  @ED-1952b
+  @ED-1952
   @profile
   @export-preferences
   Scenario Outline: Suppliers have to provide preferred country of export when building up the profile
@@ -29,32 +29,33 @@ Feature: Export Preferences
     And "Annette Geissinger" confirmed her email address
 
     When "Annette Geissinger" provides valid details of selected company
-    And "Annette Geissinger" selects sector the company is in and "<preferred>" & "<other>" countries of export
+    And "Annette Geissinger" selects sector the company is in and "<preferred>" & "<other>" as other countries of export
 
     Then "Annette Geissinger" should see "<error>" message
 
     Examples:
-      | preferred     | other           | error                                                        |
-      | China         | 1001 characters | Ensure this value has at most 1000 characters (it has 1001). |
-      | none selected | empty string    | This field is required.                                      |
+      | preferred            | other           | error                                                        |
+      | 1 predefined country | 1001 characters | Ensure this value has at most 1000 characters (it has 1001). |
+      | none selected        | empty string    | This field is required.                                      |
 
 
-  @wip
-  @ED-1952c
+  @ED-1952
   @profile
   @export-preferences
+  @bug
+  @ED-2313
+  @fixme
   Scenario Outline: Suppliers have to use commas to separate other preferred countries of export when building up the profile
     Given "Annette Geissinger" is an unauthenticated supplier
     And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
     And "Annette Geissinger" confirmed her email address
 
     When "Annette Geissinger" provides valid details of selected company
-    And "Annette Geissinger" selects sector the company is in and "<preferred>" & "<other>" countries of export
+    And "Annette Geissinger" selects sector the company is in and "<preferred>" & "<other>" as other countries of export
 
     Then "Annette Geissinger" should see "<error>" message
 
     Examples:
-      | preferred     | other                 | error                   |
-      | none selected | Canada; Poland; Italy | Enter 3 maximum         |
-      | none selected | Canada.Poland.Italy   | Enter 3 maximum         |
-
+      | preferred     | other                 | error                                  |
+      | none selected | Canada; Poland; Italy | You can only enter letters and commas. |
+      | none selected | Canada.Poland.Italy   | You can only enter letters and commas. |

--- a/tests/functional/pages/fab_ui_build_profile_sector.py
+++ b/tests/functional/pages/fab_ui_build_profile_sector.py
@@ -29,12 +29,12 @@ def should_be_here(response: Response):
                   "Choose Your company sector")
 
 
-def submit(actor: Actor, sector: str, country: str, other: str) -> Response:
+def submit(actor: Actor, sector: str, countries: list, other: str) -> Response:
     """Submit Build your profile - Choose your sector form.
 
     :param actor: a namedtuple with Actor details
     :param sector: Industry Sector in which company is interested in
-    :param country: country code of the country you're exporting to
+    :param countries: a list of country codes of preferred countries to export
     :param other: list of other countries your company is exporting to
     :return: response object
     """
@@ -43,7 +43,7 @@ def submit(actor: Actor, sector: str, country: str, other: str) -> Response:
         "csrfmiddlewaretoken": actor.csrfmiddlewaretoken,
         "company_profile_edit_view-current_step": "classification",
         "classification-sectors": sector,
-        "classification-export_destinations": country,
+        "classification-export_destinations": countries,
         "classification-export_destinations_other": other
     }
     response = make_request(

--- a/tests/functional/steps/fab_then_def.py
+++ b/tests/functional/steps/fab_then_def.py
@@ -47,7 +47,8 @@ from tests.functional.steps.fab_then_impl import (
     sso_should_get_password_reset_email,
     sso_should_see_invalid_password_reset_link_error,
     should_see_selected_pages,
-    fab_should_be_asked_about_verification_form)
+    fab_should_be_asked_about_verification_form, should_see_message
+)
 
 from tests.functional.steps.fab_when_impl import (
     fas_feedback_request_should_be_submitted,
@@ -357,3 +358,8 @@ def then_actor_should_see_selected_pages(context, actor_alias):
 @then('"{supplier_alias}" should be asked to decide how to verify her identity')
 def then_supplier_should_be_asked_about_verification(context, supplier_alias):
     fab_should_be_asked_about_verification_form(context, supplier_alias)
+
+
+@then('"{actor_alias}" should see "{message}" message')
+def step_impl(context, actor_alias, message):
+    should_see_message(context, actor_alias, message)

--- a/tests/functional/steps/fab_then_def.py
+++ b/tests/functional/steps/fab_then_def.py
@@ -46,8 +46,8 @@ from tests.functional.steps.fab_then_impl import (
     sso_should_be_told_about_password_reset,
     sso_should_get_password_reset_email,
     sso_should_see_invalid_password_reset_link_error,
-    should_see_selected_pages
-)
+    should_see_selected_pages,
+    fab_should_be_asked_about_verification_form)
 
 from tests.functional.steps.fab_when_impl import (
     fas_feedback_request_should_be_submitted,
@@ -352,3 +352,8 @@ def then_supplier_should_see_specific_page(context, supplier_alias, page_name):
 @then('"{actor_alias}" should be able to see all selected pages')
 def then_actor_should_see_selected_pages(context, actor_alias):
     should_see_selected_pages(context, actor_alias)
+
+
+@then('"{supplier_alias}" should be asked to decide how to verify her identity')
+def then_supplier_should_be_asked_about_verification(context, supplier_alias):
+    fab_should_be_asked_about_verification_form(context, supplier_alias)

--- a/tests/functional/steps/fab_then_def.py
+++ b/tests/functional/steps/fab_then_def.py
@@ -361,5 +361,5 @@ def then_supplier_should_be_asked_about_verification(context, supplier_alias):
 
 
 @then('"{actor_alias}" should see "{message}" message')
-def step_impl(context, actor_alias, message):
+def then_actor_should_see_a_message(context, actor_alias, message):
     should_see_message(context, actor_alias, message)

--- a/tests/functional/steps/fab_then_impl.py
+++ b/tests/functional/steps/fab_then_impl.py
@@ -21,8 +21,8 @@ from tests.functional.pages import (
     sso_ui_invalid_password_reset_link,
     sso_ui_logout,
     sso_ui_password_reset,
-    sso_ui_verify_your_email
-)
+    sso_ui_verify_your_email,
+    fab_ui_confirm_identity)
 from tests.functional.registry import get_fabs_page_object
 from tests.functional.utils.generic import (
     detect_page_language,
@@ -810,3 +810,10 @@ def should_see_selected_pages(context: Context, actor_alias: str):
         page = get_fabs_page_object(page_name.lower())
         page.should_be_here(response)
         logging.debug("%s successfully got to '%s' page", actor_alias, page_name)
+
+
+def fab_should_be_asked_about_verification_form(
+        context: Context, supplier_alias: str):
+    fab_ui_confirm_identity.should_be_here(context.response)
+    logging.debug(
+        "%s was asked about the form of identity verification", supplier_alias)

--- a/tests/functional/steps/fab_then_impl.py
+++ b/tests/functional/steps/fab_then_impl.py
@@ -817,3 +817,11 @@ def fab_should_be_asked_about_verification_form(
     fab_ui_confirm_identity.should_be_here(context.response)
     logging.debug(
         "%s was asked about the form of identity verification", supplier_alias)
+
+
+def should_see_message(context: Context, actor_alias: str, message: str):
+    response = context.response
+    with assertion_msg(
+            "Response doesn't contain expetected message: '%s'", message):
+        assert message in response
+    logging.debug("%s saw expected message: '%s'", actor_alias, message)

--- a/tests/functional/steps/fab_then_impl.py
+++ b/tests/functional/steps/fab_then_impl.py
@@ -820,8 +820,8 @@ def fab_should_be_asked_about_verification_form(
 
 
 def should_see_message(context: Context, actor_alias: str, message: str):
-    response = context.response
+    content = context.response.content.decode("utf-8")
     with assertion_msg(
-            "Response doesn't contain expetected message: '%s'", message):
-        assert message in response
+            "Response content doesn't contain expected message: '%s'", message):
+        assert message in content
     logging.debug("%s saw expected message: '%s'", actor_alias, message)

--- a/tests/functional/steps/fab_when_def.py
+++ b/tests/functional/steps/fab_when_def.py
@@ -354,7 +354,7 @@ def when_actor_goes_to_specific_pages(context, actor_alias):
 
 
 @when('"{supplier_alias}" selects sector the company is in and "{preferred}" &'
-      ' "{other}" countries of export')
+      ' "{other}" as other countries of export')
 def when_supplier_select_preferred_countries_of_export(
         context, supplier_alias, preferred, other):
     fab_select_preferred_countries_of_export(

--- a/tests/functional/steps/fab_when_def.py
+++ b/tests/functional/steps/fab_when_def.py
@@ -52,8 +52,8 @@ from tests.functional.steps.fab_when_impl import (
     sso_open_password_reset_link,
     sso_request_password_reset,
     sso_sign_in,
-    sso_supplier_confirms_email_address
-)
+    sso_supplier_confirms_email_address,
+    fab_select_preferred_countries_of_export)
 
 
 @when('"{supplier_alias}" randomly selects an active company without a '
@@ -351,3 +351,10 @@ def when_supplier_goes_sud_page(context, supplier_alias, page_name):
 @when('"{actor_alias}" goes to specific pages')
 def when_actor_goes_to_specific_pages(context, actor_alias):
     go_to_pages(context, actor_alias, context.table)
+
+
+@when('"{supplier_alias}" selects sector the company is in and preferred '
+      'countries of export')
+def when_supplier_select_preferred_countries_of_export(context, supplier_alias):
+    fab_select_preferred_countries_of_export(
+        context, supplier_alias, context.table)

--- a/tests/functional/steps/fab_when_def.py
+++ b/tests/functional/steps/fab_when_def.py
@@ -353,8 +353,9 @@ def when_actor_goes_to_specific_pages(context, actor_alias):
     go_to_pages(context, actor_alias, context.table)
 
 
-@when('"{supplier_alias}" selects sector the company is in and preferred '
-      'countries of export')
-def when_supplier_select_preferred_countries_of_export(context, supplier_alias):
+@when('"{supplier_alias}" selects sector the company is in and "{preferred}" &'
+      ' "{other}" countries of export')
+def when_supplier_select_preferred_countries_of_export(
+        context, supplier_alias, preferred, other):
     fab_select_preferred_countries_of_export(
-        context, supplier_alias, context.table)
+        context, supplier_alias, preferred, other)

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -1821,7 +1821,7 @@ def go_to_pages(context: Context, actor_alias: str, table: Table):
 
 
 def fab_select_preferred_countries_of_export(
-        context: Context, supplier_alias: str, table: Table):
+        context: Context, supplier_alias: str, preferred, other):
     actor = context.get_actor(supplier_alias)
     country_codes = {
         "china": "CN",
@@ -1830,21 +1830,9 @@ def fab_select_preferred_countries_of_export(
         "japan": "JP",
         "united states": "US"
     }
-    results = []
-    for row in table:
-        sector = random.choice(SECTORS)
-        country_names = row["predefined countries"].split(", ")
-        countries = [country_codes[country.lower()] for country in country_names]
-        other = row["other"]
-        error = row["other"] if "other" in row else None
-        response = fab_ui_build_profile_sector.submit(
-            actor, sector, countries, other)
-        result = {
-            "predefined": countries,
-            "other": other,
-            "error": error,
-            "response": response
-        }
-        context.response = response
-        results.append(result)
-    context.results = results
+    sector = random.choice(SECTORS)
+    country_names = preferred.split(", ")
+    countries = [country_codes[country.lower()] for country in country_names]
+    response = fab_ui_build_profile_sector.submit(
+        actor, sector, countries, other)
+    context.response = response

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -330,11 +330,11 @@ def bp_select_random_sector_and_export_to_country(context, supplier_alias):
     """
     actor = context.get_actor(supplier_alias)
     sector = random.choice(SECTORS)
-    country = COUNTRIES[random.choice(list(COUNTRIES))]
+    countries = [COUNTRIES[random.choice(list(COUNTRIES))]]
     other = ""
 
     # Step 1 - Submit the Choose Your Sector form
-    response = fab_ui_build_profile_sector.submit(actor, sector, country, other)
+    response = fab_ui_build_profile_sector.submit(actor, sector, countries, other)
     context.response = response
 
     # Step 2 - check if Supplier is on Confirm Address page

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -1836,22 +1836,11 @@ def go_to_pages(context: Context, actor_alias: str, table: Table):
 
 
 def fab_select_preferred_countries_of_export(
-        context: Context, supplier_alias: str, preferred, other):
+        context: Context, supplier_alias: str, country_names, other_countries):
     actor = context.get_actor(supplier_alias)
-    country_codes = {
-        "china": "CN",
-        "germany": "DE",
-        "india": "IN",
-        "japan": "JP",
-        "united states": "US",
-        "none selected": None,
-        "empty string": ""
-    }
-    value = get_form_value(value_type)
-    sector = random.choice(SECTORS)
-    country_names = preferred.split(", ")
-    countries = [country_codes[country.lower()] for country in country_names]
-    other = "" if other == "empty string" else other
+    country_codes = get_form_value(country_names)
+    other = get_form_value(other_countries)
+    sector = get_form_value("sector")
     response = fab_ui_build_profile_sector.submit(
-        actor, sector, countries, other)
+        actor, sector, country_codes, other)
     context.response = response

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -1631,7 +1631,7 @@ def fab_submit_verification_code(context, supplier_alias):
     context.response = response
 
 
-def get_form_value(key: str) -> str:
+def get_form_value(key: str) -> str or list or int or None:
 
     def get_number_from_key(key: str) -> int:
         numbers = [int(word) for word in key.split() if word.isdigit()]
@@ -1662,7 +1662,9 @@ def get_form_value(key: str) -> str:
         (" characters$", get_n_chars(get_number_from_key(key))),
         (" words$", get_n_words(get_number_from_key(key))),
         (" predefined countries$", get_n_country_codes(get_number_from_key(key))),
-        ("none selected", None)
+        ("1 predefined country$", get_n_country_codes(1)),
+        ("none selected", None),
+        ("sector", random.choice(SECTORS))
     ]
 
     found = False

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -1818,3 +1818,33 @@ def go_to_pages(context: Context, actor_alias: str, table: Table):
         results[page_name] = response
 
     context.results = results
+
+
+def fab_select_preferred_countries_of_export(
+        context: Context, supplier_alias: str, table: Table):
+    actor = context.get_actor(supplier_alias)
+    country_codes = {
+        "china": "CN",
+        "germany": "DE",
+        "india": "IN",
+        "japan": "JP",
+        "united states": "US"
+    }
+    results = []
+    for row in table:
+        sector = random.choice(SECTORS)
+        country_names = row["predefined countries"].split(", ")
+        countries = [country_codes[country.lower()] for country in country_names]
+        other = row["other"]
+        error = row["other"] if "other" in row else None
+        response = fab_ui_build_profile_sector.submit(
+            actor, sector, countries, other)
+        result = {
+            "predefined": countries,
+            "other": other,
+            "error": error,
+            "response": response
+        }
+        context.response = response
+        results.append(result)
+    context.results = results

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -1828,11 +1828,14 @@ def fab_select_preferred_countries_of_export(
         "germany": "DE",
         "india": "IN",
         "japan": "JP",
-        "united states": "US"
+        "united states": "US",
+        "none selected": None,
+        "empty string": ""
     }
     sector = random.choice(SECTORS)
     country_names = preferred.split(", ")
     countries = [country_codes[country.lower()] for country in country_names]
+    other = "" if other == "empty string" else other
     response = fab_ui_build_profile_sector.submit(
         actor, sector, countries, other)
     context.response = response

--- a/tests/functional/utils/generic.py
+++ b/tests/functional/utils/generic.py
@@ -108,7 +108,6 @@ def init_loggers(context: Context):
     context.config.setup_logging(handlers=[log_file_handler])
 
 
-
 def decode_as_utf8(content):
     """Try to decode provided content as UTF-8
 
@@ -436,7 +435,6 @@ def extract_password_reset_link(payload: str) -> str:
         assert "accounts/password/reset/key/" in password_reset_link
     logging.debug("Found password reset link: %s", password_reset_link)
     return password_reset_link
-
 
 
 def get_absolute_path_of_file(filename):

--- a/tests/functional/utils/request.py
+++ b/tests/functional/utils/request.py
@@ -200,4 +200,3 @@ def check_response(response: Response, status_code: int, *,
                 "Expected Location header to start with: '%s' but got '%s' "
                 "instead.", location_starts_with, new_location):
             assert new_location.startswith(location_starts_with)
-


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-1952).
This PR also contains a scenario for [bug ED-2313](https://uktrade.atlassian.net/browse/ED-2313)

Scenario:
```gherkin
  @ED-1952
  @profile
  @export-preferences
  Scenario Outline: Suppliers can select preferred countries of export from the given list and provide a list of other countries
    Given "Annette Geissinger" is an unauthenticated supplier
    And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
    And "Annette Geissinger" confirmed her email address

    When "Annette Geissinger" provides valid details of selected company
    And "Annette Geissinger" selects sector the company is in and "<preferred>" & "<other>" as other countries of export

    Then "Annette Geissinger" should be asked to decide how to verify her identity

    Examples:
      | preferred              | other                 |
      | 3 predefined countries | empty string          |
      | 5 predefined countries | Canada, Poland, Italy |


  @ED-1952
  @profile
  @export-preferences
  Scenario Outline: Suppliers have to provide preferred country of export when building up the profile
    Given "Annette Geissinger" is an unauthenticated supplier
    And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
    And "Annette Geissinger" confirmed her email address

    When "Annette Geissinger" provides valid details of selected company
    And "Annette Geissinger" selects sector the company is in and "<preferred>" & "<other>" as other countries of export

    Then "Annette Geissinger" should see "<error>" message

    Examples:
      | preferred            | other           | error                                                        |
      | 1 predefined country | 1001 characters | Ensure this value has at most 1000 characters (it has 1001). |
      | none selected        | empty string    | This field is required.                                      |


  @ED-1952
  @profile
  @export-preferences
  @bug
  @ED-2313
  @fixme
  Scenario Outline: Suppliers have to use commas to separate other preferred countries of export when building up the profile
    Given "Annette Geissinger" is an unauthenticated supplier
    And "Annette Geissinger" created a SSO/great.gov.uk account associated with randomly selected company "Company X"
    And "Annette Geissinger" confirmed her email address

    When "Annette Geissinger" provides valid details of selected company
    And "Annette Geissinger" selects sector the company is in and "<preferred>" & "<other>" as other countries of export

    Then "Annette Geissinger" should see "<error>" message

    Examples:
      | preferred     | other                 | error                                  |
      | none selected | Canada; Poland; Italy | You can only enter letters and commas. |
      | none selected | Canada.Poland.Italy   | You can only enter letters and commas. |
```
