### PR TITLE
ED-2467 guidance banner

### DIFF
--- a/tests/exred/features/guidance.feature
+++ b/tests/exred/features/guidance.feature
@@ -85,7 +85,6 @@ Feature: Guidance articles
       | Getting paid      |
 
 
-  @wip
   @ED-2467
   @banner
   @<category>
@@ -93,8 +92,8 @@ Feature: Guidance articles
   Scenario Outline: Guidance Banner should be visible when on "<category>" Guidance Article List accessed via "<location>"
     Given "Robert" accessed "<category>" guidance articles using "<location>"
 
-    Then "Robert" should see the Guidance Category Banner
-    And "Robert" should see that the banner tile for "guidance_category" category is highlighted
+    Then "Robert" should see the Guidance Navigation Ribbon
+    And "Robert" should see that the banner tile for "<category>" category is highlighted
 
     Examples: header menu
       | category                  | location    |

--- a/tests/exred/features/guidance.feature
+++ b/tests/exred/features/guidance.feature
@@ -88,17 +88,37 @@ Feature: Guidance articles
   @wip
   @ED-2467
   @banner
-  Scenario Outline: Guidance Banner should be visible when on Guidance Article List
-    Given "Robert" accessed "<guidance_category>" guidance articles using "<guidance_menu_location>"
+  @<category>
+  @<location>
+  Scenario Outline: Guidance Banner should be visible when on "<category>" Guidance Article List accessed via "<location>"
+    Given "Robert" accessed "<category>" guidance articles using "<location>"
 
     Then "Robert" should see the Guidance Category Banner
     And "Robert" should see that the banner tile for "guidance_category" category is highlighted
 
-    Examples:
-      | guidance_category | guidance_menu_location |
-      | Market research   | header menu            |
-      | Customer insight  | home page              |
-      | Finance           | personalised page      |
-      | Business planning | footer links           |
-      | Getting paid      | ....                   |
+    Examples: header menu
+      | category                  | location    |
+      | Market research           | header menu |
+      | Customer insight          | header menu |
+      | Finance                   | header menu |
+      | Business planning         | header menu |
+      | Getting paid              | header menu |
+      | Operations and Compliance | header menu |
 
+    Examples: footer links
+      | category                  | location     |
+      | Market research           | footer links |
+      | Customer insight          | footer links |
+      | Finance                   | footer links |
+      | Business planning         | footer links |
+      | Getting paid              | footer links |
+      | Operations and Compliance | footer links |
+
+    Examples: home page
+      | category                  | location  |
+      | Market research           | home page |
+      | Customer insight          | home page |
+      | Finance                   | home page |
+      | Business planning         | home page |
+      | Getting paid              | home page |
+      | Operations and Compliance | home page |

--- a/tests/exred/features/guidance.feature
+++ b/tests/exred/features/guidance.feature
@@ -1,0 +1,104 @@
+@guidance
+Feature: Guidance articles
+
+  @wip
+  @ED-2463
+  @home-page
+  @articles
+  Scenario Outline: Any Exporter should get to a relevant article list from Guidance section on the homepage
+    Given "Robert" is interested in "<guidance_category>" guidance
+
+    When "Robert" goes to the relevant "<guidance_category>" link in the Guidance section on the homepage
+
+    Then "Robert" should see an ordered list of all articles  selected for "<guidance_category>" + "next category"
+    And "Robert" should see a Articles Read counter, Total number of Articles and Time to complete remaining chapters
+    And "Robert" should see a link to the next Guidance category
+
+    Examples:
+      | guidance_category |
+      | Market research   |
+      | Customer insight  |
+      | Finance           |
+      | Business planning |
+      | Getting paid      |
+
+
+  @wip
+  @ED-2464
+  @home-page
+  @articles
+  Scenario Outline: Any Exporter should see article read count for each tile in the Guidance section on the homepage
+    Given "Robert" visits the home page
+
+    When "Robert" sees "<guidance_category>" tile in the Guidance section on the homepage
+
+    Then "Robert" should see an article read count for the "<guidance_category>"
+
+    Examples:
+      | guidance_category |
+      | Market research   |
+      | Customer insight  |
+      | Finance           |
+      | Business planning |
+      | Getting paid      |
+
+
+  @wip
+  @ED-2465
+  @personalised-page
+  @articles
+  Scenario Outline: Regular Exporter should see article read count for each tile in the Guidance section on the personalised page
+    Given "Nadia" visits the personalised page
+
+    When "Nadia" sees "<guidance_category>" tile in the Guidance section on the homepage
+
+    Then "Nadia" should see an article read count for the "<guidance_category>"
+
+    Examples:
+      | guidance_category |
+      | Market research   |
+      | Customer insight  |
+      | Finance           |
+      | Business planning |
+      | Getting paid      |
+
+
+  @wip
+  @ED-2466
+  @personalised-page
+  @articles
+  Scenario Outline: Regular Exporter should get to a relevant article list from Guidance section on the personalised page
+    Given "Nadia" is interested in "<guidance_category>" guidance
+
+    When "Nadia" goes to the relevant "<guidance_category>" link in the Guidance section on the personalised page
+
+    Then "Nadia" should see an ordered list of all articles  selected for "<guidance_category>" + "next category"
+    And "Nadia" should see a Articles Read counter, Total number of Articles and Time to complete remaining chapters
+    And "Nadia" should see a link to the next Guidance category
+
+    Examples:
+      | guidance_category |
+      | Market research   |
+      | Customer insight  |
+      | Finance           |
+      | Business planning |
+      | Getting paid      |
+
+
+  @wip
+  @ED-2467
+  @banner
+  Scenario Outline: Guidance Banner should be visible when on Guidance Article List
+    Given "Robert" accessed "<guidance_category>" guidance articles using "<guidance_menu_location>"
+
+    Then "Robert" should see the Guidance Category Banner
+    And "Robert" should see that the banner tile for "guidance_category" category is highlighted
+
+    Examples:
+      | guidance_category | guidance_menu_location |
+      | Market research   | header menu            |
+      | Customer insight  | home page              |
+      | Finance           | personalised page      |
+      | Business planning | footer links           |
+      | Getting paid      | ....                   |
+

--- a/tests/exred/pages/footer.py
+++ b/tests/exred/pages/footer.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""ExRed Footer Page Object."""
+import logging
+
+from selenium import webdriver
+
+from utils import assertion_msg, selenium_action, take_screenshot
+
+NAME = "ExRed Footer"
+URL = None
+
+SECTIONS = {
+    "export readiness": {
+        "label": "#footer-links-2",
+        "i'm new to exporting": "#footer-links-2  ~ ul > li:nth-child(1) > a",
+        "i export occasionally": "#footer-links-2  ~ ul > li:nth-child(2) > a",
+        "i'm a regular exporter": "#footer-links-2  ~ ul > li:nth-child(3) > a"
+    },
+    "guidance": {
+        "label": "#footer-links-3",
+        "market research": "#footer-links-3  ~ ul a[href='/market-research']",
+        "customer insight": "#footer-links-3  ~ ul a[href='/customer-insight']",
+        "finance": "#footer-links-3  ~ ul a[href='/finance']",
+        "business planning": "#footer-links-3  ~ ul a[href='/business-planning']",
+        "getting paid": "#footer-links-3  ~ ul a[href='/getting-paid']",
+        "operations and compliance": "#footer-links-3  ~ ul a[href='/operations-and-compliance']"
+    },
+    "services": {
+        "label": "#footer-links-4",
+        "export opportunities": "#footer-links-4  ~ ul > li:nth-child(1) > a",
+        "selling online overseas": "#footer-links-4  ~ ul > li:nth-child(2) > a",
+        "find a buyer": "#footer-links-4  ~ ul > li:nth-child(3) > a",
+        "get finance": "#footer-links-4  ~ ul > li:nth-child(4) > a",
+        "events": "#footer-links-4  ~ ul > li:nth-child(5) > a"
+    },
+    "general links": {
+        "part of great.gov.uk": "#footer > .site-links > ul > li:nth-child(1) > a",
+        "about": "#footer > .site-links > ul > li:nth-child(2) > a",
+        "contact us": "#footer > .site-links > ul > li:nth-child(3) > a",
+        "privacy and cookies": "#footer > .site-links > ul > li:nth-child(4) > a",
+        "terms and conditions": "#footer > .site-links > ul > li:nth-child(5) > a",
+        "department for international trade": "#footer > .site-links > ul > li:nth-child(6) > a"
+    }
+}
+
+
+def should_see_all_menus(driver: webdriver):
+    for section in SECTIONS:
+        for name, selector in SECTIONS[section].items():
+            logging.debug(
+                "Looking for '%s' link in '%s' section with '%s' selector",
+                name, section, selector)
+            with selenium_action(
+                    driver, "Could not find '%s link' using '%s'",
+                    name, selector):
+                element = driver.find_element_by_css_selector(selector)
+            with assertion_msg(
+                    "It looks like '%s' in '%s' section is not visible",
+                    name, section):
+                assert element.is_displayed()
+        logging.debug("All elements in '%s' section are visible", section)
+    logging.debug(
+        "All expected sections on %s are visible", NAME)
+
+
+def open(driver: webdriver, group: str, element: str):
+    link = SECTIONS[group.lower()][element.lower()]
+    button = driver.find_element_by_css_selector(link)
+    assert button.is_displayed()
+    button.click()
+    take_screenshot(
+        driver, NAME + " after clicking on: %s link".format(element))

--- a/tests/exred/pages/guidance_common.py
+++ b/tests/exred/pages/guidance_common.py
@@ -34,3 +34,14 @@ def ribbon_should_be_visible(driver: webdriver):
                 "It looks like '%s' is not visible", element_name):
             assert element.is_displayed()
     take_screenshot(driver, NAME + " Ribbon")
+
+
+def ribbon_tile_should_be_highlighted(driver: webdriver, tile: str):
+    tile_selector = RIBBON[tile.lower()]
+    with selenium_action(driver, "Could not find '%s' tile", tile):
+        tile_link = driver.find_element_by_css_selector(tile_selector)
+        tile_class = tile_link.get_attribute("class")
+    with assertion_msg(
+            "It looks like '%s' tile is not active (it's class is %s)",
+            tile, tile_class):
+        assert tile_class == "active"

--- a/tests/exred/pages/guidance_common.py
+++ b/tests/exred/pages/guidance_common.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""ExRed Common Guidance Page Object."""
+import logging
+
+from selenium import webdriver
+
+from utils import assertion_msg, selenium_action, take_screenshot
+
+NAME = "ExRed Common Guidance"
+URL = None
+
+
+RIBBON = {
+    "itself": ".navigation-ribbon",
+    "market research": ".navigation-ribbon a[href='/market-research']",
+    "customer insight": ".navigation-ribbon a[href='/customer-insight']",
+    "finance": ".navigation-ribbon a[href='/finance']",
+    "business planning": ".navigation-ribbon a[href='/business-planning']",
+    "getting paid": ".navigation-ribbon a[href='/getting-paid']",
+    "operations and compliance": ".navigation-ribbon a[href='/operations-and-compliance']"
+}
+
+
+def ribbon_should_be_visible(driver: webdriver):
+    for element_name, element_selector in RIBBON.items():
+        logging.debug(
+            "Looking for Ribbon '%s' element with '%s' selector",
+            element_name, element_selector)
+        with selenium_action(
+                driver, "Could not find '%s' using '%s'", element_name,
+                element_selector):
+            element = driver.find_element_by_css_selector(element_selector)
+        with assertion_msg(
+                "It looks like '%s' is not visible", element_name):
+            assert element.is_displayed()
+    take_screenshot(driver, NAME + " Ribbon")

--- a/tests/exred/pages/header.py
+++ b/tests/exred/pages/header.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 """ExRed Header Page Object."""
 import logging
+from collections import OrderedDict
 
 from selenium import webdriver
+from selenium.webdriver import ActionChains
 
 from utils import assertion_msg, selenium_action, take_screenshot
 
@@ -11,30 +13,32 @@ URL = None
 
 
 HOME_LINK = "#menu > ul > li:nth-child(1) > a"
+# some sections contain an OrderedDict, this is because of the quirky browser
+# behaviour when dealing with JS menus. Please refer to open() for more details
 SECTIONS = {
-    "export readiness": {
-        "menu": "#nav-export-readiness",
-        "i'm new to exporting": "#nav-export-readiness-list a[href='/new']",
-        "i export occasionally": "#nav-export-readiness-list a[href='/occasional']",
-        "i'm a regular exporter": "#nav-export-readiness-list a[href='/regular']"
-    },
-    "guidance": {
-        "menu": "#nav-guidance",
-        "market research": "#nav-guidance-list  a[href='/market-research']",
-        "customer insight": "#nav-guidance-list  a[href='/customer-insight']",
-        "finance": "#nav-guidance-list  a[href='/finance']",
-        "business planning": "#nav-guidance-list  a[href='/business-planning']",
-        "getting paid": "#nav-guidance-list  a[href='/getting-paid']",
-        "operations and compliance": "#nav-guidance-list  a[href='/operations-and-compliance']"
-    },
-    "services": {
-        "menu": "#nav-services",
-        "find a buyer": "#nav-services-list > li:nth-child(1) > a",
-        "selling online overseas": "#nav-services-list > li:nth-child(2) > a",
-        "export opportunities": "#nav-services-list > li:nth-child(3) > a",
-        "get finance": "#nav-services-list > li:nth-child(4) > a",
-        "events": "#nav-services-list > li:nth-child(5) > a"
-    },
+    "export readiness": OrderedDict([
+        ("menu", "#nav-export-readiness"),
+        ("i'm new to exporting", "#nav-export-readiness-list a[href='/new']"),
+        ('i export occasionally', "#nav-export-readiness-list a[href='/occasional']"),
+        ("i'm a regular exporter", "#nav-export-readiness-list a[href='/regular']")
+    ]),
+    "guidance": OrderedDict([
+        ("menu", "#nav-guidance"),
+        ("market research", "#nav-guidance-list  a[href='/market-research']"),
+        ("customer insight", "#nav-guidance-list  a[href='/customer-insight']"),
+        ("finance", "#nav-guidance-list  a[href='/finance']"),
+        ("business planning", "#nav-guidance-list  a[href='/business-planning']"),
+        ("getting paid", "#nav-guidance-list  a[href='/getting-paid']"),
+        ("operations and compliance", "#nav-guidance-list  a[href='/operations-and-compliance']")
+    ]),
+    "services": OrderedDict([
+        ("menu", "#nav-services"),
+        ("find a buyer", "#nav-services-list > li:nth-child(1) > a"),
+        ("selling online overseas", "#nav-services-list > li:nth-child(2) > a"),
+        ("export opportunities", "#nav-services-list > li:nth-child(3) > a"),
+        ("get finance", "#nav-services-list > li:nth-child(4) > a"),
+        ("events", "#nav-services-list > li:nth-child(5) > a)")
+    ]),
     "government links": {
         "part of great.gov.uk": "#header-bar > div > p > a"
     },
@@ -65,18 +69,37 @@ def should_see_all_links(driver: webdriver):
 
 
 def open(driver: webdriver, group: str, element: str):
+    """Open specific element that belongs to the group.
+
+    NOTE:
+    Some browsers (Firefox & IE) can cause problems when dealing with JS menus.
+    In order to move the cursor to the correct menu element before clicking on
+    it, the driver needs to be instructed to move the cursor to a visible menu
+    element that is not diagonally positioned in respect to the main menu.
+    It's because "moving" the cursor diagonally can cause driver to "lose"
+    the focus of the menu and which will make menu to fold.
+    """
     if "menu" in SECTIONS[group.lower()]:
         menu_selector = SECTIONS[group.lower()]["menu"]
         menu = driver.find_element_by_css_selector(menu_selector)
-        menu.is_displayed()
-        menu.click()
-        take_screenshot(
-            driver, NAME + " after clicking on '%s' menu".format(group))
-    link_selector = SECTIONS[group.lower()][element.lower()]
-    with selenium_action(
-            driver, "Could not find '%s' menu '%s' link", group, element):
-        link = driver.find_element_by_css_selector(link_selector)
-    assert link.is_displayed()
-    link.click()
+
+        last_menu_item_name = next(reversed(SECTIONS[group.lower()]))
+        last_menu_selector = SECTIONS[group.lower()][last_menu_item_name]
+        last_menu_item = driver.find_element_by_css_selector(last_menu_selector)
+
+        menu_item_selector = SECTIONS[group.lower()][element.lower()]
+        menu_item = driver.find_element_by_css_selector(menu_item_selector)
+
+        actions = ActionChains(driver)
+        actions.move_to_element(menu)
+        if menu_item_selector != last_menu_selector:
+            actions.move_to_element(last_menu_item)
+        actions.click(menu_item)
+        actions.perform()
+    else:
+        menu_item_selector = SECTIONS[group.lower()][element.lower()]
+        menu_item = driver.find_element_by_css_selector(menu_item_selector)
+        assert menu_item.is_displayed()
+        menu_item.click()
     take_screenshot(
         driver, NAME + " after clicking on: %s link".format(element))

--- a/tests/exred/pages/header.py
+++ b/tests/exred/pages/header.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 """ExRed Header Page Object."""
 import logging
-from collections import OrderedDict
 
 from selenium import webdriver
-from selenium.webdriver import ActionChains
+from selenium.webdriver.common.keys import Keys
 
 from utils import assertion_msg, selenium_action, take_screenshot
 
@@ -13,32 +12,30 @@ URL = None
 
 
 HOME_LINK = "#menu > ul > li:nth-child(1) > a"
-# some sections contain an OrderedDict, this is because of the quirky browser
-# behaviour when dealing with JS menus. Please refer to open() for more details
 SECTIONS = {
-    "export readiness": OrderedDict([
-        ("menu", "#nav-export-readiness"),
-        ("i'm new to exporting", "#nav-export-readiness-list a[href='/new']"),
-        ('i export occasionally', "#nav-export-readiness-list a[href='/occasional']"),
-        ("i'm a regular exporter", "#nav-export-readiness-list a[href='/regular']")
-    ]),
-    "guidance": OrderedDict([
-        ("menu", "#nav-guidance"),
-        ("market research", "#nav-guidance-list  a[href='/market-research']"),
-        ("customer insight", "#nav-guidance-list  a[href='/customer-insight']"),
-        ("finance", "#nav-guidance-list  a[href='/finance']"),
-        ("business planning", "#nav-guidance-list  a[href='/business-planning']"),
-        ("getting paid", "#nav-guidance-list  a[href='/getting-paid']"),
-        ("operations and compliance", "#nav-guidance-list  a[href='/operations-and-compliance']")
-    ]),
-    "services": OrderedDict([
-        ("menu", "#nav-services"),
-        ("find a buyer", "#nav-services-list > li:nth-child(1) > a"),
-        ("selling online overseas", "#nav-services-list > li:nth-child(2) > a"),
-        ("export opportunities", "#nav-services-list > li:nth-child(3) > a"),
-        ("get finance", "#nav-services-list > li:nth-child(4) > a"),
-        ("events", "#nav-services-list > li:nth-child(5) > a)")
-    ]),
+    "export readiness": {
+        "menu": "#nav-export-readiness",
+        "i'm new to exporting": "#nav-export-readiness-list a[href='/new']",
+        'i export occasionally': "#nav-export-readiness-list a[href='/occasional']",
+        "i'm a regular exporter": "#nav-export-readiness-list a[href='/regular']"
+    },
+    "guidance": {
+        "menu": "#nav-guidance",
+        "market research": "#nav-guidance-list  a[href='/market-research']",
+        "customer insight": "#nav-guidance-list  a[href='/customer-insight']",
+        "finance": "#nav-guidance-list  a[href='/finance']",
+        "business planning": "#nav-guidance-list  a[href='/business-planning']",
+        "getting paid": "#nav-guidance-list  a[href='/getting-paid']",
+        "operations and compliance": "#nav-guidance-list  a[href='/operations-and-compliance']"
+    },
+    "services": {
+        "menu": "#nav-services",
+        "find a buyer": "#nav-services-list > li:nth-child(1) > a",
+        "selling online overseas": "#nav-services-list > li:nth-child(2) > a",
+        "export opportunities": "#nav-services-list > li:nth-child(3) > a",
+        "get finance": "#nav-services-list > li:nth-child(4) > a",
+        "events": "#nav-services-list > li:nth-child(5) > a"
+    },
     "government links": {
         "part of great.gov.uk": "#header-bar > div > p > a"
     },
@@ -80,26 +77,13 @@ def open(driver: webdriver, group: str, element: str):
     the focus of the menu and which will make menu to fold.
     """
     if "menu" in SECTIONS[group.lower()]:
+        # Open the menu by sending "Down Arrow" key
         menu_selector = SECTIONS[group.lower()]["menu"]
         menu = driver.find_element_by_css_selector(menu_selector)
-
-        last_menu_item_name = next(reversed(SECTIONS[group.lower()]))
-        last_menu_selector = SECTIONS[group.lower()][last_menu_item_name]
-        last_menu_item = driver.find_element_by_css_selector(last_menu_selector)
-
-        menu_item_selector = SECTIONS[group.lower()][element.lower()]
-        menu_item = driver.find_element_by_css_selector(menu_item_selector)
-
-        actions = ActionChains(driver)
-        actions.move_to_element(menu)
-        if menu_item_selector != last_menu_selector:
-            actions.move_to_element(last_menu_item)
-        actions.click(menu_item)
-        actions.perform()
-    else:
-        menu_item_selector = SECTIONS[group.lower()][element.lower()]
-        menu_item = driver.find_element_by_css_selector(menu_item_selector)
-        assert menu_item.is_displayed()
-        menu_item.click()
+        menu.send_keys(Keys.DOWN)
+    menu_item_selector = SECTIONS[group.lower()][element.lower()]
+    menu_item = driver.find_element_by_css_selector(menu_item_selector)
+    assert menu_item.is_displayed()
+    menu_item.click()
     take_screenshot(
-        driver, NAME + " after clicking on: %s link".format(element))
+        driver, NAME + " after clicking on: {} link".format(element))

--- a/tests/exred/pages/header.py
+++ b/tests/exred/pages/header.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""ExRed Header Page Object."""
+import logging
+
+from selenium import webdriver
+
+from utils import assertion_msg, selenium_action, take_screenshot
+
+NAME = "ExRed Header"
+URL = None
+
+
+HOME_LINK = "#menu > ul > li:nth-child(1) > a"
+SECTIONS = {
+    "export readiness": {
+        "menu": "#nav-export-readiness",
+        "i'm new to exporting": "#nav-export-readiness-list a[href='/new']",
+        "i export occasionally": "#nav-export-readiness-list a[href='/occasional']",
+        "i'm a regular exporter": "#nav-export-readiness-list a[href='/regular']"
+    },
+    "guidance": {
+        "menu": "#nav-guidance",
+        "market research": "#nav-guidance-list  a[href='/market-research']",
+        "customer insight": "#nav-guidance-list  a[href='/customer-insight']",
+        "finance": "#nav-guidance-list  a[href='/finance']",
+        "business planning": "#nav-guidance-list  a[href='/business-planning']",
+        "getting paid": "#nav-guidance-list  a[href='/getting-paid']",
+        "operations and compliance": "#nav-guidance-list  a[href='/operations-and-compliance']"
+    },
+    "services": {
+        "menu": "#nav-services",
+        "find a buyer": "#nav-services-list > li:nth-child(1) > a",
+        "selling online overseas": "#nav-services-list > li:nth-child(2) > a",
+        "export opportunities": "#nav-services-list > li:nth-child(3) > a",
+        "get finance": "#nav-services-list > li:nth-child(4) > a",
+        "events": "#nav-services-list > li:nth-child(5) > a"
+    },
+    "government links": {
+        "part of great.gov.uk": "#header-bar > div > p > a"
+    },
+    "account links": {
+        "register": "#header-bar .account-links li:nth-child(1) > a",
+        "sign in": "#header-bar .account-links li:nth-child(2) > a"
+    }
+}
+
+
+def should_see_all_links(driver: webdriver):
+    for section in SECTIONS:
+        for element_name, element_selector in SECTIONS[section].items():
+            logging.debug(
+                "Looking for '%s' element in '%s' section with '%s' selector",
+                element_name, section, element_selector)
+            with selenium_action(
+                    driver, "Could not find '%s' using '%s'", element_name,
+                    element_selector):
+                element = driver.find_element_by_css_selector(element_selector)
+            with assertion_msg(
+                    "It looks like '%s' in '%s' section is not visible",
+                    element_name, section):
+                assert element.is_displayed()
+        logging.debug("All elements in '%s' section are visible", section)
+    logging.debug(
+        "All expected sections on %s are visible", NAME)
+
+
+def open(driver: webdriver, group: str, element: str):
+    if "menu" in SECTIONS[group.lower()]:
+        menu_selector = SECTIONS[group.lower()]["menu"]
+        menu = driver.find_element_by_css_selector(menu_selector)
+        menu.is_displayed()
+        menu.click()
+        take_screenshot(
+            driver, NAME + " after clicking on '%s' menu".format(group))
+    link_selector = SECTIONS[group.lower()][element.lower()]
+    with selenium_action(
+            driver, "Could not find '%s' menu '%s' link", group, element):
+        link = driver.find_element_by_css_selector(link_selector)
+    assert link.is_displayed()
+    link.click()
+    take_screenshot(
+        driver, NAME + " after clicking on: %s link".format(element))

--- a/tests/exred/pages/home.py
+++ b/tests/exred/pages/home.py
@@ -136,3 +136,12 @@ def start_exporting_journey(driver: webdriver):
     button = driver.find_element_by_css_selector(GET_STARTED_BUTTON)
     assert button.is_displayed()
     button.click()
+
+
+def open(driver: webdriver, group: str, element: str):
+    selector = SECTIONS[group.lower()][element.lower()]
+    link = driver.find_element_by_css_selector(selector)
+    assert link.is_displayed()
+    link.click()
+    take_screenshot(
+        driver, NAME + " after clicking on: %s link".format(element))

--- a/tests/exred/pages/home.py
+++ b/tests/exred/pages/home.py
@@ -20,58 +20,66 @@ ONLINE_MARKETPLACES_SERVICE_LINK = "#services div:nth-child(2) > article > a"
 EXPORT_OPPORTUNITIES_SERVICE_LINK = "#services div:nth-child(3) > article > a"
 CAROUSEL_PREVIOUS_BUTTON = "#carousel label.ed-carousel__control--backward"
 CAROUSEL_NEXT_BUTTON = "#carousel label.ed-carousel__control--forward"
-SECTION_VIDEO = {
-    "itself": "#content > section.hero-section",
-    "teaser": "#content > section.hero-section div.hero-teaser",
-    "teaser_title": "#content > section.hero-section div.hero-teaser h1.title",
-    "teaser_logo": "#content > section.hero-section div.hero-teaser img",
-}
-SECTION_EXPORTING_JOURNEY = {
-    "itself": "#content > section.triage.triage-section",
-    "heading": "#content > section.triage.triage-section .heading",
-    "introduction": "#content > section.triage.triage-section .intro",
-    "get_started_button": GET_STARTED_BUTTON,
-    "image": "#content > section.triage.triage-section .container > img"
-}
-SECTION_PERSONAS = {
-    "itself": "#personas",
-    "header": "#personas > .container > .header",
-    "intro": "#personas > .container > .intro",
-    "groups": "#personas > .container > .group",
-    "new_to_exporting_link": NEW_TO_EXPORTING_LINK,
-    "occasional_exporter_link": OCCASIONAL_EXPORTER_LINK,
-    "regular_exported_link": REGULAR_EXPORTED_LINK,
-}
-SECTION_GUIDANCE = {
-    "itself": "#resource-guidance",
-    "header": "#resource-guidance > .container .section-header",
-    "intro": "#resource-guidance > .container .section-intro",
-    "groups": "#resource-guidance > .container .group",
-    "market_research_group": "#resource-guidance .group .market-research",
-    "customer_insight_group": "#resource-guidance .group .customer-insight",
-    "finance_group": "#resource-guidance .group .finance",
-    "business_planning_group": "#resource-guidance .group .business-planning",
-    "getting_paid_group": "#resource-guidance .group .getting-paid",
-    "operations_and_compliance_group":
-        "#resource-guidance .group .operations-and-compliance",
-}
-SECTION_SERVICES = {
-    "itself": "#services",
-    "intro": "#services .intro",
-    "groups": "#services .group",
-    "find_a_buyer_service": "#services div:nth-child(1) > article",
-    "online_marketplaces_service": "#services div:nth-child(2) > article",
-    "export_opportunities_service": "#services div:nth-child(3) > article",
-    "find_a_buyer_service_link": FIND_A_BUYER_SERVICE_LINK,
-    "online_marketplaces_service_link": ONLINE_MARKETPLACES_SERVICE_LINK,
-    "export_opportunities_service_link": EXPORT_OPPORTUNITIES_SERVICE_LINK,
-}
-SECTION_CASE_STUDIES = {
-    "itself": "#carousel",
-    "heading": "#carousel .heading",
-    "intro": "#carousel .intro",
-    "carousel_previous_button": CAROUSEL_PREVIOUS_BUTTON,
-    "carousel_next_button": CAROUSEL_NEXT_BUTTON
+MARKET_RESEARCH_LINK = "#resource-guidance a[href='/market-research']"
+CUSTOMER_INSIGHT_LINK = "#resource-guidance a[href='/customer-insight']"
+FINANCE_LINK = "#resource-guidance a[href='/finance']"
+BUSINESS_LINK = "#resource-guidance a[href='/business-planning']"
+GETTING_PAID_LINK = "#resource-guidance a[href='/getting-paid']"
+OPERATIONS_AND_COMPLIANCE_LINK = "#resource-guidance a[href='/operations-and-compliance']"
+
+SECTIONS = {
+    "video": {
+        "itself": "#content > section.hero-section",
+        "teaser": "#content > section.hero-section div.hero-teaser",
+        "teaser_title": "#content > section.hero-section div.hero-teaser h1.title",
+        "teaser_logo": "#content > section.hero-section div.hero-teaser img",
+    },
+    "exporting_journey": {
+        "itself": "#content > section.triage.triage-section",
+        "heading": "#content > section.triage.triage-section .heading",
+        "introduction": "#content > section.triage.triage-section .intro",
+        "get_started_button": GET_STARTED_BUTTON,
+        "image": "#content > section.triage.triage-section .container > img"
+    },
+    "personas": {
+        "itself": "#personas",
+        "header": "#personas > .container > .header",
+        "intro": "#personas > .container > .intro",
+        "groups": "#personas > .container > .group",
+        "new_to_exporting_link": NEW_TO_EXPORTING_LINK,
+        "occasional_exporter_link": OCCASIONAL_EXPORTER_LINK,
+        "regular_exported_link": REGULAR_EXPORTED_LINK,
+    },
+    "guidance": {
+        "itself": "#resource-guidance",
+        "header": "#resource-guidance > .container .section-header",
+        "intro": "#resource-guidance > .container .section-intro",
+        "groups": "#resource-guidance > .container .group",
+        "market research": MARKET_RESEARCH_LINK,
+        "customer insight": CUSTOMER_INSIGHT_LINK,
+        "finance": FINANCE_LINK,
+        "business planning": BUSINESS_LINK,
+        "getting paid": GETTING_PAID_LINK,
+        "operations and compliance": OPERATIONS_AND_COMPLIANCE_LINK,
+    },
+    "services": {
+        "itself": "#services",
+        "intro": "#services .intro",
+        "groups": "#services .group",
+        "find_a_buyer_service": "#services div:nth-child(1) > article",
+        "online_marketplaces_service": "#services div:nth-child(2) > article",
+        "export_opportunities_service": "#services div:nth-child(3) > article",
+        "find_a_buyer_service_link": FIND_A_BUYER_SERVICE_LINK,
+        "online_marketplaces_service_link": ONLINE_MARKETPLACES_SERVICE_LINK,
+        "export_opportunities_service_link": EXPORT_OPPORTUNITIES_SERVICE_LINK,
+    },
+    "case_studies": {
+        "itself": "#carousel",
+        "heading": "#carousel .heading",
+        "intro": "#carousel .intro",
+        "carousel_previous_button": CAROUSEL_PREVIOUS_BUTTON,
+        "carousel_next_button": CAROUSEL_NEXT_BUTTON
+    }
 }
 
 
@@ -97,14 +105,6 @@ def should_see_sections(driver: webdriver, section_names: list):
     :param driver: Any Selenium Driver (Remote, Chrome, Firefox, PhantomJS etc.
     :param section_names: list of page section to check
     """
-    sections = {
-        "video": SECTION_VIDEO,
-        "exporting_journey": SECTION_EXPORTING_JOURNEY,
-        "personas": SECTION_PERSONAS,
-        "guidance": SECTION_GUIDANCE,
-        "services": SECTION_SERVICES,
-        "case_studies": SECTION_CASE_STUDIES
-    }
     browser = "%s v:%s %s" % (driver.capabilities.get("browserName",
                                                       "unknown browse"),
                               driver.capabilities.get("version",
@@ -112,7 +112,7 @@ def should_see_sections(driver: webdriver, section_names: list):
                               driver.capabilities.get("platform",
                                                       "unknown platform"))
     for section_name in section_names:
-        section = sections[section_name.lower().replace(" ", "_")]
+        section = SECTIONS[section_name.lower().replace(" ", "_")]
         for element_name, element_selector in section.items():
             logging.debug(
                 "Looking for '%s' element in '%s' section with '%s' selector",

--- a/tests/exred/pages/triage_result.py
+++ b/tests/exred/pages/triage_result.py
@@ -40,7 +40,7 @@ def should_be_here(driver: webdriver):
 
 def get_classification(driver: webdriver) -> str:
     element = driver.find_element_by_css_selector(CLASSIFICATION)
-    return element.text
+    return element.text.lower()
 
 
 def should_be_classified_as(driver: webdriver, expected: str):
@@ -52,15 +52,15 @@ def should_be_classified_as(driver: webdriver, expected: str):
 
 
 def should_be_classified_as_new(driver: webdriver):
-    should_be_classified_as(driver, "New Exporter")
+    should_be_classified_as(driver, "new exporter")
 
 
 def should_be_classified_as_occasional(driver: webdriver):
-    should_be_classified_as(driver, "Occasional Exporter")
+    should_be_classified_as(driver, "occasional exporter")
 
 
 def should_be_classified_as_regular(driver: webdriver):
-    should_be_classified_as(driver, "Regular Exporter")
+    should_be_classified_as(driver, "regular exporter")
 
 
 def create_exporting_journey(driver: webdriver):

--- a/tests/exred/steps/given_def.py
+++ b/tests/exred/steps/given_def.py
@@ -5,6 +5,7 @@ from behave import given
 from steps.given_imp import (
     actor_classifies_himself_as,
     finish_triage_as,
+    guidance_open_category,
     triage_classify_as,
     visit_page
 )
@@ -35,3 +36,8 @@ def given_actor_was_classified_as(context, actor_alias, exporter_status):
 @given('"{actor_alias}" has answered triage questions')
 def given_actor_answered_triage_questions(context, actor_alias):
     finish_triage_as(context, actor_alias)
+
+
+@given('"{actor_alias}" accessed "{category}" guidance articles using "{location}"')
+def given_actor_opened_guidance(context, actor_alias, category, location):
+    guidance_open_category(context, actor_alias, category, location)

--- a/tests/exred/steps/given_imp.py
+++ b/tests/exred/steps/given_imp.py
@@ -5,6 +5,7 @@ import random
 
 from behave.runner import Context
 
+from pages import footer, header, home
 from registry import get_page_object
 from steps.when_impl import (
     start_triage,
@@ -107,3 +108,14 @@ def actor_classifies_himself_as(
     actor = unauthenticated_actor(
         actor_alias, self_classification=exporter_status)
     add_actor(context, actor)
+
+
+def open_group_element(
+        context: Context, group: str, element: str, location: str):
+    driver = context.driver
+    if location == "home page":
+        home.open(driver, group, element)
+    elif location == "header menu":
+        header.open(driver, group, element)
+    elif location == "footer links":
+        footer.open(driver, group, element)

--- a/tests/exred/steps/given_imp.py
+++ b/tests/exred/steps/given_imp.py
@@ -119,3 +119,13 @@ def open_group_element(
         header.open(driver, group, element)
     elif location == "footer links":
         footer.open(driver, group, element)
+
+
+def guidance_open_category(
+        context: Context, actor: str, category: str, location: str):
+    home.visit(driver=context.driver)
+    logging.debug(
+        "%s is about to open Guidance '%s' category from %s",
+        actor, category, location)
+    open_group_element(
+        context, group="guidance", element=category, location=location)

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
-"""Then step definitions."""
+"""Then steps definitions."""
 from behave import then
 
-from steps.then_impl import should_be_on_page, should_see_sections_on_home_page
+from steps.then_impl import (
+    guidance_ribbon_should_be_visible,
+    should_be_on_page,
+    should_see_sections_on_home_page
+)
 
 
 @then('"{actor_name}" should see the "{sections}" sections on home page')
@@ -13,3 +17,8 @@ def then_actor_should_see_sections(context, actor_name, sections):
 @then('"{actor_alias}" should be on the "{page_name}" page')
 def then_actor_should_be_on_page(context, actor_alias, page_name):
     should_be_on_page(context, actor_alias, page_name)
+
+
+@then('"{actor_alias}" should see the Guidance Navigation Ribbon')
+def then_guidance_ribbon_should_be_visible(context, actor_alias):
+    guidance_ribbon_should_be_visible(context, actor_alias)

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -4,6 +4,7 @@ from behave import then
 
 from steps.then_impl import (
     guidance_ribbon_should_be_visible,
+    guidance_tile_should_be_highlighted,
     should_be_on_page,
     should_see_sections_on_home_page
 )
@@ -22,3 +23,8 @@ def then_actor_should_be_on_page(context, actor_alias, page_name):
 @then('"{actor_alias}" should see the Guidance Navigation Ribbon')
 def then_guidance_ribbon_should_be_visible(context, actor_alias):
     guidance_ribbon_should_be_visible(context, actor_alias)
+
+
+@then('"{actor_alias}" should see that the banner tile for "{tile}" category is highlighted')
+def then_guidance_tile_should_be_highlighted(context, actor_alias, tile):
+    guidance_tile_should_be_highlighted(context, actor_alias, tile)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -28,3 +28,12 @@ def guidance_ribbon_should_be_visible(context: Context, actor_alias: str):
     guidance_common.ribbon_should_be_visible(driver)
     logging.debug(
         "%s can see Guidance Ribbon on %s", actor_alias, driver.current_url)
+
+
+def guidance_tile_should_be_highlighted(
+        context: Context, actor_alias: str, tile: str):
+    driver = context.driver
+    guidance_common.ribbon_tile_should_be_highlighted(driver, tile)
+    logging.debug(
+        "%s can see highlighted Guidance Ribbon '%s' tile on %s",
+        actor_alias, tile, driver.current_url)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -4,7 +4,7 @@ import logging
 
 from behave.runner import Context
 
-from pages import home
+from pages import guidance_common, home
 from registry import get_page_object
 
 
@@ -21,3 +21,10 @@ def should_be_on_page(context: Context, actor_alias: str, page_name: str):
     page = get_page_object(page_name)
     page.should_be_here(context.driver)
     logging.debug("%s is on %s page", actor_alias, page_name)
+
+
+def guidance_ribbon_should_be_visible(context: Context, actor_alias: str):
+    driver = context.driver
+    guidance_common.ribbon_should_be_visible(driver)
+    logging.debug(
+        "%s can see Guidance Ribbon on %s", actor_alias, driver.current_url)


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2467).

Scenario:
```gherkin
  @ED-2467
  @banner
  @<category>
  @<location>
  Scenario Outline: Guidance Banner should be visible when on "<category>" Guidance Article List accessed via "<location>"
    Given "Robert" accessed "<category>" guidance articles using "<location>"

    Then "Robert" should see the Guidance Navigation Ribbon
    And "Robert" should see that the banner tile for "<category>" category is highlighted

    Examples: header menu
      | category                  | location    |
      | Market research           | header menu |
      | Customer insight          | header menu |
      | Finance                   | header menu |
      | Business planning         | header menu |
      | Getting paid              | header menu |
      | Operations and Compliance | header menu |

    Examples: footer links
      | category                  | location     |
      | Market research           | footer links |
      | Customer insight          | footer links |
      | Finance                   | footer links |
      | Business planning         | footer links |
      | Getting paid              | footer links |
      | Operations and Compliance | footer links |

    Examples: home page
      | category                  | location  |
      | Market research           | home page |
      | Customer insight          | home page |
      | Finance                   | home page |
      | Business planning         | home page |
      | Getting paid              | home page |
      | Operations and Compliance | home page |
```
