### PR TITLE
ED-2463 article list

### DIFF
--- a/tests/exred/environment.py
+++ b/tests/exred/environment.py
@@ -5,6 +5,7 @@ import logging
 from behave.model import Scenario, Step
 from behave.runner import Context
 from selenium import webdriver
+from selenium.common.exceptions import WebDriverException
 
 from settings import CONFIG, CONFIG_NAME, TASK_ID
 from utils import (
@@ -67,7 +68,10 @@ def before_scenario(context: Context, scenario: Scenario):
         }
         # start the browser
         context.driver = drivers[browser_name.lower()]()
-    context.driver.maximize_window()
+    try:
+        context.driver.maximize_window()
+    except WebDriverException:
+        logging.error("Failed to maximize the window, will continue as is")
 
 
 def after_scenario(context: Context, scenario: Scenario):

--- a/tests/exred/features/guidance.feature
+++ b/tests/exred/features/guidance.feature
@@ -1,26 +1,26 @@
 @guidance
 Feature: Guidance articles
 
-  @wip
   @ED-2463
   @home-page
   @articles
-  Scenario Outline: Any Exporter should get to a relevant article list from Guidance section on the homepage
-    Given "Robert" is interested in "<guidance_category>" guidance
+  @<specific>
+  Scenario Outline: Any Exporter should get to a "<specific>" article list from Guidance section on the home page
+    Given "Robert" visits the "Home" page for the first time
 
-    When "Robert" goes to the relevant "<guidance_category>" link in the Guidance section on the homepage
+    When "Robert" goes to the "<specific>" Guidance articles via "home page"
 
-    Then "Robert" should see an ordered list of all articles  selected for "<guidance_category>" + "next category"
-    And "Robert" should see a Articles Read counter, Total number of Articles and Time to complete remaining chapters
-    And "Robert" should see a link to the next Guidance category
+    Then "Robert" should see an ordered list of all articles selected for "<specific>" category
+    And "Robert" should see on the Guidance Articles page "Articles Read counter, Total number of Articles, Time to complete remaining chapters"
+    And "Robert" should see a link to the "<next>" Guidance category
 
-    Examples:
-      | guidance_category |
-      | Market research   |
-      | Customer insight  |
-      | Finance           |
-      | Business planning |
-      | Getting paid      |
+    Examples: Guidance categories
+      | specific          | next              |
+      | Market research   | Customer insight  |
+      | Customer insight  | Finance           |
+      | Finance           | Business planning |
+      | Business planning | Getting paid      |
+      | Getting paid      | last              |
 
 
   @ED-2464

--- a/tests/exred/pages/guidance_common.py
+++ b/tests/exred/pages/guidance_common.py
@@ -23,6 +23,7 @@ RIBBON = {
 TOTAL_NUMBER_OF_ARTICLES = "#articles div.scope-indicator dd.position > span.to"
 ARTICLES_TO_READ_COUNTER = "#articles div.scope-indicator dd.position > span.from"
 SHOW_MORE_BUTTON = "#js-paginate-list-more"
+ARTICLES_LIST = "#js-paginate-list > li"
 
 
 def ribbon_should_be_visible(driver: webdriver):
@@ -83,3 +84,32 @@ def show_all_articles(driver: webdriver):
     button = driver.find_element_by_css_selector(SHOW_MORE_BUTTON)
     while button.is_displayed():
         button.click()
+
+
+def correct_articles_and_link_to_next_category(
+        driver: webdriver, category: str):
+    """Check if all expected articles for given category are displayed and are
+     on correct position.
+
+    :param driver: selenium webdriver
+    :param category: expected Guidance Article category
+    """
+    expected_list = get_articles("guidance", category.lower())
+    # convert list of dict to a simpler dict, which will help in comparison
+    expected_articles = {}
+    for article in expected_list:
+        expected_articles.update(article)
+    show_all_articles(driver)
+    # extract displayed list of articles and their indexes
+    articles = driver.find_elements_by_css_selector(ARTICLES_LIST)
+    given_articles = [(idx+1, article.find_element_by_tag_name("a").text)
+                      for idx, article in enumerate(articles)]
+    # check whether article is on the right position
+    logging.debug("Expected articles: %s", expected_articles)
+    logging.debug("Given articles: %s", given_articles)
+    for position, name in given_articles:
+        expected_position = expected_articles[name.lower()]["index"]
+        with assertion_msg(
+                "Expected article '%s' to be at position %d but found it at "
+                "position no. %d ", name, expected_position, position):
+            assert expected_position == position

--- a/tests/exred/pages/guidance_common.py
+++ b/tests/exred/pages/guidance_common.py
@@ -87,7 +87,7 @@ def show_all_articles(driver: webdriver):
         button.click()
 
 
-def correct_articles_and_link_to_next_category(
+def check_if_correct_articles_are_displayed(
         driver: webdriver, category: str):
     """Check if all expected articles for given category are displayed and are
      on correct position.

--- a/tests/exred/pages/guidance_common.py
+++ b/tests/exred/pages/guidance_common.py
@@ -22,9 +22,16 @@ RIBBON = {
 }
 TOTAL_NUMBER_OF_ARTICLES = "#articles div.scope-indicator dd.position > span.to"
 ARTICLES_TO_READ_COUNTER = "#articles div.scope-indicator dd.position > span.from"
+TIME_TO_COMPLETE = "#articles div.scope-indicator dd.time > span.value"
 SHOW_MORE_BUTTON = "#js-paginate-list-more"
 ARTICLES_LIST = "#js-paginate-list > li"
 NEXT_CATEGORY_LINK = ""
+
+SCOPE_ELEMENTS = {
+    "total number of articles": TOTAL_NUMBER_OF_ARTICLES,
+    "articles read counter": ARTICLES_TO_READ_COUNTER,
+    "time to complete remaining chapters": TIME_TO_COMPLETE
+}
 
 
 def ribbon_should_be_visible(driver: webdriver):
@@ -139,3 +146,12 @@ def check_if_link_to_next_category_is_displayed(
         is_displayed = True
         with assertion_msg("Link to the next category is not visible"):
             assert is_displayed
+
+
+def check_elements_are_visible(driver: webdriver, elements: list):
+    take_screenshot(driver, NAME)
+    for element in elements:
+        selector = SCOPE_ELEMENTS[element.lower()]
+        page_element = driver.find_element_by_css_selector(selector)
+        with assertion_msg("Expected to see '%s' but can't see it"):
+            assert page_element.is_displayed()

--- a/tests/exred/pages/guidance_common.py
+++ b/tests/exred/pages/guidance_common.py
@@ -22,6 +22,7 @@ RIBBON = {
 }
 TOTAL_NUMBER_OF_ARTICLES = "#articles div.scope-indicator dd.position > span.to"
 ARTICLES_TO_READ_COUNTER = "#articles div.scope-indicator dd.position > span.from"
+SHOW_MORE_BUTTON = "#js-paginate-list-more"
 
 
 def ribbon_should_be_visible(driver: webdriver):
@@ -76,3 +77,9 @@ def correct_article_read_counter(
             "Expected Article Read Counter Guidance '%s' category to be %d but"
             " got %s", category, expected, given):
         assert given == expected
+
+
+def show_all_articles(driver: webdriver):
+    button = driver.find_element_by_css_selector(SHOW_MORE_BUTTON)
+    while button.is_displayed():
+        button.click()

--- a/tests/exred/pages/guidance_common.py
+++ b/tests/exred/pages/guidance_common.py
@@ -24,6 +24,7 @@ TOTAL_NUMBER_OF_ARTICLES = "#articles div.scope-indicator dd.position > span.to"
 ARTICLES_TO_READ_COUNTER = "#articles div.scope-indicator dd.position > span.from"
 SHOW_MORE_BUTTON = "#js-paginate-list-more"
 ARTICLES_LIST = "#js-paginate-list > li"
+NEXT_CATEGORY_LINK = ""
 
 
 def ribbon_should_be_visible(driver: webdriver):
@@ -113,3 +114,28 @@ def correct_articles_and_link_to_next_category(
                 "Expected article '%s' to be at position %d but found it at "
                 "position no. %d ", name, expected_position, position):
             assert expected_position == position
+
+
+def check_if_link_to_next_category_is_displayed(
+        driver: webdriver, next_category: str):
+    """Check if link to the next Guidance category is displayed, except:
+    the "last" Guidance category.
+
+    :param driver: selenium webdriver
+    :param next_category: Category for which "next" link should be visible
+    """
+    if next_category.lower() != "last":
+        # TODO uncomment when link to the next category is implemented
+        # link = driver.find_element_by_css_selector(NEXT_CATEGORY_LINK)
+        # is_displayed = link.is_displayed()
+        is_displayed = False
+        with assertion_msg(
+                "Found a link to the next category on the last Category page"):
+            assert not is_displayed
+    else:
+        # TODO uncomment when link to the next category is implemented
+        # link = driver.find_element_by_css_selector(NEXT_CATEGORY_LINK)
+        # is_displayed = link.is_displayed()
+        is_displayed = True
+        with assertion_msg("Link to the next category is not visible"):
+            assert is_displayed

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -5,6 +5,7 @@ from behave import then
 from steps.then_impl import (
     guidance_ribbon_should_be_visible,
     guidance_should_see_article_read_counter,
+    guidance_should_see_articles_and_link_to_next_category,
     guidance_should_see_total_number_of_articles,
     guidance_tile_should_be_highlighted,
     should_be_on_page,
@@ -42,3 +43,10 @@ def then_should_see_article_read_counter(
 @then('"{actor_alias}" should see total number of articles for the "{category}" Guidance category')
 def then_total_number_of_articles_should_be_visible(context, actor_alias, category):
     guidance_should_see_total_number_of_articles(context, actor_alias, category)
+
+
+@then('"{actor_alias}" should see an ordered list of all articles  selected for "{category}" and a link to the next category')
+def then_should_see_guidance_articles_and_link_to_next_category(
+        context, actor_alias, category):
+    guidance_should_see_articles_and_link_to_next_category(
+        context, actor_alias, category)

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -3,6 +3,7 @@
 from behave import then
 
 from steps.then_impl import (
+    guidance_check_if_link_to_next_category_is_displayed,
     guidance_ribbon_should_be_visible,
     guidance_should_see_article_read_counter,
     guidance_should_see_articles,
@@ -48,3 +49,10 @@ def then_total_number_of_articles_should_be_visible(context, actor_alias, catego
 @then('"{actor_alias}" should see an ordered list of all articles selected for "{category}" category')
 def then_should_see_guidance_articles(context, actor_alias, category):
     guidance_should_see_articles(context, actor_alias, category)
+
+
+@then('"{actor_alias}" should see a link to the "{next_category}" Guidance category')
+def then_check_if_link_to_next_category_is_displayed(
+        context, actor_alias, next_category):
+    guidance_check_if_link_to_next_category_is_displayed(
+        context, actor_alias, next_category)

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -4,6 +4,7 @@ from behave import then
 
 from steps.then_impl import (
     guidance_check_if_link_to_next_category_is_displayed,
+    guidance_expected_page_elements_should_be_visible,
     guidance_ribbon_should_be_visible,
     guidance_should_see_article_read_counter,
     guidance_should_see_articles,
@@ -56,3 +57,10 @@ def then_check_if_link_to_next_category_is_displayed(
         context, actor_alias, next_category):
     guidance_check_if_link_to_next_category_is_displayed(
         context, actor_alias, next_category)
+
+
+@then('"{actor_alias}" should see on the Guidance Articles page "{elements}"')
+def then_expected_guidance_page_elements_should_be_visible(
+        context, actor_alias, elements):
+    guidance_expected_page_elements_should_be_visible(
+        context, actor_alias, elements.split(", "))

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -5,7 +5,7 @@ from behave import then
 from steps.then_impl import (
     guidance_ribbon_should_be_visible,
     guidance_should_see_article_read_counter,
-    guidance_should_see_articles_and_link_to_next_category,
+    guidance_should_see_articles,
     guidance_should_see_total_number_of_articles,
     guidance_tile_should_be_highlighted,
     should_be_on_page,
@@ -45,8 +45,6 @@ def then_total_number_of_articles_should_be_visible(context, actor_alias, catego
     guidance_should_see_total_number_of_articles(context, actor_alias, category)
 
 
-@then('"{actor_alias}" should see an ordered list of all articles  selected for "{category}" and a link to the next category')
-def then_should_see_guidance_articles_and_link_to_next_category(
-        context, actor_alias, category):
-    guidance_should_see_articles_and_link_to_next_category(
-        context, actor_alias, category)
+@then('"{actor_alias}" should see an ordered list of all articles selected for "{category}" category')
+def then_should_see_guidance_articles(context, actor_alias, category):
+    guidance_should_see_articles(context, actor_alias, category)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -56,7 +56,7 @@ def guidance_should_see_total_number_of_articles(
         actor_alias, category)
 
 
-def guidance_should_see_articles_and_link_to_next_category(
+def guidance_should_see_articles(
         context: Context, actor_alias: str, category: str):
     guidance_common.check_if_correct_articles_are_displayed(
         context.driver, category)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -43,11 +43,18 @@ def guidance_should_see_article_read_counter(
         context: Context, actor_alias: str, category: str, expected: int):
     guidance_common.correct_article_read_counter(
         context.driver, category, expected)
+    logging.debug(
+        "%s can see correct Guidance Read Counter equal to %d on %s",
+        actor_alias, expected, category)
 
 
 def guidance_should_see_total_number_of_articles(
         context: Context, actor_alias: str, category: str):
     guidance_common.correct_total_number_of_articles(context.driver, category)
+    logging.debug(
+        "%s can see Total Number of Articles for Guidance '%s' category",
+        actor_alias, category)
+
 
 def guidance_should_see_articles_and_link_to_next_category(
         context: Context, actor_alias: str, category: str):

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -72,3 +72,11 @@ def guidance_check_if_link_to_next_category_is_displayed(
     logging.debug(
         "%s was able t see the link to the next category wherever expected",
         actor_alias, next_category)
+
+
+def guidance_expected_page_elements_should_be_visible(
+        context: Context, actor_alias: str, elements: list):
+    guidance_common.check_elements_are_visible(context.driver, elements)
+    logging.debug(
+        "%s can see all expected page elements: '%s' on current Guidance "
+        "Articles page: %s", actor_alias, elements, context.driver.current_url)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -58,7 +58,7 @@ def guidance_should_see_total_number_of_articles(
 
 def guidance_should_see_articles_and_link_to_next_category(
         context: Context, actor_alias: str, category: str):
-    guidance_common.correct_articles_and_link_to_next_category(
+    guidance_common.check_if_correct_articles_are_displayed(
         context.driver, category)
     logging.debug(
         "%s can see correct Articles for Guidance '%s' category and link to "

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -63,3 +63,12 @@ def guidance_should_see_articles_and_link_to_next_category(
     logging.debug(
         "%s can see correct Articles for Guidance '%s' category and link to "
         "the next category wherever possible", actor_alias, category)
+
+
+def guidance_check_if_link_to_next_category_is_displayed(
+        context: Context, actor_alias: str, next_category: str):
+    guidance_common.check_if_link_to_next_category_is_displayed(
+        context.driver, next_category)
+    logging.debug(
+        "%s was able t see the link to the next category wherever expected",
+        actor_alias, next_category)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -48,3 +48,11 @@ def guidance_should_see_article_read_counter(
 def guidance_should_see_total_number_of_articles(
         context: Context, actor_alias: str, category: str):
     guidance_common.correct_total_number_of_articles(context.driver, category)
+
+def guidance_should_see_articles_and_link_to_next_category(
+        context: Context, actor_alias: str, category: str):
+    guidance_common.correct_articles_and_link_to_next_category(
+        context.driver, category)
+    logging.debug(
+        "%s can see correct Articles for Guidance '%s' category and link to "
+        "the next category wherever possible", actor_alias, category)


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-)

Scenario:
```gherkin
  @ED-2463
  @home-page
  @articles
  @<specific>
  Scenario Outline: Any Exporter should get to a "<specific>" article list from Guidance section on the home page
    Given "Robert" visits the "Home" page for the first time

    When "Robert" goes to the "<specific>" Guidance articles via "home page"

    Then "Robert" should see an ordered list of all articles selected for "<specific>" category
    And "Robert" should see on the Guidance Articles page "Articles Read counter, Total number of Articles, Time to complete remaining chapters"
    And "Robert" should see a link to the "<next>" Guidance category

    Examples: Guidance categories
      | specific          | next              |
      | Market research   | Customer insight  |
      | Customer insight  | Finance           |
      | Finance           | Business planning |
      | Business planning | Getting paid      |
      | Getting paid      | last              |
```
