### PR TITLE
ED-2520, ED-2521 & ED-2522 triage scenarios or new, occasional & regular exporters

### DIFF
--- a/makefile
+++ b/makefile
@@ -161,7 +161,7 @@ exred_local:
 
 exred_browserstack:
 	$(EXRED_SET_DOCKER_ENV_VARS) && \
-	cd tests/exred && paver run --config=browserstacka --tag=${TAG}
+	cd tests/exred && paver run --config=browserstack --tag=${TAG}
 
 exred_browserstack_single:
 	$(EXRED_SET_DOCKER_ENV_VARS) && \

--- a/makefile
+++ b/makefile
@@ -157,11 +157,15 @@ EXRED_DOCKER_REMOVE_ALL:
 
 exred_local:
 	$(EXRED_SET_LOCAL_ENV_VARS) && \
-	cd tests/exred && BROWSERS=$(BROWSERS) paver run local
+	cd tests/exred && paver run --config=local --browsers=${BROWSERS} --tag=${TAG}
 
 exred_browserstack:
 	$(EXRED_SET_DOCKER_ENV_VARS) && \
-	cd tests/exred && paver run browserstack
+	cd tests/exred && paver run --config=browserstacka --tag=${TAG}
+
+exred_browserstack_single:
+	$(EXRED_SET_DOCKER_ENV_VARS) && \
+	cd tests/exred && paver run --config=browserstack-single --browsers=${BROWSERS} --versions=${VERSIONS} --tag=${TAG}
 
 exred_docker_browserstack: EXRED_DOCKER_REMOVE_ALL
 	$(EXRED_SET_DOCKER_ENV_VARS) && \

--- a/requirements_exred.ini
+++ b/requirements_exred.ini
@@ -3,5 +3,5 @@ paver==1.2.4
 retrying==1.3.3
 requests==2.11.1
 retrying==1.3.3
-selenium==3.6.0
--e git+https://git@github.com/uktrade/directory-constants.git@v6.0.2#egg=directory-constants
+selenium==3.7.0
+-e git+https://git@github.com/uktrade/directory-constants.git@v6.1.0#egg=directory-constants

--- a/requirements_exred.txt
+++ b/requirements_exred.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file requirements_exred.txt requirements_exred.ini
 #
--e git+https://git@github.com/uktrade/directory-constants.git@v6.0.2#egg=directory-constants
+-e git+https://git@github.com/uktrade/directory-constants.git@v6.1.0#egg=directory-constants
 behave==1.2.5
 django==1.11.5
 parse-type==0.4.2         # via behave
@@ -13,5 +13,5 @@ paver==1.2.4
 pytz==2017.2              # via django
 requests==2.11.1
 retrying==1.3.3
-selenium==3.6.0
+selenium==3.7.0
 six==1.11.0               # via behave, parse-type, retrying

--- a/tests/exred/README.md
+++ b/tests/exred/README.md
@@ -25,9 +25,15 @@ make exred_local
 ```
 
 
-If you want to run the scenarios in a different browser then specify it using `BROWSERS` environment variable:  
+If you want to run all the scenarios in a specific browser, then use `BROWSERS` environment variable:  
 ```bash
 BROWSERS=firefox make exred_local
+```
+
+
+If you want to run specific scenario in a specific browser, then use `TAG` & `BROWSERS` environment variables:  
+```bash
+TAG=ED-2366 BROWSERS=firefox make exred_local
 ```
 
 
@@ -51,11 +57,22 @@ Run all scenarios on [BrowserStack](https://www.browserstack.com/automate) in pa
 make exred_browserstack
 ```
 
+Run specific scenario on [BrowserStack](https://www.browserstack.com/automate) in parallel:  
+```bash
+TAG=ED-2366 make exred_browserstack
+```
+
+
+Run specific scenario on [BrowserStack](https://www.browserstack.com/automate) using specific browser and browser version:
+```bash
+TAG=ED-2366 BROWSERS=Edge VERSIONS=16.0 make exred_browserstack_single
+```
+
 
 To run all scenarios on [BrowserStack](https://www.browserstack.com/automate) in parallel with `paver` command:
 ```bash
 cd tests/exred
-paver run browserstack
+paver run --config=browserstack
 ```
 
 
@@ -63,6 +80,13 @@ To run all scenarios on [BrowserStack](https://www.browserstack.com/automate) wi
 ```bash
 cd tests/exred
 CONFIG=browserstack behave -k --format progress3 --no-logcapture --stop --tags=-wip --tags=-skip --tags=~fixme
+```
+
+
+To run specific scenario on [BrowserStack](https://www.browserstack.com/automate) with `behave` command):   
+```bash
+cd tests/exred
+BROWSERS=Edge VERSIONS=16.0 CONFIG=browserstack-single behave -k --format progress3 --no-logcapture --stop --tags=-wip --tags=-skip --tags=~fixme --tags={YOUR_TAG}
 ```
 
 # Run scenarios in Docker container on BrowserStack

--- a/tests/exred/config/__init__.py
+++ b/tests/exred/config/__init__.py
@@ -10,7 +10,7 @@ def load_template(config_file: str) -> str:
 
 def render(
         template: str, hub_url: str, capabilities: dict, browsers: list,
-        build_id: str) -> str:
+        versions: list, build_id: str) -> str:
     # wrap values in double quotes so that they render correct JSON file
     hub_url = '"{}"'.format(hub_url) if hub_url else "null"
 
@@ -24,18 +24,24 @@ def render(
     else:
         browsers = ['"Chrome"', '"Firefox"', '"PhantomJS"']
 
+    if versions:
+        versions = ['"{}"'.format(version) for version in versions]
+    else:
+        versions = ['""']
+
     build_id = '"{}"'.format(build_id) if build_id else '""'
 
     return template.format(
         HUB_URL=hub_url, CAPABILITIES=capabilities, BROWSERS=browsers,
-        BUILD_ID=build_id)
+        VERSIONS=versions, BUILD_ID=build_id)
 
 
 def get(
         config_file: str, *, hub_url: str = None, capabilities: dict = None,
-        browsers: list = None, build_id: str = None) -> dict:
+        browsers: list = None, versions: list = None,
+        build_id: str = None) -> dict:
     config_template = load_template(config_file)
     rendered = render(
         config_template, hub_url=hub_url, capabilities=capabilities,
-        browsers=browsers, build_id=build_id)
+        browsers=browsers, versions=versions, build_id=build_id)
     return json.loads(rendered)

--- a/tests/exred/config/browserstack-single.json
+++ b/tests/exred/config/browserstack-single.json
@@ -1,0 +1,16 @@
+{{
+  "hub_url": {HUB_URL},
+  "capabilities": {{
+    "browserstack.debug": true,
+    "browserstack.selenium_version": "3.5.2",
+    "build": {BUILD_ID},
+    "project": "ExRed",
+    "resolution": "1600x1200"
+  }},
+  "environments": [
+    {{
+      "browser": {BROWSERS[0]},
+      "browser_version": {VERSIONS[0]}
+    }}
+  ]
+}}

--- a/tests/exred/environment.py
+++ b/tests/exred/environment.py
@@ -80,6 +80,7 @@ def before_scenario(context: Context, scenario: Scenario):
             logging.warning("Set window size to 1600x1200")
         except WebDriverException:
             logging.warning("Failed to set window size, will continue as is")
+    logging.debug("Browser Capabilities: %s", context.driver.capabilities)
 
 
 def after_scenario(context: Context, scenario: Scenario):

--- a/tests/exred/environment.py
+++ b/tests/exred/environment.py
@@ -73,7 +73,11 @@ def before_scenario(context: Context, scenario: Scenario):
     try:
         context.driver.maximize_window()
     except WebDriverException:
-        logging.error("Failed to maximize the window, will continue as is")
+        logging.warning("Failed to maximize the window.")
+        try:
+            context.driver.set_window_size(1600, 1200)
+        except WebDriverException:
+            logging.warning("Failed to set window size, will continue as is")
 
 
 def after_scenario(context: Context, scenario: Scenario):

--- a/tests/exred/environment.py
+++ b/tests/exred/environment.py
@@ -72,10 +72,12 @@ def before_scenario(context: Context, scenario: Scenario):
     context.driver.set_page_load_timeout(time_to_wait=30)
     try:
         context.driver.maximize_window()
+        logging.debug("Maximized the window.")
     except WebDriverException:
-        logging.warning("Failed to maximize the window.")
+        logging.debug("Failed to maximize the window.")
         try:
             context.driver.set_window_size(1600, 1200)
+            logging.warning("Set window size to 1600x1200")
         except WebDriverException:
             logging.warning("Failed to set window size, will continue as is")
 

--- a/tests/exred/features/guidance.feature
+++ b/tests/exred/features/guidance.feature
@@ -49,7 +49,7 @@ Feature: Guidance articles
   @<relevant>
   @bug
   @ED-2508
-  @fixme
+  @fixed
   Scenario Outline: "<relevant>" Exporter should see Guidance Articles Read Counter on the personalised page
     Given "Nadia" classifies herself as "<relevant>" exporter
 

--- a/tests/exred/features/guidance.feature
+++ b/tests/exred/features/guidance.feature
@@ -71,6 +71,7 @@ Feature: Guidance articles
   @optimize
   Scenario Outline: Regular Exporter should see article read count for each tile in the Guidance section on the personalised page
     Given "Nadia" was classified as "regular" exporter in the triage process
+    And "Nadia" decided to create her personalised journey page
 
     When "Nadia" goes to the "<specific>" Guidance articles via "personalised journey"
 
@@ -94,6 +95,7 @@ Feature: Guidance articles
   @<specific>
   Scenario Outline: Regular Exporter should see "<specific>" Guidance Articles accessed via personalised journey page
     Given "Nadia" was classified as "regular" exporter in the triage process
+    And "Nadia" decided to create her personalised journey page
 
     When "Nadia" goes to the "<specific>" Guidance articles via "personalised journey"
 

--- a/tests/exred/features/home-page.feature
+++ b/tests/exred/features/home-page.feature
@@ -23,6 +23,7 @@ Feature: Home Page
   @triage
   Scenario: Any Exporter visiting the home page after triage should be able to get to personalised page
     Given "Robert" answered triage questions
+    And "Robert" decided to create his personalised journey page
     And "Robert" goes to the "Home" page
 
     When "Robert" decides to continue in Exporting journey section

--- a/tests/exred/features/home-page.feature
+++ b/tests/exred/features/home-page.feature
@@ -16,7 +16,7 @@ Feature: Home Page
 
     When "Robert" decides to get started in Exporting journey section
 
-    Then "Robert" should be on the "Triage - what is your sector" page
+    Then "Robert" should be on the "Triage - what do you want to export" page
 
 
   @ED-2366

--- a/tests/exred/features/home-page.feature
+++ b/tests/exred/features/home-page.feature
@@ -22,7 +22,7 @@ Feature: Home Page
   @ED-2366
   @triage
   Scenario: Any Exporter visiting the home page after triage should be able to get to personalised page
-    Given "Robert" has answered triage questions
+    Given "Robert" answered triage questions
     And "Robert" goes to the "Home" page
 
     When "Robert" decides to continue in Exporting journey section

--- a/tests/exred/features/triage.feature
+++ b/tests/exred/features/triage.feature
@@ -3,6 +3,7 @@ Feature: Triage
 
   @ED-2520
   @first-time
+  @regular
   Scenario Outline: Regular Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
     Given "Nadia" visits the "Home" page for the first time
     And "Nadia" decided to build her exporting journey
@@ -25,9 +26,27 @@ Feature: Triage
       | types in and selects |
 
 
-  @wip
+  @ED-2520
+  @first-time
+  @regular
+  Scenario: Not incorporated Regular Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
+    Given "Nadia" visits the "Home" page for the first time
+    And "Nadia" decided to build her exporting journey
+
+    When "Nadia" says what does she wants to export
+    And "Nadia" says that she "has" exported before
+    And "Nadia" says that exporting is "a regular" part of her business
+    And "Nadia" says that her company "is not" incorporated
+    And "Nadia" sees the summary page with answers to the questions she was asked
+    And "Nadia" can see that she was classified as a "regular" exporter
+    And "Nadia" decides to create her personalised journey page
+
+    Then "Nadia" should be on the personalised "regular" exporter journey page
+
+
   @ED-2521
   @first-time
+  @occasional
   Scenario Outline: Occasional Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
     Given "Inigo" visits the "home" page for the first time
     And "Inigo" decided to build his exporting journey
@@ -54,116 +73,10 @@ Feature: Triage
       | has never     | types in and selects |
 
 
-  @wip
-  @ED-2522
+  @ED-2521
   @first-time
-  Scenario Outline: New Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
-    Given "Jonah" visits the "home" page for the first time
-    And "Jonah" decided to build his exporting journey
-
-    When "Jonah" says what does he wants to export
-    And "Jonah" says that he "has never" exported before
-    And "Jonah" says that his company "is" incorporated
-    And "Jonah" "<company_name_action>" his company name
-    And "Jonah" sees the summary page with answers to the questions he was asked
-    And "Jonah" can see that he was classified as a "new" exporter
-    And "Jonah" decides to create his personalised journey page
-
-    Then "Jonah" should be on the personalised "new" exporter journey page
-
-    Examples:
-      | company_name_action  |
-      | types in             |
-      | does not provide     |
-      | types in and selects |
-
-
-  @wip
-  @ED-2523
-  @first-time
-  Scenario: Any Exporter should be able to change their answers to at the end of triage
-    Given "Robert" visits the home page for the first time
-    And "Robert" answered triage questions
-
-    When "Robert" decides to change his answers
-
-    Then "Robert" should be able to answer the triage questions again with his previous answers pre-populated
-
-
-  @wip
-  @ED-2524
-  @sole-trader
-  Scenario: Sole Trader visiting the home page for the 1st time should be able asked for Company name if he is not registered with companies house
-    Given "Robert" is in triage
-    And "Robert" said that his company "is not" incorporated
-
-    Then "Robert" should not be asked for his Company name
-    And "Robert" should be presented with the summary page with answers to the questions he asked
-
-
-  @wip
-  @ED-2525
-  @sole-trader
-  Scenario: Sole Trader visiting the home page for the 1st time should be able to get to personalised page after going through triage process
-    Given "Robert" is in triage
-    And "Robert" said that his company "is not" incorporated
-    And "Robert" sees the summary page with answers to the questions he was asked
-    And "Robert" decides to create his personalised journey page
-
-    Then "Robert" should be on the personalised journey page
-
-
-  @wip
-  @ED-2526
-  @classification
-  Scenario Outline: Triaging should help to identify "new exporter"
-    Given "Jonah" visits the "home" page for the first time
-    And "Jonah" decided to build his exporting journey
-
-    When "Jonah" says what does he wants to export
-    And "Jonah" says that he "has never" exported before
-    And "Jonah" says that his company "is" incorporated
-    And "Jonah" "<company_name_action>" his company name
-
-
-    Then "Nadia" should see the summary page with answers to the questions she was asked
-    And "Nadia" should be classified as "new" exporter
-
-    Examples:
-      | company_name_action  |
-      | types in             |
-      | does not provide     |
-      | types in and selects |
-
-
-  @wip
-  @ED-2527
-  @first-time
-  Scenario Outline: New Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
-    Given "Jonah" visits the "home" page for the first time
-    And "Jonah" decided to build his exporting journey
-
-    When "Jonah" says what does he wants to export
-    And "Jonah" says that he "has never" exported before
-    And "Jonah" says that his company "is" incorporated
-    And "Jonah" "<company_name_action>" his company name
-    And "Jonah" sees the summary page with answers to the questions he was asked
-    And "Jonah" can see that he was classified as a "new" exporter
-    And "Jonah" decides to create his personalised journey page
-
-    Then "Jonah" should be on the personalised "new" exporter journey page
-
-    Examples:
-      | company_name_action  |
-      | types in             |
-      | does not provide     |
-      | types in and selects |
-
-
-  @wip
-  @ED-2528
-  @classification
-  Scenario Outline: Triaging should help to identify "occasional exporter"
+  @occasional
+  Scenario Outline: Not incorporated Occasional Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
     Given "Inigo" visits the "home" page for the first time
     And "Inigo" decided to build his exporting journey
 
@@ -171,18 +84,66 @@ Feature: Triage
     And "Inigo" says that she "has" exported before
     And "Inigo" says that exporting is "not a regular" part of her business
     And "Inigo" says that she "<online_action>" used online marketplaces
-    And "Inigo" says that her company "is" incorporated
-    And "Inigo" "<company_name_action>" her company name
+    And "Inigo" says that her company "is not" incorporated
+    And "Inigo" sees the summary page with answers to the questions he was asked
+    And "Inigo" can see that she was classified as a "occasional" exporter
+    And "Inigo" decides to create her personalised journey page
 
-
-    Then "Inigo" should see the summary page with answers to the questions she was asked
-    And "Inigo" should be classified as "occasional" exporter
+    Then "Inigo" should be on the personalised "occasional" exporter journey page
 
     Examples:
-      | online_action | company_name_action  |
-      | has           | types in             |
-      | has never     | types in             |
-      | has           | does not provide     |
-      | has never     | does not provide     |
-      | has           | types in and selects |
-      | has never     | types in and selects |
+      | online_action |
+      | has           |
+      | has never     |
+
+
+  @ED-2522
+  @first-time
+  @new
+  Scenario Outline: New Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
+    Given "Jonah" visits the "home" page for the first time
+    And "Jonah" decided to build his exporting journey
+
+    When "Jonah" says what does he wants to export
+    And "Jonah" says that he "has never" exported before
+    And "Jonah" says that his company "is" incorporated
+    And "Jonah" "<company_name_action>" his company name
+    And "Jonah" sees the summary page with answers to the questions he was asked
+    And "Jonah" can see that he was classified as a "new" exporter
+    And "Jonah" decides to create his personalised journey page
+
+    Then "Jonah" should be on the personalised "new" exporter journey page
+
+    Examples:
+      | company_name_action  |
+      | types in             |
+      | does not provide     |
+      | types in and selects |
+
+
+  @ED-2522
+  @first-time
+  @new
+  Scenario: Not incorporated New Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
+    Given "Jonah" visits the "home" page for the first time
+    And "Jonah" decided to build his exporting journey
+
+    When "Jonah" says what does he wants to export
+    And "Jonah" says that he "has never" exported before
+    And "Jonah" says that his company "is not" incorporated
+    And "Jonah" sees the summary page with answers to the questions he was asked
+    And "Jonah" can see that he was classified as a "new" exporter
+    And "Jonah" decides to create his personalised journey page
+
+    Then "Jonah" should be on the personalised "new" exporter journey page
+
+
+  @wip
+  @ED-2523
+  @first-time
+  Scenario: Any Exporter should be able to change their answers to at the end of triage
+    Given "Robert" answered triage questions
+
+    When "Robert" decides to change his answers
+
+    Then "Robert" should be able to answer the triage questions again with his previous answers pre-populated

--- a/tests/exred/features/triage.feature
+++ b/tests/exred/features/triage.feature
@@ -7,7 +7,7 @@ Feature: Triage
     Given "Nadia" visits the "Home" page for the first time
     And "Nadia" decided to build her exporting journey
 
-    When "Nadia" selects her sector
+    When "Nadia" says what does she wants to export
     And "Nadia" says that she "has" exported before
     And "Nadia" says that exporting is "a regular" part of her business
     And "Nadia" tells that she "is" registered with companies house

--- a/tests/exred/features/triage.feature
+++ b/tests/exred/features/triage.feature
@@ -29,10 +29,10 @@ Feature: Triage
   @ED-2521
   @first-time
   Scenario Outline: Occasional Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
-    Given "Inigo" visits the home page for the first time
+    Given "Inigo" visits the "home" page for the first time
     And "Inigo" decided to build his exporting journey
 
-    When "Inigo" selects her sector
+    When "Inigo" says what does she wants to export
     And "Inigo" says that she "has" exported before
     And "Inigo" says that exporting is "not a regular" part of her business
     And "Inigo" says that he "<online_action>" used online marketplaces
@@ -58,15 +58,15 @@ Feature: Triage
   @ED-2522
   @first-time
   Scenario Outline: New Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
-    Given "Jonah" visits the home page for the first time
+    Given "Jonah" visits the "home" page for the first time
     And "Jonah" decided to build his exporting journey
 
-    When "Jonah" selects his sector
+    When "Jonah" says what does he wants to export
     And "Jonah" says that he "has never" exported before
     And "Jonah" says that his company "is" incorporated
     And "Jonah" "<company_name_action>" his company name
     And "Jonah" sees the summary page with answers to the questions he was asked
-    And "Jonah" can see that she was classified as a "new" exporter
+    And "Jonah" can see that he was classified as a "new" exporter
     And "Jonah" decides to create his personalised journey page
 
     Then "Jonah" should be on the personalised "new" exporter journey page
@@ -117,10 +117,10 @@ Feature: Triage
   @ED-2526
   @classification
   Scenario Outline: Triaging should help to identify "new exporter"
-    Given "Jonah" visits the home page for the first time
+    Given "Jonah" visits the "home" page for the first time
     And "Jonah" decided to build his exporting journey
 
-    When "Jonah" selects his sector
+    When "Jonah" says what does he wants to export
     And "Jonah" says that he "has never" exported before
     And "Jonah" says that his company "is" incorporated
     And "Jonah" "<company_name_action>" his company name
@@ -140,15 +140,15 @@ Feature: Triage
   @ED-2527
   @first-time
   Scenario Outline: New Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
-    Given "Jonah" visits the home page for the first time
+    Given "Jonah" visits the "home" page for the first time
     And "Jonah" decided to build his exporting journey
 
-    When "Jonah" selects his sector
+    When "Jonah" says what does he wants to export
     And "Jonah" says that he "has never" exported before
     And "Jonah" says that his company "is" incorporated
     And "Jonah" "<company_name_action>" his company name
     And "Jonah" sees the summary page with answers to the questions he was asked
-    And "Jonah" can see that she was classified as a "new" exporter
+    And "Jonah" can see that he was classified as a "new" exporter
     And "Jonah" decides to create his personalised journey page
 
     Then "Jonah" should be on the personalised "new" exporter journey page
@@ -167,9 +167,9 @@ Feature: Triage
     Given "Inigo" visits the home page for the first time
     And "Inigo" decided to build his exporting journey
 
-    When "Inigo" selects his sector
-    And "Inigo" says that he "has" exported before
-    And "Inigo" says that exporting is "not a regular" part of his business
+    When "Inigo" says what does she wants to export
+    And "Inigo" says that she "has" exported before
+    And "Inigo" says that exporting is "not a regular" part of her business
     And "Inigo" says that she "<online_action>" used online marketplaces
     And "Inigo" says that her company "is" incorporated
     And "Inigo" "<company_name_action>" her company name

--- a/tests/exred/features/triage.feature
+++ b/tests/exred/features/triage.feature
@@ -10,7 +10,7 @@ Feature: Triage
     When "Nadia" says what does she wants to export
     And "Nadia" says that she "has" exported before
     And "Nadia" says that exporting is "a regular" part of her business
-    And "Nadia" tells that she "is" registered with companies house
+    And "Nadia" says that her company "is" incorporated
     And "Nadia" "<company_name_action>" her company name
     And "Nadia" sees the summary page with answers to the questions she was asked
     And "Nadia" decides to create her personalised journey page
@@ -31,15 +31,15 @@ Feature: Triage
     Given "Inigo" visits the home page for the first time
     And "Inigo" decided to build his exporting journey
 
-    When "Inigo" selects his sector
-    And "Inigo" says that he "has" exported before
-    And "Inigo" says that exporting is "not a regular" part of his business
+    When "Inigo" selects her sector
+    And "Inigo" says that she "has" exported before
+    And "Inigo" says that exporting is "not a regular" part of her business
     And "Inigo" says that he "<online_action>" used online marketplaces
-    And "Inigo" tells that he "is" registered with companies house
+    And "Inigo" says that her company "is" incorporated
     And "Inigo" "<company_name_action>" his company name
 
     And "Inigo" sees the summary page with answers to the questions he was asked
-    And "Inigo" decides to create his personalised journey page
+    And "Inigo" decides to create her personalised journey page
 
     Then "Inigo" should be on the personalised "occasional exporter" journey page
 
@@ -62,7 +62,7 @@ Feature: Triage
 
     When "Jonah" selects his sector
     And "Jonah" says that he "has never" exported before
-    And "Jonah" tells that he "is" registered with companies house
+    And "Jonah" says that his company "is" incorporated
     And "Jonah" "<company_name_action>" his company name
     And "Jonah" sees the summary page with answers to the questions he was asked
     And "Jonah" decides to create his personalised journey page
@@ -92,7 +92,7 @@ Feature: Triage
   @sole-trader
   Scenario: Sole Trader visiting the home page for the 1st time should be able asked for Company name if he is not registered with companies house
     Given "Robert" is in triage
-    And "Robert" tells that he "is not" registered in Companies House
+    And "Robert" said that his company "is not" incorporated
 
     Then "Robert" should not be asked for his Company name
     And "Robert" should be presented with the summary page with answers to the questions he asked
@@ -103,7 +103,7 @@ Feature: Triage
   @sole-trader
   Scenario: Sole Trader visiting the home page for the 1st time should be able to get to personalised page after going through triage process
     Given "Robert" is in triage
-    And "Robert" tells that he "is not" registered in Companies House
+    And "Robert" said that his company "is not" incorporated
     And "Robert" sees the summary page with answers to the questions he was asked
     And "Robert" decides to create his personalised journey page
 
@@ -119,7 +119,7 @@ Feature: Triage
 
     When "Jonah" selects his sector
     And "Jonah" says that he "has never" exported before
-    And "Jonah" tells that she "is" registered with companies house
+    And "Jonah" says that his company "is" incorporated
     And "Jonah" "<company_name_action>" his company name
 
 
@@ -142,7 +142,7 @@ Feature: Triage
 
     When "Jonah" selects his sector
     And "Jonah" says that he "has never" exported before
-    And "Jonah" tells that she "is" registered with companies house
+    And "Jonah" says that his company "is" incorporated
     And "Jonah" "<company_name_action>" his company name
     And "Jonah" sees the summary page with answers to the questions he was asked
     And "Jonah" decides to create his personalised journey page
@@ -166,9 +166,9 @@ Feature: Triage
     When "Inigo" selects his sector
     And "Inigo" says that he "has" exported before
     And "Inigo" says that exporting is "not a regular" part of his business
-    And "Inigo" says that he "<online_action>" used online marketplaces
-    And "Inigo" tells that she "is" registered with companies house
-    And "Inigo" "<company_name_action>" his company name
+    And "Inigo" says that she "<online_action>" used online marketplaces
+    And "Inigo" says that her company "is" incorporated
+    And "Inigo" "<company_name_action>" her company name
 
 
     Then "Inigo" should see the summary page with answers to the questions she was asked

--- a/tests/exred/features/triage.feature
+++ b/tests/exred/features/triage.feature
@@ -13,9 +13,10 @@ Feature: Triage
     And "Nadia" says that her company "is" incorporated
     And "Nadia" "<company_name_action>" her company name
     And "Nadia" sees the summary page with answers to the questions she was asked
+    And "Nadia" can see that she was classified as a "regular" exporter
     And "Nadia" decides to create her personalised journey page
 
-    Then "Nadia" should be on the personalised "regular exporter" journey page
+    Then "Nadia" should be on the personalised "regular" exporter journey page
 
     Examples:
       | company_name_action  |
@@ -37,11 +38,11 @@ Feature: Triage
     And "Inigo" says that he "<online_action>" used online marketplaces
     And "Inigo" says that her company "is" incorporated
     And "Inigo" "<company_name_action>" his company name
-
     And "Inigo" sees the summary page with answers to the questions he was asked
+    And "Inigo" can see that she was classified as a "occasional" exporter
     And "Inigo" decides to create her personalised journey page
 
-    Then "Inigo" should be on the personalised "occasional exporter" journey page
+    Then "Inigo" should be on the personalised "occasional" exporter journey page
 
     Examples:
       | online_action | company_name_action  |
@@ -65,8 +66,10 @@ Feature: Triage
     And "Jonah" says that his company "is" incorporated
     And "Jonah" "<company_name_action>" his company name
     And "Jonah" sees the summary page with answers to the questions he was asked
+    And "Jonah" can see that she was classified as a "new" exporter
     And "Jonah" decides to create his personalised journey page
-    Then "Jonah" should be on the personalised "new exporter" journey page
+
+    Then "Jonah" should be on the personalised "new" exporter journey page
 
     Examples:
       | company_name_action  |
@@ -124,7 +127,7 @@ Feature: Triage
 
 
     Then "Nadia" should see the summary page with answers to the questions she was asked
-    And "Nadia" should be classified as "new exporter"
+    And "Nadia" should be classified as "new" exporter
 
     Examples:
       | company_name_action  |
@@ -145,9 +148,10 @@ Feature: Triage
     And "Jonah" says that his company "is" incorporated
     And "Jonah" "<company_name_action>" his company name
     And "Jonah" sees the summary page with answers to the questions he was asked
+    And "Jonah" can see that she was classified as a "new" exporter
     And "Jonah" decides to create his personalised journey page
 
-    Then "Jonah" should be on the personalised "new exporter" journey page
+    Then "Jonah" should be on the personalised "new" exporter journey page
 
     Examples:
       | company_name_action  |
@@ -172,7 +176,7 @@ Feature: Triage
 
 
     Then "Inigo" should see the summary page with answers to the questions she was asked
-    And "Inigo" should be classified as (the header on summary says) "occasional exporter"
+    And "Inigo" should be classified as "occasional" exporter
 
     Examples:
       | online_action | company_name_action  |

--- a/tests/exred/features/triage.feature
+++ b/tests/exred/features/triage.feature
@@ -35,7 +35,7 @@ Feature: Triage
     When "Inigo" says what does she wants to export
     And "Inigo" says that she "has" exported before
     And "Inigo" says that exporting is "not a regular" part of her business
-    And "Inigo" says that he "<online_action>" used online marketplaces
+    And "Inigo" says that she "<online_action>" used online marketplaces
     And "Inigo" says that her company "is" incorporated
     And "Inigo" "<company_name_action>" his company name
     And "Inigo" sees the summary page with answers to the questions he was asked
@@ -164,7 +164,7 @@ Feature: Triage
   @ED-2528
   @classification
   Scenario Outline: Triaging should help to identify "occasional exporter"
-    Given "Inigo" visits the home page for the first time
+    Given "Inigo" visits the "home" page for the first time
     And "Inigo" decided to build his exporting journey
 
     When "Inigo" says what does she wants to export

--- a/tests/exred/pages/guidance_common.py
+++ b/tests/exred/pages/guidance_common.py
@@ -167,8 +167,9 @@ def check_elements_are_visible(driver: webdriver, elements: list):
                 driver, "Could not find '%s' on '%s' using '%s' selector",
                 element, driver.current_url, selector):
             page_element = driver.find_element_by_css_selector(selector)
-            action_chains = ActionChains(driver)
-            action_chains.move_to_element(page_element)
-            action_chains.perform()
+            if driver.capabilities["browserName"].lower() == "edge":
+                action_chains = ActionChains(driver)
+                action_chains.move_to_element(page_element)
+                action_chains.perform()
         with assertion_msg("Expected to see '%s' but can't see it", element):
             assert page_element.is_displayed()

--- a/tests/exred/pages/guidance_common.py
+++ b/tests/exred/pages/guidance_common.py
@@ -97,9 +97,11 @@ def show_all_articles(driver: webdriver):
         show_more_button.click()
         counter += 1
     if counter > max_clicks:
-        logging.warning(
-            "Expected 'Show more' button to disappear after clicking on it for"
-            " %d times.", counter)
+        with assertion_msg(
+                "'Show more' button didn't disappear after clicking on it for"
+                " %d times", counter):
+            assert counter == max_clicks
+    take_screenshot(driver, NAME + " after showing all articles")
 
 
 def check_if_correct_articles_are_displayed(

--- a/tests/exred/pages/guidance_common.py
+++ b/tests/exred/pages/guidance_common.py
@@ -89,9 +89,17 @@ def correct_article_read_counter(
 
 
 def show_all_articles(driver: webdriver):
-    button = driver.find_element_by_css_selector(SHOW_MORE_BUTTON)
-    while button.is_displayed():
-        button.click()
+    show_more_button = driver.find_element_by_css_selector(SHOW_MORE_BUTTON)
+    max_clicks = 10
+    counter = 0
+    # click up to 11 times - see bug ED-2561
+    while show_more_button.is_displayed() and counter <= max_clicks:
+        show_more_button.click()
+        counter += 1
+    if counter > max_clicks:
+        logging.warning(
+            "Expected 'Show more' button to disappear after clicking on it for"
+            " %d times.", counter)
 
 
 def check_if_correct_articles_are_displayed(

--- a/tests/exred/pages/guidance_common.py
+++ b/tests/exred/pages/guidance_common.py
@@ -3,6 +3,7 @@
 import logging
 
 from selenium import webdriver
+from selenium.webdriver import ActionChains
 
 from registry.articles import get_articles
 from utils import assertion_msg, selenium_action, take_screenshot
@@ -166,5 +167,8 @@ def check_elements_are_visible(driver: webdriver, elements: list):
                 driver, "Could not find '%s' on '%s' using '%s' selector",
                 element, driver.current_url, selector):
             page_element = driver.find_element_by_css_selector(selector)
+            action_chains = ActionChains(driver)
+            action_chains.move_to_element(page_element)
+            action_chains.perform()
         with assertion_msg("Expected to see '%s' but can't see it", element):
             assert page_element.is_displayed()

--- a/tests/exred/pages/guidance_common.py
+++ b/tests/exred/pages/guidance_common.py
@@ -167,7 +167,8 @@ def check_elements_are_visible(driver: webdriver, elements: list):
                 driver, "Could not find '%s' on '%s' using '%s' selector",
                 element, driver.current_url, selector):
             page_element = driver.find_element_by_css_selector(selector)
-            if driver.capabilities["browserName"].lower() == "edge":
+            if "firefox" not in driver.capabilities["browserName"].lower():
+                logging.debug("Moving focus to '%s' element", element)
                 action_chains = ActionChains(driver)
                 action_chains.move_to_element(page_element)
                 action_chains.perform()

--- a/tests/exred/pages/guidance_common.py
+++ b/tests/exred/pages/guidance_common.py
@@ -160,6 +160,9 @@ def check_elements_are_visible(driver: webdriver, elements: list):
     take_screenshot(driver, NAME)
     for element in elements:
         selector = SCOPE_ELEMENTS[element.lower()]
-        page_element = driver.find_element_by_css_selector(selector)
-        with assertion_msg("Expected to see '%s' but can't see it"):
+        with selenium_action(
+                driver, "Could not find '%s' on '%s' using '%s' selector",
+                element, driver.current_url, selector):
+            page_element = driver.find_element_by_css_selector(selector)
+        with assertion_msg("Expected to see '%s' but can't see it", element):
             assert page_element.is_displayed()

--- a/tests/exred/pages/home.py
+++ b/tests/exred/pages/home.py
@@ -6,7 +6,7 @@ from urllib.parse import urljoin
 from selenium import webdriver
 
 from settings import EXRED_UI_URL
-from utils import assertion_msg, take_screenshot
+from utils import assertion_msg, selenium_action, take_screenshot
 
 NAME = "ExRed Home"
 URL = urljoin(EXRED_UI_URL, "")
@@ -117,7 +117,12 @@ def should_see_sections(driver: webdriver, section_names: list):
             logging.debug(
                 "Looking for '%s' element in '%s' section with '%s' selector",
                 element_name, section_name, element_selector)
-            element = driver.find_element_by_css_selector(element_selector)
+            with selenium_action(
+                    driver,
+                    "Could not find '%s' in '%s' section using following "
+                    "selector '%s'", element_name, section_name,
+                    element_selector):
+                element = driver.find_element_by_css_selector(element_selector)
             with assertion_msg(
                     "It looks like '%s' in '%s' section is not visible (%s)",
                     element_name, section_name, browser):

--- a/tests/exred/pages/home.py
+++ b/tests/exred/pages/home.py
@@ -52,9 +52,9 @@ SECTIONS = {
     },
     "guidance": {
         "itself": "#resource-guidance",
-        "header": "#resource-guidance > .container .section-header",
-        "intro": "#resource-guidance > .container .section-intro",
-        "groups": "#resource-guidance > .container .group",
+        "header": "#resource-guidance .section-header",
+        "intro": "#resource-guidance .intro",
+        "groups": "#resource-guidance .group",
         "market research": MARKET_RESEARCH_LINK,
         "customer insight": CUSTOMER_INSIGHT_LINK,
         "finance": FINANCE_LINK,

--- a/tests/exred/pages/personalised_journey.py
+++ b/tests/exred/pages/personalised_journey.py
@@ -147,9 +147,17 @@ def show_all_articles(driver: webdriver):
     with selenium_action(
             driver, "Could not find 'Show More' button using '%s'",
             SHOW_MORE_BUTTON):
-        button = driver.find_element_by_css_selector(SHOW_MORE_BUTTON)
-    while button.is_displayed():
-        button.click()
+        show_more_button = driver.find_element_by_css_selector(SHOW_MORE_BUTTON)
+    max_clicks = 10
+    counter = 0
+    # click up to 11 times - see bug ED-2561
+    while show_more_button.is_displayed() and counter <= max_clicks:
+        show_more_button.click()
+        counter += 1
+    if counter > max_clicks:
+        logging.warning(
+            "Expected 'Show more' button to disappear after clicking on it for"
+            " %d times.", counter)
     take_screenshot(driver, NAME + " after showing all articles")
 
 

--- a/tests/exred/pages/personalised_journey.py
+++ b/tests/exred/pages/personalised_journey.py
@@ -21,41 +21,96 @@ FINANCE_LINK = "#resource-guidance a[href='/finance']"
 BUSINESS_LINK = "#resource-guidance a[href='/business-planning']"
 GETTING_PAID_LINK = "#resource-guidance a[href='/getting-paid']"
 OPERATIONS_AND_COMPLIANCE_LINK = "#resource-guidance a[href='/operations-and-compliance']"
-
+TOP_IMPORTER = "#top_importer_name"
+TRADE_VALUE = "#top_importer_global_trade_value"
+TOP_10_TRADE_VALUE = ".cell-global_trade_value"
 SECTIONS = {
     "hero": {
-        "hero - title": "section.hero-section h1",
-        "hero - introduction": "section.hero-section p",
-        "hero - exporting is great logo": "section.hero-section img",
+        "title": "section.hero-section h1",
+        "introduction": "section.hero-section p",
+        "exporting is great logo": "section.hero-section img",
+        "update preferences link": "section.hero-section a.preferences",
     },
     "facts": {
-        "facts - intro": "#content > section.sector-fact p.intro",
-        "facts - figures": "#content > section.sector-fact p.figure",
+        "intro": "#content > section.sector-fact p.intro",
+        "figures": "#content > section.sector-fact p.figure",
     },
     "articles": {
-        "articles - heading": "#persona-overview h2",
-        "articles - introduction": "#persona-overview p.intro",
-        "articles - article list": "#persona-overview div.section-content-list",
+        "heading": "#persona-overview h2",
+        "introduction": "#persona-overview p.intro",
+        "article list": "#persona-overview div.section-content-list",
     },
     "top 10": {
-        "top 10 - heading": "#content > section.markets h1",
-        "top 10 - table": "#content > section.markets table",
+        "heading": "section.top-markets h2",
+        "intro": "section.top-markets .intro",
+        "table": "#top-of-the-markets",
+        "source data": "section.top-markets #market-source-data",
     },
     "services": {
-        "services - heading": "section.service-section h2",
-        "services - intro": "section.service-section .intro",
-        "services - other": "#other-services > div > div",
+        "heading": "section.service-section h2",
+        "intro": "section.service-section .intro",
+        "other": "#other-services > div > div",
+    },
+    "fas section": {
+        "heading": "section.service-section.fas h2",
+        "fas image": "section.service-section.fas img",
+        "intro": "section.service-section.fas .intro",
+        "create a trade profile": "section.service-section.fas .intro .button",
+    },
+    "exopps tile": {
+        "heading": "#other-services div.lg-2:nth-child(2) h3",
+        "soo image": "#other-services div.lg-2:nth-child(2) img",
+        "intro": "#other-services div.lg-2:nth-child(2) p",
+        "find marketplaces link": "#other-services div.lg-2:nth-child(2) a",
+    },
+    "exopps section": {
+        "heading": "section.service-section.soo h2",
+        "soo image": "section.service-section.soo img",
+        "intro": "section.service-section.soo .intro",
+        "find marketplaces button": "section.service-section.soo .intro .button",
+    },
+    "soo section": {
+        "heading": "section.service-section.soo h2",
+        "soo image": "section.service-section.soo img",
+        "intro": "section.service-section.soo .intro",
+        "find marketplaces button": "section.service-section.soo .intro .button",
+    },
+    "soo tile": {
+        "heading": "#other-services div.lg-2:nth-child(1) h3",
+        "soo image": "#other-services div.lg-2:nth-child(1) img",
+        "intro": "#other-services div.lg-2:nth-child(1) p",
+        "find marketplaces link": "#other-services div.lg-2:nth-child(1) a",
+    },
+    "article list": {
+        "itself": "#articles",
+        "heading": "#articles h2",
+        "introduction": "#articles .intro",
+        "article list": "#articles .section-content-list",
     },
     "guidance": {
-        "guidance - heading": "#resource-guidance h2",
-        "guidance - introduction": "#resource-guidance p.section-intro",
-        "guidance - categories": "#resource-guidance div.group",
+        "itself": "#resource-guidance",
+        "guidance - heading": "#resource-guidance h2.section-header",
+        "guidance - introduction": "#resource-guidance p.intro",
+        "guidance - categories": "#resource-guidance .group",
         "market research": MARKET_RESEARCH_LINK,
         "customer insight": CUSTOMER_INSIGHT_LINK,
         "finance": FINANCE_LINK,
         "business planning": BUSINESS_LINK,
         "getting paid": GETTING_PAID_LINK,
         "operations and compliance": OPERATIONS_AND_COMPLIANCE_LINK,
+    },
+    "case studies": {
+        "heading": "#carousel h2",
+        "intro": "#carousel .intro",
+        "article": "#carousel .ed-carousel-container",
+        "previous article": "#carousel label.ed-carousel__control--backward",
+        "next article": "#carousel label.ed-carousel__control--forward",
+        "case study head link": ".ed-carousel__track > div:nth-child(1) h3 a",
+        "case study intro": ".ed-carousel__track > div:nth-child(1) p",
+        "case study intro link": ".ed-carousel__track > div:nth-child(1) div > a",
+        "carousel indicator #1": "#carousel .ed-carousel__indicator[for='1']",
+        "carousel indicator #2": "#carousel .ed-carousel__indicator[for='2']",
+        "carousel indicator #3": "#carousel .ed-carousel__indicator[for='3']",
     }
 }
 

--- a/tests/exred/pages/personalised_journey.py
+++ b/tests/exred/pages/personalised_journey.py
@@ -172,9 +172,10 @@ def should_see_read_counter(
             driver, "Could not find 'Article Read Counter' using '%s'",
             READ_COUNTER):
         counter = driver.find_element_by_css_selector(READ_COUNTER)
-        action_chains = ActionChains(driver)
-        action_chains.move_to_element(counter)
-        action_chains.perform()
+        if driver.capabilities["browserName"].lower() == "edge":
+            action_chains = ActionChains(driver)
+            action_chains.move_to_element(counter)
+            action_chains.perform()
     with assertion_msg(
             "Guidance Article Read Counter is not visible on '%s' page", NAME):
         assert counter.is_displayed()

--- a/tests/exred/pages/personalised_journey.py
+++ b/tests/exred/pages/personalised_journey.py
@@ -5,6 +5,7 @@ from urllib.parse import urljoin
 
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
@@ -171,6 +172,9 @@ def should_see_read_counter(
             driver, "Could not find 'Article Read Counter' using '%s'",
             READ_COUNTER):
         counter = driver.find_element_by_css_selector(READ_COUNTER)
+        action_chains = ActionChains(driver)
+        action_chains.move_to_element(counter)
+        action_chains.perform()
     with assertion_msg(
             "Guidance Article Read Counter is not visible on '%s' page", NAME):
         assert counter.is_displayed()

--- a/tests/exred/pages/personalised_journey.py
+++ b/tests/exred/pages/personalised_journey.py
@@ -194,3 +194,21 @@ def should_see_section(driver: webdriver, name: str):
         with assertion_msg(
                 "'%s' in '%s' is not displayed", key, name):
             assert element.is_displayed()
+
+
+def check_top_facts_values(driver: webdriver):
+    top_importer = driver.find_element_by_css_selector(TOP_IMPORTER).text
+    trade_value = driver.find_element_by_css_selector(TRADE_VALUE).text
+
+    try:
+        tr = driver.find_element_by_css_selector(
+            "#row-{}".format(top_importer))
+        cell = tr.find_element_by_css_selector(TOP_10_TRADE_VALUE).text
+        with assertion_msg(
+                "Expected to see 'Export value from the world' for %s to be %s"
+                " but got %s", top_importer, trade_value, cell):
+            assert cell == trade_value
+    except NoSuchElementException:
+        logging.debug(
+            "Country mentioned in Top Facts: %s is not present in the Top 10 "
+            "Importers table. Won't check the the trade value")

--- a/tests/exred/pages/personalised_journey.py
+++ b/tests/exred/pages/personalised_journey.py
@@ -4,6 +4,10 @@ import logging
 from urllib.parse import urljoin
 
 from selenium import webdriver
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.wait import WebDriverWait
 
 from registry.articles import get_articles
 from settings import EXRED_UI_URL
@@ -175,3 +179,18 @@ def open(driver: webdriver, group: str, element: str):
     button.click()
     take_screenshot(
         driver, NAME + " after clicking on: %s link".format(element))
+
+
+def should_see_section(driver: webdriver, name: str):
+    section = SECTIONS[name]
+    for key, selector in section.items():
+        with selenium_action(
+                driver, "Could not find: '%s' element in '%s' section using "
+                        "'%s' selector",
+                key, name, selector):
+            element = driver.find_element_by_css_selector(selector)
+            WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located((By.CSS_SELECTOR, selector)))
+        with assertion_msg(
+                "'%s' in '%s' is not displayed", key, name):
+            assert element.is_displayed()

--- a/tests/exred/pages/personalised_journey.py
+++ b/tests/exred/pages/personalised_journey.py
@@ -172,7 +172,8 @@ def should_see_read_counter(
             driver, "Could not find 'Article Read Counter' using '%s'",
             READ_COUNTER):
         counter = driver.find_element_by_css_selector(READ_COUNTER)
-        if driver.capabilities["browserName"].lower() == "edge":
+        if "firefox" not in driver.capabilities["browserName"].lower():
+            logging.debug("Moving focus to 'Read Counter' on %s", NAME)
             action_chains = ActionChains(driver)
             action_chains.move_to_element(counter)
             action_chains.perform()

--- a/tests/exred/pages/personalised_journey.py
+++ b/tests/exred/pages/personalised_journey.py
@@ -18,6 +18,7 @@ URL = urljoin(EXRED_UI_URL, "custom")
 
 SHOW_MORE_BUTTON = "#js-paginate-list-more"
 READ_COUNTER = "#articles .scope-indicator .position > span.from"
+TOTAL_ARTICLES = "#articles .scope-indicator .position > span.to"
 
 MARKET_RESEARCH_LINK = "#resource-guidance a[href='/market-research']"
 CUSTOMER_INSIGHT_LINK = "#resource-guidance a[href='/customer-insight']"
@@ -161,12 +162,31 @@ def show_all_articles(driver: webdriver):
     take_screenshot(driver, NAME + " after showing all articles")
 
 
-def should_see_read_counter(driver: webdriver, *, exporter_status: str = None):
+def should_see_read_counter(
+        driver: webdriver, *, exporter_status: str = None,
+        expected_number_articles: int = 0):
     show_all_articles(driver)
     with selenium_action(
-            driver, "Could not find 'Show More' button using '%s'",
-            SHOW_MORE_BUTTON):
+            driver, "Could not find 'Article Read Counter' using '%s'",
+            READ_COUNTER):
         counter = driver.find_element_by_css_selector(READ_COUNTER)
+    with assertion_msg(
+            "Guidance Article Read Counter is not visible on '%s' page", NAME):
+        assert counter.is_displayed()
+    given_number_articles = int(counter.text)
+    with assertion_msg(
+            "Expected the Article Read Counter to be: %d but got %d",
+            expected_number_articles, given_number_articles):
+        assert given_number_articles == expected_number_articles
+
+
+def should_see_total_articles_to_read(
+        driver: webdriver, *, exporter_status: str = None):
+    show_all_articles(driver)
+    with selenium_action(
+            driver, "Could not find 'Total Articles to Read' using '%s'",
+            TOTAL_ARTICLES):
+        counter = driver.find_element_by_css_selector(TOTAL_ARTICLES)
     with assertion_msg(
             "Guidance Article Read Counter is not visible on '%s' page", NAME):
         assert counter.is_displayed()

--- a/tests/exred/pages/personalised_journey.py
+++ b/tests/exred/pages/personalised_journey.py
@@ -156,9 +156,10 @@ def show_all_articles(driver: webdriver):
         show_more_button.click()
         counter += 1
     if counter > max_clicks:
-        logging.warning(
-            "Expected 'Show more' button to disappear after clicking on it for"
-            " %d times.", counter)
+        with assertion_msg(
+                "'Show more' button didn't disappear after clicking on it for"
+                " %d times", counter):
+            assert counter == max_clicks
     take_screenshot(driver, NAME + " after showing all articles")
 
 

--- a/tests/exred/pages/personalised_journey.py
+++ b/tests/exred/pages/personalised_journey.py
@@ -212,3 +212,15 @@ def check_top_facts_values(driver: webdriver):
         logging.debug(
             "Country mentioned in Top Facts: %s is not present in the Top 10 "
             "Importers table. Won't check the the trade value")
+
+
+def check_facts_and_top_10(driver: webdriver, sector_code: str):
+    """There are no Facts & Top 10 data for Service Sectors (start with EB)."""
+    if sector_code.startswith("EB"):
+        logging.debug(
+            "Exported chose service sector: %s for which there are no facts "
+            "and information on top 10 importers", sector_code)
+    else:
+        should_see_section(driver, "facts")
+        should_see_section(driver, "top 10")
+        check_top_facts_values(driver)

--- a/tests/exred/pages/personalised_journey.py
+++ b/tests/exred/pages/personalised_journey.py
@@ -224,3 +224,54 @@ def check_facts_and_top_10(driver: webdriver, sector_code: str):
         should_see_section(driver, "facts")
         should_see_section(driver, "top 10")
         check_top_facts_values(driver)
+
+
+def layout_for_new_exporter(
+        driver: webdriver, incorporated: bool, sector_code: str):
+    """
+    * a new exporter says his company incorporated, then only `FAB` is displayed
+    * a new exporter says his company is not incorporated, then `no services are displayed`
+    """
+    should_see_section(driver, "hero")
+    check_facts_and_top_10(driver, sector_code)
+    should_see_section(driver, "article list")
+    if incorporated:
+        should_see_section(driver, "fas section")
+    should_see_section(driver, "case studies")
+
+
+def layout_for_occasional_exporter(
+        driver: webdriver, incorporated: bool, use_online_marketplaces: bool,
+        sector_code: str):
+    """
+    * an occasional exporter says his company used online marketplaces and is incorporated, then `FAB & SOO` are displayed
+    * an occasional exporter says his company used online marketplaces but it is not incorporated, then only `SOO` is displayed
+    * an occasional exporter says his company haven't used online marketplaces but it is incorporated, then only `FAB` is displayed
+    * an occasional exporter says his company haven't used online marketplaces and it is not incorporated, then `no services are displayed`
+    """
+    should_see_section(driver, "hero")
+    check_facts_and_top_10(driver, sector_code)
+    should_see_section(driver, "article list")
+    if incorporated and use_online_marketplaces:
+        should_see_section(driver, "fas section")
+        should_see_section(driver, "soo section")
+    if not incorporated and use_online_marketplaces:
+        should_see_section(driver, "soo section")
+    if not incorporated and not use_online_marketplaces:
+        logging.debug("Nothing to show here")
+    should_see_section(driver, "case studies")
+
+
+def layout_for_regular_exporter(
+        driver: webdriver, incorporated: bool, sector_code: str):
+    """
+    * a regular exporter says his company is incorporated, then `FAB, SOO & ExOpps` are displayed
+    * a regular exporter says his company is not incorporated, then `SOO & ExOpps` are displayed
+    """
+    should_see_section(driver, "hero")
+    check_facts_and_top_10(driver, sector_code)
+    if incorporated:
+        should_see_section(driver, "fas section")
+    should_see_section(driver, "soo tile")
+    should_see_section(driver, "exopps tile")
+    should_see_section(driver, "guidance")

--- a/tests/exred/pages/triage_company_name.py
+++ b/tests/exred/pages/triage_company_name.py
@@ -16,6 +16,7 @@ NAME = "ExRed Triage - What is your company name"
 URL = urljoin(EXRED_UI_URL, "triage")
 
 COMPANY_NAME_INPUT = "#js-typeahead-company-name"
+QUESTION = "label[for=js-typeahead-company-name]"
 SUGGESTIONS = "ul.SelectiveLookupDisplay"
 FIRST_SUGGESTION = "ul.SelectiveLookupDisplay > li:nth-child(1)"
 CONTINUE_BUTTON = ".exred-triage-form button.button"
@@ -40,6 +41,15 @@ def should_be_here(driver: webdriver):
             assert element.is_displayed()
     take_screenshot(driver, NAME)
     logging.debug("All expected elements are visible on '%s' page", NAME)
+
+
+def hide_suggestions(driver: webdriver):
+    suggestions = driver.find_element_by_css_selector(SUGGESTIONS)
+    WebDriverWait(driver, 5).until(
+        EC.visibility_of_element_located((By.CSS_SELECTOR, SUGGESTIONS)))
+    if suggestions.is_displayed():
+        question = driver.find_element_by_css_selector(QUESTION)
+        question.click()
 
 
 def click_on_first_suggestion(driver: webdriver):

--- a/tests/exred/pages/triage_company_name.py
+++ b/tests/exred/pages/triage_company_name.py
@@ -15,8 +15,8 @@ from utils import assertion_msg, take_screenshot
 NAME = "ExRed Triage - What is your company name"
 URL = urljoin(EXRED_UI_URL, "triage")
 
-COMPANY_NAME_INPUT = "#js-typeahead-company-name"
 QUESTION = "label[for=js-typeahead-company-name]"
+COMPANY_NAME_INPUT = "js-typeahead-company-name"
 SUGGESTIONS = "ul.SelectiveLookupDisplay"
 FIRST_SUGGESTION = "ul.SelectiveLookupDisplay > li:nth-child(1)"
 CONTINUE_BUTTON = ".exred-triage-form button.button"
@@ -61,16 +61,18 @@ def click_on_first_suggestion(driver: webdriver):
         first_suggestion.click()
 
 
-def enter_company_name(driver: webdriver, company_name: str = None) -> str:
+def enter_company_name(driver: webdriver, company_name: str = None):
     if not company_name:
         company_name = random.choice(["automated", "browser", "tests"])
-    input_field = driver.find_element_by_css_selector(COMPANY_NAME_INPUT)
+    input_field = driver.find_element_by_id(COMPANY_NAME_INPUT)
     input_field.clear()
     input_field.send_keys(company_name)
-    click_on_first_suggestion(driver)
     take_screenshot(driver, NAME + " after typing in company name")
-    input_field = driver.find_element_by_css_selector(COMPANY_NAME_INPUT)
-    return input_field.text
+
+
+def get_company_name(driver: webdriver) -> str:
+    input_field = driver.find_element_by_id(COMPANY_NAME_INPUT)
+    return input_field.get_attribute("value")
 
 
 def submit(driver: webdriver):

--- a/tests/exred/pages/triage_result.py
+++ b/tests/exred/pages/triage_result.py
@@ -12,15 +12,16 @@ NAME = "ExRed Triage - result"
 URL = urljoin(EXRED_UI_URL, "triage/result")
 
 CLASSIFICATION = ".question > h2"
-ANSWERS = "div.answers"
+ANSWERS_SECTION = "div.answers"
 CREATE_MY_JOURNEY_BUTTON = "input.button.next"
 PREVIOUS_STEP_BUTTON = "input.button.next ~ button.previous-step"
 CHANGE_ANSWERS_LINK = "#change-answers-button-container > button"
 BACK_TO_HOME_LINK = ".home-link a"
-
+QUESTIONS = ".answers > dl > dt"
+ANSWERS = ".answers > dl > dd"
 EXPECTED_ELEMENTS = {
     "classification": CLASSIFICATION,
-    "answers section": ANSWERS,
+    "answers section": ANSWERS_SECTION,
     "continue button": CREATE_MY_JOURNEY_BUTTON,
     "change answers link": CHANGE_ANSWERS_LINK,
     "back to home link": BACK_TO_HOME_LINK
@@ -68,3 +69,12 @@ def create_exporting_journey(driver: webdriver):
     assert button.is_displayed()
     button.click()
     take_screenshot(driver, NAME + " after submitting")
+
+
+def get_questions_and_answers(driver: webdriver) -> dict:
+    questions = driver.find_elements_by_css_selector(QUESTIONS)
+    answers = driver.find_elements_by_css_selector(ANSWERS)
+    result = {}
+    for q, a in list(zip(questions, answers)):
+        result.update({q.text: a.text})
+    return result

--- a/tests/exred/pages/triage_result.py
+++ b/tests/exred/pages/triage_result.py
@@ -78,3 +78,9 @@ def get_questions_and_answers(driver: webdriver) -> dict:
     for q, a in list(zip(questions, answers)):
         result.update({q.text: a.text})
     return result
+
+
+def change_answers(driver: webdriver):
+    link = driver.find_element_by_css_selector(CHANGE_ANSWERS_LINK)
+    link.click()
+    take_screenshot(driver, NAME + " after deciding to change the answers")

--- a/tests/exred/pages/triage_what_do_you_want_to_export.py
+++ b/tests/exred/pages/triage_what_do_you_want_to_export.py
@@ -46,11 +46,11 @@ def should_be_here(driver: webdriver):
     logging.debug("All expected elements are visible on '%s' page", NAME)
 
 
-def select_sector(driver: webdriver, sector: str) -> str:
-    """Select specific sector or use randomly select one.
+def enter(driver: webdriver, sector: str) -> str:
+    """Enter information about the things you want to export.
 
     :param driver: webdriver object
-    :param sector: specific sector to use. Will select random if not set.
+    :param sector: specific product to use. Will select random if not set.
     :return: selected sector, might be different that t
     """
     if not sector:

--- a/tests/exred/pages/triage_what_do_you_want_to_export.py
+++ b/tests/exred/pages/triage_what_do_you_want_to_export.py
@@ -60,9 +60,13 @@ def enter(driver: webdriver, code: str, sector: str) -> tuple:
         code, sector = random.choice(list(EXRED_SECTORS.items()))
     with selenium_action(driver, "Can't find Sector selector input box"):
         input_field = driver.find_element_by_css_selector(SECTORS_INPUT)
-    input_field.click()
-    input_field.clear()
-    input_field.send_keys(code or sector)
+    max_retries = 5
+    counter = 0
+    while (code.lower() not in input_field.get_attribute("value").lower()) and (counter < max_retries):
+        input_field.click()
+        input_field.clear()
+        input_field.send_keys(code or sector)
+        counter += 1
     with selenium_action(driver, "Can't find Autocomplete 1st option"):
         option = driver.find_element_by_css_selector(AUTOCOMPLETE_1ST_OPTION)
     option.click()

--- a/tests/exred/pages/triage_what_do_you_want_to_export.py
+++ b/tests/exred/pages/triage_what_do_you_want_to_export.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Triage - What is you sector? Page Object."""
+"""Triage - What do you want to export? Page Object."""
 import logging
 import random
 from urllib.parse import urljoin
@@ -9,7 +9,7 @@ from selenium import webdriver
 from settings import EXRED_SECTORS, EXRED_UI_URL
 from utils import assertion_msg, selenium_action, take_screenshot
 
-NAME = "ExRed Triage - what is your sector"
+NAME = "ExRed Triage - what do you want to export"
 URL = urljoin(EXRED_UI_URL, "triage")
 
 SECTORS_COMBOBOX = ".exred-triage-form div[role=combobox]"

--- a/tests/exred/pages/triage_what_do_you_want_to_export.py
+++ b/tests/exred/pages/triage_what_do_you_want_to_export.py
@@ -46,25 +46,28 @@ def should_be_here(driver: webdriver):
     logging.debug("All expected elements are visible on '%s' page", NAME)
 
 
-def enter(driver: webdriver, sector: str) -> str:
+def enter(driver: webdriver, code: str, sector: str) -> tuple:
     """Enter information about the things you want to export.
 
     :param driver: webdriver object
+    :param code: sector code. Codes for:
+                 Goods start with HS, and for Services with EB (no facts are
+                 available for such codes)
     :param sector: specific product to use. Will select random if not set.
-    :return: selected sector, might be different that t
+    :return: selected code & sector name
     """
-    if not sector:
-        sector = random.choice(list(EXRED_SECTORS.values()))
+    if not code and not sector:
+        code, sector = random.choice(list(EXRED_SECTORS.items()))
     with selenium_action(driver, "Can't find Sector selector input box"):
         input_field = driver.find_element_by_css_selector(SECTORS_INPUT)
     input_field.click()
     input_field.clear()
-    input_field.send_keys(sector)
+    input_field.send_keys(code or sector)
     with selenium_action(driver, "Can't find Autocomplete 1st option"):
         option = driver.find_element_by_css_selector(AUTOCOMPLETE_1ST_OPTION)
     option.click()
     take_screenshot(driver, NAME)
-    return sector
+    return code, sector
 
 
 def submit(driver: webdriver):

--- a/tests/exred/registry/pages.py
+++ b/tests/exred/registry/pages.py
@@ -10,7 +10,7 @@ from pages import (
     triage_do_you_use_online_marketplaces,
     triage_have_you_exported,
     triage_result,
-    triage_what_is_your_sector
+    triage_what_do_you_want_to_export
 )
 
 EXRED_PAGE_REGISTRY = {
@@ -18,9 +18,9 @@ EXRED_PAGE_REGISTRY = {
         "url": home.URL,
         "po": home
     },
-    "triage - what is your sector": {
-        "url": triage_what_is_your_sector.URL,
-        "po": triage_what_is_your_sector
+    "triage - what do you want to export": {
+        "url": triage_what_do_you_want_to_export.URL,
+        "po": triage_what_do_you_want_to_export
     },
     "triage - have you exported before": {
         "url": triage_have_you_exported.URL,

--- a/tests/exred/settings.py
+++ b/tests/exred/settings.py
@@ -15,6 +15,7 @@ TASK_ID = int(os.environ.get("TASK_ID", 0))
 
 # optional variables set by user
 BROWSERS = os.environ.get("BROWSERS", "").split()
+BROWSERS_VERSIONS = os.environ.get("VERSIONS", "").split()
 HUB_URL = os.environ.get("HUB_URL", None)
 CAPABILITIES = os.environ.get("CAPABILITIES", None)
 BUILD_ID = os.environ.get("CIRCLE_SHA1", str(datetime.date(datetime.now())))
@@ -30,10 +31,10 @@ BROWSERSTACK_EXECUTOR_URL = ("http://{}:{}@{}/wd/hub".format(
 BROWSERSTACK_SESSIONS_URL = "https://www.browserstack.com/automate/sessions/{}.json"
 
 
-if (CONFIG_NAME == "browserstack" and
+if (CONFIG_NAME.startswith("browserstack") and
         (BROWSERSTACK_SERVER and BROWSERSTACK_USER and BROWSERSTACK_PASS)):
     HUB_URL = BROWSERSTACK_EXECUTOR_URL
 
 CONFIG = config.get(
-    config_file=CONFIG_NAME, hub_url=HUB_URL,
-    capabilities=CAPABILITIES, browsers=BROWSERS, build_id=BUILD_ID)
+    config_file=CONFIG_NAME, hub_url=HUB_URL, capabilities=CAPABILITIES,
+    browsers=BROWSERS, versions=BROWSERS_VERSIONS, build_id=BUILD_ID)

--- a/tests/exred/steps/given_def.py
+++ b/tests/exred/steps/given_def.py
@@ -8,6 +8,7 @@ from steps.when_impl import (
     guidance_open_category,
     start_triage,
     triage_classify_as,
+    triage_create_exporting_journey,
     visit_page
 )
 
@@ -39,7 +40,7 @@ def given_actor_was_classified_as(context, actor_alias, exporter_status):
     triage_classify_as(context, actor_alias, exporter_status=exporter_status)
 
 
-@given('"{actor_alias}" has answered triage questions')
+@given('"{actor_alias}" answered triage questions')
 def given_actor_answered_triage_questions(context, actor_alias):
     triage_classify_as(context, actor_alias)
 

--- a/tests/exred/steps/given_def.py
+++ b/tests/exred/steps/given_def.py
@@ -12,15 +12,15 @@ from steps.when_impl import (
 )
 
 
-@given('"{actor_name}" goes to the "{page_name}" page')
-@given('"{actor_name}" visits the "{page_name}" page')
-def given_actor_visits_page(context, actor_name, page_name):
-    visit_page(context, actor_name, page_name)
+@given('"{actor_alias}" goes to the "{page_name}" page')
+@given('"{actor_alias}" visits the "{page_name}" page')
+def given_actor_visits_page(context, actor_alias, page_name):
+    visit_page(context, actor_alias, page_name)
 
 
-@given('"{actor_name}" visits the "{page_name}" page for the first time')
-def given_actor_visits_page_for_the_first_time(context, actor_name, page_name):
-    visit_page(context, actor_name, page_name, first_time=True)
+@given('"{actor_alias}" visits the "{page_name}" page for the first time')
+def given_actor_visits_page_for_the_first_time(context, actor_alias, page_name):
+    visit_page(context, actor_alias, page_name, first_time=True)
 
 
 @given('"{actor_alias}" is on the "{page_name}" page')

--- a/tests/exred/steps/given_def.py
+++ b/tests/exred/steps/given_def.py
@@ -54,3 +54,9 @@ def given_actor_opened_guidance(context, actor_alias, category, location):
 @given('"{actor_alias}" decided to build his exporting journey')
 def given_actor_starts_exporting_journey(context, actor_alias):
     start_triage(context, actor_alias)
+
+
+@given('"{actor_alias}" decided to create her personalised journey page')
+@given('"{actor_alias}" decided to create his personalised journey page')
+def given_actor_decided_to_create_personalised_page(context, actor_alias):
+    triage_create_exporting_journey(context, actor_alias)

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -11,6 +11,7 @@ from steps.then_impl import (
     guidance_should_see_total_number_of_articles,
     guidance_tile_should_be_highlighted,
     personalised_journey_should_see_read_counter,
+    personalised_should_see_layout_for,
     should_be_on_page,
     should_see_sections_on_home_page,
     triage_should_be_classified_as
@@ -84,3 +85,9 @@ def step_impl(context, actor_alias, classification):
 @then('"{actor_alias}" should see the summary page with answers to the questions she was asked')
 def then_actor_should_see_answers_to_questions(context, actor_alias):
     triage_should_see_answers_to_questions(context, actor_alias)
+
+
+@then('"{actor_alias}" should be on the personalised "{classification}" exporter journey page')
+def then_classified_exporter_should_be_on_personalised_journey_page(
+        context, actor_alias, classification):
+    personalised_should_see_layout_for(context, actor_alias, classification)

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -15,6 +15,7 @@ from steps.then_impl import (
     should_see_sections_on_home_page,
     triage_should_be_classified_as
 )
+from steps.when_impl import triage_should_see_answers_to_questions
 
 
 @then('"{actor_name}" should see the "{sections}" sections on home page')
@@ -78,3 +79,8 @@ def then_actor_should_see_guidance_articles_read_counter(
 @then('"{actor_alias}" should be classified as "{classification}" exporter')
 def step_impl(context, actor_alias, classification):
     triage_should_be_classified_as(context, actor_alias, classification)
+
+
+@then('"{actor_alias}" should see the summary page with answers to the questions she was asked')
+def then_actor_should_see_answers_to_questions(context, actor_alias):
+    triage_should_see_answers_to_questions(context, actor_alias)

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -12,7 +12,8 @@ from steps.then_impl import (
     guidance_tile_should_be_highlighted,
     personalised_journey_should_see_read_counter,
     should_be_on_page,
-    should_see_sections_on_home_page
+    should_see_sections_on_home_page,
+    triage_should_be_classified_as
 )
 
 
@@ -72,3 +73,8 @@ def then_actor_should_see_guidance_articles_read_counter(
         context, actor_alias, exporter_status):
     personalised_journey_should_see_read_counter(
         context, actor_alias, exporter_status)
+
+
+@then('"{actor_alias}" should be classified as "{classification}" exporter')
+def step_impl(context, actor_alias, classification):
+    triage_should_be_classified_as(context, actor_alias, classification)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -6,6 +6,11 @@ from behave.runner import Context
 
 from pages import guidance_common, home, personalised_journey
 from registry.pages import get_page_object
+from steps.when_impl import (
+    triage_should_be_classified_as_new,
+    triage_should_be_classified_as_occasional,
+    triage_should_be_classified_as_regular
+)
 
 
 def should_see_sections_on_home_page(
@@ -89,3 +94,18 @@ def personalised_journey_should_see_read_counter(
     logging.debug(
         "%s can see Guidance Article Read Counter on the Personalised Journey "
         "page: %s", actor_alias, context.driver.current_url)
+
+
+def triage_should_be_classified_as(
+        context: Context, actor_alias: str, classification: str):
+    if classification == "new":
+        triage_should_be_classified_as_new(context)
+    elif classification == "occasional":
+        triage_should_be_classified_as_occasional(context)
+    elif classification == "regular":
+        triage_should_be_classified_as_regular(context)
+    else:
+        raise KeyError("Could not recognize: '%s'. Please use: ")
+    logging.debug(
+        "%s was properly classified as %s exporter", actor_alias,
+        classification)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -11,6 +11,7 @@ from steps.when_impl import (
     triage_should_be_classified_as_occasional,
     triage_should_be_classified_as_regular
 )
+from utils import get_actor
 
 
 def should_see_sections_on_home_page(
@@ -109,3 +110,28 @@ def triage_should_be_classified_as(
     logging.debug(
         "%s was properly classified as %s exporter", actor_alias,
         classification)
+
+
+def personalised_should_see_layout_for(
+        context: Context, actor_alias: str, classification: str):
+    actor = get_actor(context, actor_alias)
+    incorporated = actor.are_you_incorporated
+    online_marketplaces = actor.do_you_use_online_marketplaces
+    code, _ = actor.what_do_you_want_to_export
+    if classification == "new":
+        personalised_journey.layout_for_new_exporter(
+            context.driver, incorporated=incorporated, sector_code=code)
+    elif classification == "occasional":
+        personalised_journey.layout_for_occasional_exporter(
+            context.driver, incorporated=incorporated,
+            use_online_marketplaces=online_marketplaces, sector_code=code)
+    elif classification == "regular":
+        personalised_journey.layout_for_regular_exporter(
+            context.driver, incorporated=incorporated, sector_code=code)
+    else:
+        raise KeyError(
+            "Could not recognise '%s'. Please use: new, occasional or "
+            "regular" % classification)
+    logging.debug(
+        "%s saw Personalised Journey page layout tailored for %s exporter",
+        actor_alias, classification)

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -6,6 +6,7 @@ from steps.when_impl import (
     guidance_open_category,
     personalised_journey_create_page,
     start_triage,
+    triage_are_you_incorporated,
     triage_do_you_export_regularly,
     triage_have_you_exported_before,
     triage_say_what_do_you_want_to_export,
@@ -47,3 +48,10 @@ def when_actor_answers_whether_he_exported_before(
 def when_actor_tells_whether_he_exports_regularly_or_not(
         context, actor_alias, regular_or_not):
     triage_do_you_export_regularly(context, actor_alias, regular_or_not)
+
+
+@when('"{actor_alias}" says that her company "{is_or_not}" incorporated')
+@when('"{actor_alias}" says that his company "{is_or_not}" incorporated')
+def when_actor_says_whether_company_is_incorporated(
+        context, actor_alias, is_or_not):
+    triage_are_you_incorporated(context, actor_alias, is_or_not)

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -10,6 +10,7 @@ from steps.when_impl import (
     triage_do_you_export_regularly,
     triage_have_you_exported_before,
     triage_say_what_do_you_want_to_export,
+    triage_what_is_your_company_name
 )
 
 
@@ -55,3 +56,9 @@ def when_actor_tells_whether_he_exports_regularly_or_not(
 def when_actor_says_whether_company_is_incorporated(
         context, actor_alias, is_or_not):
     triage_are_you_incorporated(context, actor_alias, is_or_not)
+
+
+@when('"{actor_alias}" "{decision}" her company name')
+@when('"{actor_alias}" "{decision}" his company name')
+def when_actor_decide_to_enter_company_name(context, actor_alias, decision):
+    triage_what_is_your_company_name(context, actor_alias, decision)

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -10,6 +10,7 @@ from steps.when_impl import (
     triage_do_you_export_regularly,
     triage_have_you_exported_before,
     triage_say_what_do_you_want_to_export,
+    triage_should_see_answers_to_questions,
     triage_what_is_your_company_name
 )
 
@@ -62,3 +63,9 @@ def when_actor_says_whether_company_is_incorporated(
 @when('"{actor_alias}" "{decision}" his company name')
 def when_actor_decide_to_enter_company_name(context, actor_alias, decision):
     triage_what_is_your_company_name(context, actor_alias, decision)
+
+
+@when('"{actor_alias}" sees the summary page with answers to the questions he was asked')
+@when('"{actor_alias}" sees the summary page with answers to the questions she was asked')
+def when_actor_sees_answers_to_the_questions(context, actor_alias):
+    triage_should_see_answers_to_questions(context, actor_alias)

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -8,6 +8,7 @@ from steps.when_impl import (
     personalised_journey_create_page,
     start_triage,
     triage_are_you_incorporated,
+    triage_change_answers,
     triage_create_exporting_journey,
     triage_do_you_export_regularly,
     triage_have_you_exported_before,
@@ -91,3 +92,9 @@ def when_actor_says_whether_he_used_online_marktet_places(
         context, actor_alias, decision):
     triage_say_whether_you_use_online_marketplaces(
         context, actor_alias, decision)
+
+
+@when('"{actor_alias}" decides to change her answers')
+@when('"{actor_alias}" decides to change his answers')
+def when_actor_decides_to_change_the_answers(context, actor_alias):
+    triage_change_answers(context, actor_alias)

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -7,6 +7,7 @@ from steps.when_impl import (
     personalised_journey_create_page,
     start_triage,
     triage_are_you_incorporated,
+    triage_create_exporting_journey,
     triage_do_you_export_regularly,
     triage_have_you_exported_before,
     triage_say_what_do_you_want_to_export,
@@ -69,3 +70,9 @@ def when_actor_decide_to_enter_company_name(context, actor_alias, decision):
 @when('"{actor_alias}" sees the summary page with answers to the questions she was asked')
 def when_actor_sees_answers_to_the_questions(context, actor_alias):
     triage_should_see_answers_to_questions(context, actor_alias)
+
+
+@when('"{actor_alias}" decides to create her personalised journey page')
+@when('"{actor_alias}" decides to create his personalised journey page')
+def when_actor_decides_to_create_personalised_page(context, actor_alias):
+    triage_create_exporting_journey(context, actor_alias)

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -6,6 +6,7 @@ from steps.when_impl import (
     guidance_open_category,
     personalised_journey_create_page,
     start_triage,
+    triage_do_you_export_regularly,
     triage_have_you_exported_before,
     triage_say_what_do_you_want_to_export,
 )
@@ -39,3 +40,10 @@ def when_actor_says_what_he_wants_to_export(context, actor_alias):
 def when_actor_answers_whether_he_exported_before(
         context, actor_alias, has_or_has_never):
     triage_have_you_exported_before(context, actor_alias, has_or_has_never)
+
+
+@when('"{actor_alias}" says that exporting is "{regular_or_not}" part of her business')
+@when('"{actor_alias}" says that exporting is "{regular_or_not}" part of his business')
+def when_actor_tells_whether_he_exports_regularly_or_not(
+        context, actor_alias, regular_or_not):
+    triage_do_you_export_regularly(context, actor_alias, regular_or_not)

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -12,6 +12,7 @@ from steps.when_impl import (
     triage_do_you_export_regularly,
     triage_have_you_exported_before,
     triage_say_what_do_you_want_to_export,
+    triage_say_whether_you_use_online_marketplaces,
     triage_should_see_answers_to_questions,
     triage_what_is_your_company_name
 )
@@ -83,3 +84,10 @@ def when_actor_decides_to_create_personalised_page(context, actor_alias):
 @when('"{actor_alias}" can see that she was classified as a "{classification}" exporter')
 def when_actor_is_classified_as(context, actor_alias, classification):
     triage_should_be_classified_as(context, actor_alias, classification)
+
+
+@when('"{actor_alias}" says that she "{decision}" used online marketplaces')
+def when_actor_says_whether_he_used_online_marktet_places(
+        context, actor_alias, decision):
+    triage_say_whether_you_use_online_marketplaces(
+        context, actor_alias, decision)

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -6,6 +6,7 @@ from steps.when_impl import (
     guidance_open_category,
     personalised_journey_create_page,
     start_triage,
+    triage_have_you_exported_before,
     triage_say_what_do_you_want_to_export,
 )
 
@@ -31,3 +32,10 @@ def when_actor_creates_personalised_journey_page(context, actor_alias):
 @when('"{actor_alias}" says what does she wants to export')
 def when_actor_says_what_he_wants_to_export(context, actor_alias):
     triage_say_what_do_you_want_to_export(context, actor_alias)
+
+
+@when('"{actor_alias}" says that he "{has_or_has_never}" exported before')
+@when('"{actor_alias}" says that she "{has_or_has_never}" exported before')
+def when_actor_answers_whether_he_exported_before(
+        context, actor_alias, has_or_has_never):
+    triage_have_you_exported_before(context, actor_alias, has_or_has_never)

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -79,6 +79,7 @@ def when_actor_decides_to_create_personalised_page(context, actor_alias):
     triage_create_exporting_journey(context, actor_alias)
 
 
+@when('"{actor_alias}" can see that he was classified as a "{classification}" exporter')
 @when('"{actor_alias}" can see that she was classified as a "{classification}" exporter')
 def when_actor_is_classified_as(context, actor_alias, classification):
     triage_should_be_classified_as(context, actor_alias, classification)

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -2,6 +2,7 @@
 """When step definitions."""
 from behave import when
 
+from steps.then_impl import triage_should_be_classified_as
 from steps.when_impl import (
     guidance_open_category,
     personalised_journey_create_page,
@@ -76,3 +77,8 @@ def when_actor_sees_answers_to_the_questions(context, actor_alias):
 @when('"{actor_alias}" decides to create his personalised journey page')
 def when_actor_decides_to_create_personalised_page(context, actor_alias):
     triage_create_exporting_journey(context, actor_alias)
+
+
+@when('"{actor_alias}" can see that she was classified as a "{classification}" exporter')
+def when_actor_is_classified_as(context, actor_alias, classification):
+    triage_should_be_classified_as(context, actor_alias, classification)

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -6,7 +6,7 @@ from steps.when_impl import (
     guidance_open_category,
     personalised_journey_create_page,
     start_triage,
-    triage_select_sector
+    triage_say_what_do_you_want_to_export,
 )
 
 
@@ -27,7 +27,7 @@ def when_actor_creates_personalised_journey_page(context, actor_alias):
     personalised_journey_create_page(context, actor_alias)
 
 
-@when('"{actor_alias}" selects her sector')
-@when('"{actor_alias}" selects his sector')
-def when_actor_selects_sector(context, actor_alias):
-    triage_select_sector(context, actor_alias)
+@when('"{actor_alias}" says what does he wants to export')
+@when('"{actor_alias}" says what does she wants to export')
+def when_actor_says_what_he_wants_to_export(context, actor_alias):
+    triage_say_what_do_you_want_to_export(context, actor_alias)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -103,6 +103,17 @@ def triage_say_you_never_exported_before(context: Context, actor_alias: str):
     update_actor(context, actor_alias, have_you_exported_before=False)
 
 
+def triage_have_you_exported_before(context, actor_alias, has_or_has_never):
+    if has_or_has_never == "has":
+        triage_say_you_exported_before(context, actor_alias)
+    elif has_or_has_never == "has never":
+        triage_say_you_never_exported_before(context, actor_alias)
+    else:
+        raise KeyError(
+            "Could not recognize '%s', please use 'has' or 'has never'" %
+            has_or_has_never)
+
+
 def triage_say_you_are_incorporated(
         context: Context, actor_alias: str):
     driver = context.driver

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -186,12 +186,38 @@ def triage_say_you_do_not_use_online_marketplaces(
 
 
 def triage_enter_company_name(
-        context: Context, actor_alias: str, *, company_name: str = None):
+        context: Context, actor_alias: str, use_suggestions: bool, *,
+        company_name: str = None):
     driver = context.driver
-    company_name = triage_company_name.enter_company_name(driver, company_name)
+    triage_company_name.enter_company_name(driver, company_name)
+    if use_suggestions:
+        triage_company_name.click_on_first_suggestion(driver)
+    else:
+        triage_company_name.hide_suggestions(driver)
+    final_company_name = triage_company_name.get_company_name(driver)
     triage_company_name.submit(driver)
     triage_result.should_be_here(driver)
-    update_actor(context, actor_alias, company_name=company_name)
+    update_actor(context, actor_alias, company_name=final_company_name)
+
+
+def triage_do_not_enter_company_name(context: Context, actor_alias: str):
+    driver = context.driver
+    triage_company_name.submit(driver)
+    triage_result.should_be_here(driver)
+    update_actor(context, actor_alias, company_name=None)
+
+
+def triage_what_is_your_company_name(context, actor_alias, decision):
+    if decision == "types in":
+        triage_enter_company_name(context, actor_alias, use_suggestions=False)
+    elif decision == "does not provide":
+        triage_do_not_enter_company_name(context, actor_alias)
+    elif decision == "types in and selects":
+        triage_enter_company_name(context, actor_alias, use_suggestions=True)
+    else:
+        raise KeyError(
+            "Could not recognize '%s', please use 'types in', "
+            "'does not provide' or 'types in and selects'" % decision)
 
 
 def triage_should_be_classified_as_new(context: Context):

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -17,7 +17,7 @@ from pages import (
     triage_do_you_use_online_marketplaces,
     triage_have_you_exported,
     triage_result,
-    triage_what_is_your_sector
+    triage_what_do_you_want_to_export
 )
 from registry.pages import get_page_object
 from utils import add_actor, get_actor, unauthenticated_actor, update_actor
@@ -76,13 +76,13 @@ def start_triage(context: Context, actor_alias: str):
     logging.debug("%s started triage process", actor_alias)
 
 
-def triage_select_sector(
+def triage_say_what_do_you_want_to_export(
         context: Context, actor_alias: str, *, sector: str = None):
     driver = context.driver
-    final_sector = triage_what_is_your_sector.select_sector(driver, sector)
-    triage_what_is_your_sector.submit(driver)
+    final_sector = triage_what_do_you_want_to_export.enter(driver, sector)
+    triage_what_do_you_want_to_export.submit(driver)
     triage_have_you_exported.should_be_here(driver)
-    update_actor(context, actor_alias, sector=final_sector)
+    update_actor(context, actor_alias, what_do_you_want_to_export=final_sector)
 
 
 def triage_say_you_exported_before(context: Context, actor_alias: str):
@@ -178,7 +178,7 @@ def triage_create_exporting_journey(context: Context):
 
 def triage_classify_as_new(context: Context, actor_alias: str):
     start_triage(context, actor_alias)
-    triage_select_sector(context, actor_alias)
+    triage_what_do_you_want_to_export(context, actor_alias)
     triage_say_you_never_exported_before(context, actor_alias)
     if random.choice([True, False]):
         triage_say_you_are_incorporated(context, actor_alias)
@@ -192,7 +192,7 @@ def triage_classify_as_new(context: Context, actor_alias: str):
 
 def triage_classify_as_occasional(context: Context, actor_alias: str):
     start_triage(context, actor_alias)
-    triage_select_sector(context, actor_alias)
+    triage_what_do_you_want_to_export(context, actor_alias)
     triage_say_you_exported_before(context, actor_alias)
     triage_say_you_do_not_export_regularly(context, actor_alias)
     if random.choice([True, False]):
@@ -211,7 +211,7 @@ def triage_classify_as_occasional(context: Context, actor_alias: str):
 
 def triage_classify_as_regular(context: Context, actor_alias: str):
     start_triage(context, actor_alias)
-    triage_select_sector(context, actor_alias)
+    triage_what_do_you_want_to_export(context, actor_alias)
     triage_say_you_exported_before(context, actor_alias)
     triage_say_you_export_regularly(context, actor_alias)
     if random.choice([True, False]):

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -147,6 +147,17 @@ def triage_say_you_do_not_export_regularly(context: Context, actor_alias: str):
     update_actor(context, actor_alias, do_you_export_regularly=False)
 
 
+def triage_do_you_export_regularly(context, actor_alias, regular_or_not):
+    if regular_or_not == "a regular":
+        triage_say_you_export_regularly(context, actor_alias)
+    elif regular_or_not == "not a regular":
+        triage_say_you_do_not_export_regularly(context, actor_alias)
+    else:
+        raise KeyError(
+            "Could not recognize '%s', please use 'a regular' or "
+            "'not a regular'" % regular_or_not)
+
+
 def triage_say_you_use_online_marketplaces(context: Context, actor_alias: str):
     driver = context.driver
     triage_do_you_use_online_marketplaces.select_yes(driver)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -34,6 +34,8 @@ def visit_page(
     the webdriver' page load timeout set to value lower than the retry's
     `wait_fixed` timer, e.g `driver.set_page_load_timeout(time_to_wait=30)`
     """
+    if not get_actor(context, actor_alias):
+        add_actor(context, unauthenticated_actor(actor_alias))
     context.current_page = get_page_object(page_name)
     logging.debug(
         "%s will visit '%s' page using: '%s'", actor_alias, page_name,

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -232,8 +232,9 @@ def triage_should_be_classified_as_regular(context: Context):
     triage_result.should_be_classified_as_regular(context.driver)
 
 
-def triage_create_exporting_journey(context: Context):
+def triage_create_exporting_journey(context: Context, actor_alias: str):
     triage_result.create_exporting_journey(context.driver)
+    update_actor(context, alias=actor_alias, created_personalised_journey=True)
 
 
 def triage_classify_as_new(context: Context, actor_alias: str):
@@ -246,7 +247,7 @@ def triage_classify_as_new(context: Context, actor_alias: str):
     else:
         triage_say_you_are_not_incorporated(context, actor_alias)
     triage_should_be_classified_as_new(context)
-    triage_create_exporting_journey(context)
+    triage_create_exporting_journey(context, actor_alias)
     update_actor(context, alias=actor_alias, triage_classification="new")
 
 
@@ -265,7 +266,7 @@ def triage_classify_as_occasional(context: Context, actor_alias: str):
     else:
         triage_say_you_are_not_incorporated(context, actor_alias)
     triage_should_be_classified_as_occasional(context)
-    triage_create_exporting_journey(context)
+    triage_create_exporting_journey(context, actor_alias)
     update_actor(context, alias=actor_alias, triage_classification="occasional")
 
 
@@ -280,7 +281,7 @@ def triage_classify_as_regular(context: Context, actor_alias: str):
     else:
         triage_say_you_are_not_incorporated(context, actor_alias)
     triage_should_be_classified_as_regular(context)
-    triage_create_exporting_journey(context)
+    triage_create_exporting_journey(context, actor_alias)
     update_actor(context, alias=actor_alias, triage_classification="regular")
 
 

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -239,7 +239,7 @@ def triage_create_exporting_journey(context: Context, actor_alias: str):
 
 def triage_classify_as_new(context: Context, actor_alias: str):
     start_triage(context, actor_alias)
-    triage_what_do_you_want_to_export(context, actor_alias)
+    triage_say_what_do_you_want_to_export(context, actor_alias)
     triage_say_you_never_exported_before(context, actor_alias)
     if random.choice([True, False]):
         triage_say_you_are_incorporated(context, actor_alias)
@@ -253,7 +253,7 @@ def triage_classify_as_new(context: Context, actor_alias: str):
 
 def triage_classify_as_occasional(context: Context, actor_alias: str):
     start_triage(context, actor_alias)
-    triage_what_do_you_want_to_export(context, actor_alias)
+    triage_say_what_do_you_want_to_export(context, actor_alias)
     triage_say_you_exported_before(context, actor_alias)
     triage_say_you_do_not_export_regularly(context, actor_alias)
     if random.choice([True, False]):
@@ -272,7 +272,7 @@ def triage_classify_as_occasional(context: Context, actor_alias: str):
 
 def triage_classify_as_regular(context: Context, actor_alias: str):
     start_triage(context, actor_alias)
-    triage_what_do_you_want_to_export(context, actor_alias)
+    triage_say_what_do_you_want_to_export(context, actor_alias)
     triage_say_you_exported_before(context, actor_alias)
     triage_say_you_export_regularly(context, actor_alias)
     if random.choice([True, False]):

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -20,7 +20,13 @@ from pages import (
     triage_what_do_you_want_to_export
 )
 from registry.pages import get_page_object
-from utils import add_actor, get_actor, unauthenticated_actor, update_actor
+from utils import (
+    add_actor,
+    assertion_msg,
+    get_actor,
+    unauthenticated_actor,
+    update_actor
+)
 
 
 @retry(wait_fixed=31000, stop_max_attempt_number=3)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -321,8 +321,8 @@ def triage_should_see_answers_to_questions(context, actor_alias):
     actor = get_actor(context, actor_alias)
     q_and_a = triage_result.get_questions_and_answers(context.driver)
     if actor.what_do_you_want_to_export is not None:
-        what = actor.what_do_you_want_to_export
-        assert q_and_a["What do you want to export?"] == what
+        code, sector = actor.what_do_you_want_to_export
+        assert q_and_a["What do you want to export?"] == sector
     if actor.company_name is not None:
         name = actor.company_name
         assert q_and_a["Company name"] == name

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -261,7 +261,6 @@ def triage_classify_as_new(context: Context, actor_alias: str):
     else:
         triage_say_you_are_not_incorporated(context, actor_alias)
     triage_should_be_classified_as_new(context)
-    triage_create_exporting_journey(context, actor_alias)
     update_actor(context, alias=actor_alias, triage_classification="new")
 
 
@@ -280,7 +279,6 @@ def triage_classify_as_occasional(context: Context, actor_alias: str):
     else:
         triage_say_you_are_not_incorporated(context, actor_alias)
     triage_should_be_classified_as_occasional(context)
-    triage_create_exporting_journey(context, actor_alias)
     update_actor(context, alias=actor_alias, triage_classification="occasional")
 
 
@@ -295,7 +293,6 @@ def triage_classify_as_regular(context: Context, actor_alias: str):
     else:
         triage_say_you_are_not_incorporated(context, actor_alias)
     triage_should_be_classified_as_regular(context)
-    triage_create_exporting_journey(context, actor_alias)
     update_actor(context, alias=actor_alias, triage_classification="regular")
 
 
@@ -345,6 +342,7 @@ def personalised_journey_create_page(context: Context, actor_alias: str):
     actor = get_actor(context, actor_alias)
     exporter_status = actor.self_classification
     triage_classify_as(context, actor_alias, exporter_status=exporter_status)
+    triage_create_exporting_journey(context, actor_alias)
     personalised_journey.should_be_here(context.driver)
 
 

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -25,7 +25,7 @@ from utils import add_actor, get_actor, unauthenticated_actor, update_actor
 
 @retry(wait_fixed=31000, stop_max_attempt_number=3)
 def visit_page(
-        context: Context, actor_name: str, page_name: str, *,
+        context: Context, actor_alias: str, page_name: str, *,
         first_time: bool = False):
     """Will visit specific page.
 
@@ -36,7 +36,7 @@ def visit_page(
     """
     context.current_page = get_page_object(page_name)
     logging.debug(
-        "%s will visit '%s' page using: '%s'", actor_name, page_name,
+        "%s will visit '%s' page using: '%s'", actor_alias, page_name,
         context.current_page.URL)
     context.current_page.visit(context.driver, first_time=first_time)
 

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -302,6 +302,29 @@ def triage_classify_as(
     step(context, actor_alias)
 
 
+def triage_should_see_answers_to_questions(context, actor_alias):
+    actor = get_actor(context, actor_alias)
+    q_and_a = triage_result.get_questions_and_answers(context.driver)
+    if actor.what_do_you_want_to_export is not None:
+        what = actor.what_do_you_want_to_export
+        assert q_and_a["What do you want to export?"] == what
+    if actor.company_name is not None:
+        name = actor.company_name
+        assert q_and_a["Company name"] == name
+    if actor.have_you_exported_before is not None:
+        exported_before = "Yes" if actor.have_you_exported_before else "No"
+        assert q_and_a["Have you exported before?"] == exported_before
+    if actor.do_you_export_regularly is not None:
+        export_regularly = "Yes" if actor.do_you_export_regularly else "No"
+        assert q_and_a["Is exporting a regular part of your business activities?"] == export_regularly
+    # if actor.are_you_incorporated is not None:
+    #     incorporated = "Yes" if actor.are_you_incorporated else "No"
+    #     assert q_and_a["Is your company incorporated in the UK?"] == incorporated
+    if actor.do_you_use_online_marketplaces is not None:
+        sell_online = "Yes" if actor.do_you_use_online_marketplaces else "No"
+        assert q_and_a["Do you use online marketplaces to sell your products?"] == sell_online
+
+
 def personalised_journey_create_page(context: Context, actor_alias: str):
     actor = get_actor(context, actor_alias)
     exporter_status = actor.self_classification

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -185,6 +185,18 @@ def triage_say_you_do_not_use_online_marketplaces(
     update_actor(context, actor_alias, do_you_use_online_marketplaces=False)
 
 
+def triage_say_whether_you_use_online_marketplaces(
+        context: Context, actor_alias: str, decision: str):
+    if decision == "has":
+        triage_say_you_use_online_marketplaces(context, actor_alias)
+    elif decision == "has never":
+        triage_say_you_do_not_use_online_marketplaces(context, actor_alias)
+    else:
+        raise KeyError(
+            "Could not recognize '%s', please use 'has' or 'has never'" %
+            decision)
+
+
 def triage_enter_company_name(
         context: Context, actor_alias: str, use_suggestions: bool, *,
         company_name: str = None):

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -79,12 +79,14 @@ def start_triage(context: Context, actor_alias: str):
 
 
 def triage_say_what_do_you_want_to_export(
-        context: Context, actor_alias: str, *, sector: str = None):
+        context: Context, actor_alias: str, *, code: str = None,
+        sector: str = None):
     driver = context.driver
-    final_sector = triage_what_do_you_want_to_export.enter(driver, sector)
+    code, sector = triage_what_do_you_want_to_export.enter(driver, code, sector)
     triage_what_do_you_want_to_export.submit(driver)
     triage_have_you_exported.should_be_here(driver)
-    update_actor(context, actor_alias, what_do_you_want_to_export=final_sector)
+    update_actor(
+        context, actor_alias, what_do_you_want_to_export=(code, sector))
 
 
 def triage_say_you_exported_before(context: Context, actor_alias: str):

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -319,16 +319,32 @@ def triage_should_see_answers_to_questions(context, actor_alias):
     q_and_a = triage_result.get_questions_and_answers(context.driver)
     if actor.what_do_you_want_to_export is not None:
         code, sector = actor.what_do_you_want_to_export
-        assert q_and_a["What do you want to export?"] == sector
+        question = "What do you want to export?"
+        with assertion_msg(
+                "Expected answer to question '%s' to be '%s', but got '%s' "
+                "instead", question, sector, q_and_a[question]):
+            assert q_and_a[question] == sector
     if actor.company_name is not None:
         name = actor.company_name
-        assert q_and_a["Company name"] == name
+        question = "Company name"
+        with assertion_msg(
+                "Expected answer to question '%s' to be '%s', but got '%s' "
+                "instead", question, name, q_and_a[question]):
+            assert q_and_a[question] == name
     if actor.have_you_exported_before is not None:
         exported_before = "Yes" if actor.have_you_exported_before else "No"
-        assert q_and_a["Have you exported before?"] == exported_before
+        question = "Have you exported before?"
+        with assertion_msg(
+                "Expected answer to question '%s' to be '%s', but got '%s' "
+                "instead", question, exported_before, q_and_a[question]):
+            assert q_and_a[question] == exported_before
     if actor.do_you_export_regularly is not None:
         export_regularly = "Yes" if actor.do_you_export_regularly else "No"
-        assert q_and_a["Is exporting a regular part of your business activities?"] == export_regularly
+        question = "Is exporting a regular part of your business activities?"
+        with assertion_msg(
+                "Expected answer to question '%s' to be '%s', but got '%s' "
+                "instead", question, export_regularly, q_and_a[question]):
+            assert q_and_a[question] == export_regularly
     # TODO uncomment when ED-2494 & ED-2536 are fixed
     # if actor.are_you_incorporated is not None:
     #     incorporated = "Yes" if actor.are_you_incorporated else "No"

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -346,3 +346,9 @@ def personalised_journey_create_page(context: Context, actor_alias: str):
     exporter_status = actor.self_classification
     triage_classify_as(context, actor_alias, exporter_status=exporter_status)
     personalised_journey.should_be_here(context.driver)
+
+
+def triage_change_answers(context, actor_alias):
+    triage_result.change_answers(context.driver)
+    triage_what_do_you_want_to_export.should_be_here(context.driver)
+    logging.debug("%s was able to change the Triage answers", actor_alias)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -131,6 +131,16 @@ def triage_say_you_are_not_incorporated(context: Context, actor_alias: str):
     update_actor(context, actor_alias, are_you_incorporated=False)
 
 
+def triage_are_you_incorporated(context, actor_alias, is_or_not):
+    if is_or_not == "is":
+        triage_say_you_are_incorporated(context, actor_alias)
+    elif is_or_not == "is not":
+        triage_say_you_are_not_incorporated(context, actor_alias)
+    else:
+        raise KeyError(
+            "Could not recognize '%s', please use 'is' or 'is not'" % is_or_not)
+
+
 def triage_say_you_export_regularly(context: Context, actor_alias: str):
     driver = context.driver
     triage_are_you_regular_exporter.select_yes(driver)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -332,12 +332,13 @@ def triage_should_see_answers_to_questions(context, actor_alias):
     if actor.do_you_export_regularly is not None:
         export_regularly = "Yes" if actor.do_you_export_regularly else "No"
         assert q_and_a["Is exporting a regular part of your business activities?"] == export_regularly
+    # TODO uncomment when ED-2494 & ED-2536 are fixed
     # if actor.are_you_incorporated is not None:
     #     incorporated = "Yes" if actor.are_you_incorporated else "No"
     #     assert q_and_a["Is your company incorporated in the UK?"] == incorporated
-    if actor.do_you_use_online_marketplaces is not None:
-        sell_online = "Yes" if actor.do_you_use_online_marketplaces else "No"
-        assert q_and_a["Do you use online marketplaces to sell your products?"] == sell_online
+    # if actor.do_you_use_online_marketplaces is not None:
+    #     sell_online = "Yes" if actor.do_you_use_online_marketplaces else "No"
+    #     assert q_and_a["Do you use online marketplaces to sell your products?"] == sell_online
 
 
 def personalised_journey_create_page(context: Context, actor_alias: str):

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -242,7 +242,7 @@ def triage_classify_as_new(context: Context, actor_alias: str):
     triage_say_you_never_exported_before(context, actor_alias)
     if random.choice([True, False]):
         triage_say_you_are_incorporated(context, actor_alias)
-        triage_enter_company_name(context, actor_alias)
+        triage_enter_company_name(context, actor_alias, use_suggestions=True)
     else:
         triage_say_you_are_not_incorporated(context, actor_alias)
     triage_should_be_classified_as_new(context)
@@ -261,7 +261,7 @@ def triage_classify_as_occasional(context: Context, actor_alias: str):
         triage_say_you_do_not_use_online_marketplaces(context, actor_alias)
     if random.choice([True, False]):
         triage_say_you_are_incorporated(context, actor_alias)
-        triage_enter_company_name(context, actor_alias)
+        triage_enter_company_name(context, actor_alias, use_suggestions=True)
     else:
         triage_say_you_are_not_incorporated(context, actor_alias)
     triage_should_be_classified_as_occasional(context)
@@ -276,7 +276,7 @@ def triage_classify_as_regular(context: Context, actor_alias: str):
     triage_say_you_export_regularly(context, actor_alias)
     if random.choice([True, False]):
         triage_say_you_are_incorporated(context, actor_alias)
-        triage_enter_company_name(context, actor_alias)
+        triage_enter_company_name(context, actor_alias, use_suggestions=True)
     else:
         triage_say_you_are_not_incorporated(context, actor_alias)
     triage_should_be_classified_as_regular(context)

--- a/tests/exred/utils/__init__.py
+++ b/tests/exred/utils/__init__.py
@@ -34,8 +34,9 @@ Actor = namedtuple(
     "Actor",
     [
         "alias", "email", "password", "self_classification",
-        "triage_classification", "sector", "have_you_exported_before",
-        "do_you_export_regularly", "are_you_incorporated", "company_name",
+        "triage_classification", "what_do_you_want_to_export",
+        "have_you_exported_before", "do_you_export_regularly",
+        "are_you_incorporated", "company_name",
         "do_you_use_online_marketplaces"
     ]
 )

--- a/tests/exred/utils/__init__.py
+++ b/tests/exred/utils/__init__.py
@@ -171,7 +171,7 @@ def selenium_action(driver: webdriver, message: str, *args):
     """
     try:
         yield
-    except WebDriverException as e:
+    except (WebDriverException, NoSuchElementException) as e:
         browser = driver.capabilities.get("browserName", "unknown browser")
         version = driver.capabilities.get("version", "unknown version")
         platform = driver.capabilities.get("platform", "unknown platform")
@@ -180,6 +180,7 @@ def selenium_action(driver: webdriver, message: str, *args):
                 .format(browser, version, platform, session_id))
         if args:
             message = message % args
+        print("%s - %s" % (info, message))
         logging.error("%s - %s", info, message)
         e.args += (message,)
         _, _, tb = sys.exc_info()

--- a/tests/exred/utils/__init__.py
+++ b/tests/exred/utils/__init__.py
@@ -37,7 +37,7 @@ Actor = namedtuple(
         "triage_classification", "what_do_you_want_to_export",
         "have_you_exported_before", "do_you_export_regularly",
         "are_you_incorporated", "company_name",
-        "do_you_use_online_marketplaces"
+        "do_you_use_online_marketplaces", "created_personalised_journey"
     ]
 )
 

--- a/tests/exred/utils/__init__.py
+++ b/tests/exred/utils/__init__.py
@@ -16,7 +16,10 @@ from os.path import abspath, join
 import requests
 from behave.runner import Context
 from selenium import webdriver
-from selenium.common.exceptions import WebDriverException
+from selenium.common.exceptions import (
+    WebDriverException,
+    NoSuchElementException
+)
 
 from settings import (
     BROWSERSTACK_SESSIONS_URL,


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2520)

As steps were common for most of the `Triage` scenarios I've automated all following scenarios:
Scenario:
```gherkin
  @ED-2520
  @first-time
  @regular
  Scenario Outline: Regular Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
    Given "Nadia" visits the "Home" page for the first time
    And "Nadia" decided to build her exporting journey

    When "Nadia" says what does she wants to export
    And "Nadia" says that she "has" exported before
    And "Nadia" says that exporting is "a regular" part of her business
    And "Nadia" says that her company "is" incorporated
    And "Nadia" "<company_name_action>" her company name
    And "Nadia" sees the summary page with answers to the questions she was asked
    And "Nadia" can see that she was classified as a "regular" exporter
    And "Nadia" decides to create her personalised journey page

    Then "Nadia" should be on the personalised "regular" exporter journey page

    Examples:
      | company_name_action  |
      | types in             |
      | does not provide     |
      | types in and selects |


  @ED-2520
  @first-time
  @regular
  Scenario: Not incorporated Regular Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
    Given "Nadia" visits the "Home" page for the first time
    And "Nadia" decided to build her exporting journey

    When "Nadia" says what does she wants to export
    And "Nadia" says that she "has" exported before
    And "Nadia" says that exporting is "a regular" part of her business
    And "Nadia" says that her company "is not" incorporated
    And "Nadia" sees the summary page with answers to the questions she was asked
    And "Nadia" can see that she was classified as a "regular" exporter
    And "Nadia" decides to create her personalised journey page

    Then "Nadia" should be on the personalised "regular" exporter journey page


  @ED-2521
  @first-time
  @occasional
  Scenario Outline: Occasional Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
    Given "Inigo" visits the "home" page for the first time
    And "Inigo" decided to build his exporting journey

    When "Inigo" says what does she wants to export
    And "Inigo" says that she "has" exported before
    And "Inigo" says that exporting is "not a regular" part of her business
    And "Inigo" says that she "<online_action>" used online marketplaces
    And "Inigo" says that her company "is" incorporated
    And "Inigo" "<company_name_action>" his company name
    And "Inigo" sees the summary page with answers to the questions he was asked
    And "Inigo" can see that she was classified as a "occasional" exporter
    And "Inigo" decides to create her personalised journey page

    Then "Inigo" should be on the personalised "occasional" exporter journey page

    Examples:
      | online_action | company_name_action  |
      | has           | types in             |
      | has never     | types in             |
      | has           | does not provide     |
      | has never     | does not provide     |
      | has           | types in and selects |
      | has never     | types in and selects |


  @ED-2521
  @first-time
  @occasional
  Scenario Outline: Not incorporated Occasional Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
    Given "Inigo" visits the "home" page for the first time
    And "Inigo" decided to build his exporting journey

    When "Inigo" says what does she wants to export
    And "Inigo" says that she "has" exported before
    And "Inigo" says that exporting is "not a regular" part of her business
    And "Inigo" says that she "<online_action>" used online marketplaces
    And "Inigo" says that her company "is not" incorporated
    And "Inigo" sees the summary page with answers to the questions he was asked
    And "Inigo" can see that she was classified as a "occasional" exporter
    And "Inigo" decides to create her personalised journey page

    Then "Inigo" should be on the personalised "occasional" exporter journey page

    Examples:
      | online_action |
      | has           |
      | has never     |


  @ED-2522
  @first-time
  @new
  Scenario Outline: New Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
    Given "Jonah" visits the "home" page for the first time
    And "Jonah" decided to build his exporting journey

    When "Jonah" says what does he wants to export
    And "Jonah" says that he "has never" exported before
    And "Jonah" says that his company "is" incorporated
    And "Jonah" "<company_name_action>" his company name
    And "Jonah" sees the summary page with answers to the questions he was asked
    And "Jonah" can see that he was classified as a "new" exporter
    And "Jonah" decides to create his personalised journey page

    Then "Jonah" should be on the personalised "new" exporter journey page

    Examples:
      | company_name_action  |
      | types in             |
      | does not provide     |
      | types in and selects |


  @ED-2522
  @first-time
  @new
  Scenario: Not incorporated New Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
    Given "Jonah" visits the "home" page for the first time
    And "Jonah" decided to build his exporting journey

    When "Jonah" says what does he wants to export
    And "Jonah" says that he "has never" exported before
    And "Jonah" says that his company "is not" incorporated
    And "Jonah" sees the summary page with answers to the questions he was asked
    And "Jonah" can see that he was classified as a "new" exporter
    And "Jonah" decides to create his personalised journey page

    Then "Jonah" should be on the personalised "new" exporter journey page
```
