### PR TITLE
ED-2366 Exporters should be able to get to a relevant Export Readiness Article List from Personas section on the home page

### DIFF
--- a/tests/exred/features/guidance.feature
+++ b/tests/exred/features/guidance.feature
@@ -10,7 +10,7 @@ Feature: Guidance articles
 
     When "Robert" goes to the "<specific>" Guidance articles via "home page"
 
-    Then "Robert" should see an ordered list of all articles selected for "<specific>" category
+    Then "Robert" should see an ordered list of all Guidance Articles selected for "<specific>" category
     And "Robert" should see on the Guidance Articles page "Articles Read counter, Total number of Articles, Time to complete remaining chapters"
     And "Robert" should see a link to the "<next>" Guidance category
 
@@ -99,7 +99,7 @@ Feature: Guidance articles
 
     When "Nadia" goes to the "<specific>" Guidance articles via "personalised journey"
 
-    Then "Nadia" should see an ordered list of all articles selected for "<specific>" category
+    Then "Nadia" should see an ordered list of all Guidance Articles selected for "<specific>" category
     And "Nadia" should see on the Guidance Articles page "Articles Read counter, Total number of Articles, Time to complete remaining chapters"
     And "Nadia" should see a link to the "<next>" Guidance category
 

--- a/tests/exred/features/home-page.feature
+++ b/tests/exred/features/home-page.feature
@@ -31,20 +31,19 @@ Feature: Home Page
     Then "Robert" should be on the "Personalised Journey" page
 
 
-  @wip
   @ED-2366
   @personas
   @articles
-  Scenario Outline: "<exporter_status>" Exporter should be able to get to a relevant article list from Personas section on the homepage
-    Given "Robert" classifies himself as "<exporter_status>" exporter
+  Scenario Outline: "<exporter_status>" Exporter should be able to get to a relevant Export Readiness Article List from Personas section on the home page
+    Given "Robert" classifies himself as "<specific>" exporter
 
-    When "Robert" goes to the relevant "<exporter_status>" exporter link in the Personas section on the Home page
+    When "Robert" goes to the Export Readiness Articles for "<specific>" Exporters via "home page"
 
-    Then "Robert" should see an ordered list of "previous + next 5" articles selected for "<exporter_status>" exporter
-    And "Robert" should see a Articles Read counter, Total number of Articles and Time to complete remaining chapters
+    Then "Robert" should see an ordered list of all Export Readiness Articles selected for "<specific>" Exporters
+    And "Robert" should see on the Export Readiness Articles page "Articles Read counter, Total number of Articles, Time to complete remaining chapters"
 
     Examples:
-      | exporter_status |
-      | New             |
-      | Occasional      |
-      | Regular         |
+      | specific   |
+      | New        |
+      | Occasional |
+      | Regular    |

--- a/tests/exred/pages/export_readiness_common.py
+++ b/tests/exred/pages/export_readiness_common.py
@@ -3,9 +3,10 @@
 import logging
 
 from selenium import webdriver
+from selenium.webdriver import ActionChains
 
 from registry.articles import get_articles
-from utils import assertion_msg, take_screenshot
+from utils import assertion_msg, selenium_action, take_screenshot
 
 NAME = "ExRed Common Export Readiness"
 URL = None
@@ -95,3 +96,20 @@ def check_if_correct_articles_are_displayed(
                 "Expected article '%s' to be at position %d but found it at "
                 "position no. %d ", name, expected_position, position):
             assert expected_position == position
+
+
+def check_elements_are_visible(driver: webdriver, elements: list):
+    take_screenshot(driver, NAME)
+    for element in elements:
+        selector = SCOPE_ELEMENTS[element.lower()]
+        with selenium_action(
+                driver, "Could not find '%s' on '%s' using '%s' selector",
+                element, driver.current_url, selector):
+            page_element = driver.find_element_by_css_selector(selector)
+            if "firefox" not in driver.capabilities["browserName"].lower():
+                logging.debug("Moving focus to '%s' element", element)
+                action_chains = ActionChains(driver)
+                action_chains.move_to_element(page_element)
+                action_chains.perform()
+        with assertion_msg("Expected to see '%s' but can't see it", element):
+            assert page_element.is_displayed()

--- a/tests/exred/pages/export_readiness_common.py
+++ b/tests/exred/pages/export_readiness_common.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""ExRed Common Export Readiness Page Object."""
+import logging
+
+from selenium import webdriver
+
+from registry.articles import get_articles
+from utils import assertion_msg, take_screenshot
+
+NAME = "ExRed Common Export Readiness"
+URL = None
+
+
+TOTAL_NUMBER_OF_ARTICLES = "#articles div.scope-indicator dd.position > span.to"
+ARTICLES_TO_READ_COUNTER = "#articles div.scope-indicator dd.position > span.from"
+TIME_TO_COMPLETE = "#articles div.scope-indicator dd.time > span.value"
+SHOW_MORE_BUTTON = "#js-paginate-list-more"
+ARTICLES_LIST = "#js-paginate-list > li"
+
+SCOPE_ELEMENTS = {
+    "total number of articles": TOTAL_NUMBER_OF_ARTICLES,
+    "articles read counter": ARTICLES_TO_READ_COUNTER,
+    "time to complete remaining chapters": TIME_TO_COMPLETE
+}
+
+
+def correct_total_number_of_articles(driver: webdriver, category: str):
+    expected = len(get_articles("export readiness", category))
+    total = driver.find_element_by_css_selector(TOTAL_NUMBER_OF_ARTICLES)
+    with assertion_msg(
+            "Total Number of Export Readiness Articles to read for '%s' "
+            "Exporter is not visible", category):
+        assert total.is_displayed()
+    given = int(total.text)
+    with assertion_msg(
+            "Expected Total Number of Export Readiness Articles to read for "
+            "'%s' Exporter to be %d but got %s", category, expected, given):
+        assert given == expected
+
+
+def correct_article_read_counter(
+        driver: webdriver, category: str, expected: int):
+    counter = driver.find_element_by_css_selector(ARTICLES_TO_READ_COUNTER)
+    with assertion_msg(
+            "Export Readiness Article Read Counter for '%s' Exporter is not "
+            "visible", category):
+        assert counter.is_displayed()
+    given = int(counter.text)
+    with assertion_msg(
+            "Expected Export Readiness Article Read Counter for '%s' Exporter"
+            " to be %d but got %s", category, expected, given):
+        assert given == expected
+
+
+def show_all_articles(driver: webdriver):
+    show_more_button = driver.find_element_by_css_selector(SHOW_MORE_BUTTON)
+    max_clicks = 10
+    counter = 0
+    # click up to 11 times - see bug ED-2561
+    while show_more_button.is_displayed() and counter <= max_clicks:
+        show_more_button.click()
+        counter += 1
+    if counter > max_clicks:
+        with assertion_msg(
+                "'Show more' button didn't disappear after clicking on it for"
+                " %d times", counter):
+            assert counter == max_clicks
+    take_screenshot(driver, NAME + " after showing all articles")
+
+
+def check_if_correct_articles_are_displayed(
+        driver: webdriver, category: str):
+    """Check if all expected articles for given category are displayed and are
+     on correct position.
+
+    :param driver: selenium webdriver
+    :param category: expected Guidance Article category
+    """
+    expected_list = get_articles("export readiness", category.lower())
+    # convert list of dict to a simpler dict, which will help in comparison
+    expected_articles = {}
+    for article in expected_list:
+        expected_articles.update(article)
+    show_all_articles(driver)
+    # extract displayed list of articles and their indexes
+    articles = driver.find_elements_by_css_selector(ARTICLES_LIST)
+    given_articles = [(idx+1, article.find_element_by_tag_name("a").text)
+                      for idx, article in enumerate(articles)]
+    # check whether article is on the right position
+    logging.debug("Expected articles: %s", expected_articles)
+    logging.debug("Given articles: %s", given_articles)
+    for position, name in given_articles:
+        expected_position = expected_articles[name.lower()]["index"]
+        with assertion_msg(
+                "Expected article '%s' to be at position %d but found it at "
+                "position no. %d ", name, expected_position, position):
+            assert expected_position == position

--- a/tests/exred/pages/home.py
+++ b/tests/exred/pages/home.py
@@ -46,9 +46,9 @@ SECTIONS = {
         "header": "#personas > .container > .header",
         "intro": "#personas > .container > .intro",
         "groups": "#personas > .container > .group",
-        "new_to_exporting_link": NEW_TO_EXPORTING_LINK,
-        "occasional_exporter_link": OCCASIONAL_EXPORTER_LINK,
-        "regular_exported_link": REGULAR_EXPORTED_LINK,
+        "new": NEW_TO_EXPORTING_LINK,
+        "occasional": OCCASIONAL_EXPORTER_LINK,
+        "regular": REGULAR_EXPORTED_LINK,
     },
     "guidance": {
         "itself": "#resource-guidance",

--- a/tests/exred/pages/personalised_journey.py
+++ b/tests/exred/pages/personalised_journey.py
@@ -237,7 +237,9 @@ def check_top_facts_values(driver: webdriver):
 
     try:
         tr = driver.find_element_by_css_selector(
-            "#row-{}".format(top_importer))
+            "#row-{}".format(top_importer
+                             .replace(",", "\,")
+                             .replace(" ", "\ ")))
         cell = tr.find_element_by_css_selector(TOP_10_TRADE_VALUE).text
         with assertion_msg(
                 "Expected to see 'Export value from the world' for %s to be %s"

--- a/tests/exred/registry/articles.py
+++ b/tests/exred/registry/articles.py
@@ -23,6 +23,11 @@ ARTICLES = {
                 "index": 5,
                 "next": "know your customers",
                 "previous": "visit a trade show"
+            },
+            "regular": {
+                "index": 3,
+                "next": "license your product or service",
+                "previous": "do field research"
             }
         }
     },
@@ -45,6 +50,11 @@ ARTICLES = {
         "export readiness": {
             "occasional": {
                 "index": 20,
+                "next": "raise money with investment",
+                "previous": "raise money by borrowing"
+            },
+            "regular": {
+                "index": 12,
                 "next": "raise money with investment",
                 "previous": "raise money by borrowing"
             }
@@ -76,6 +86,11 @@ ARTICLES = {
                 "index": 17,
                 "next": "get export finance",
                 "previous": "get money to export"
+            },
+            "regular": {
+                "index": 9,
+                "next": "get export finance",
+                "previous": "understand your customer's culture"
             }
         },
     },
@@ -187,6 +202,11 @@ ARTICLES = {
                 "index": 2,
                 "previous": "do research first",
                 "next": "do field research"
+            },
+            "regular": {
+                "index": 1,
+                "next": "do field research",
+                "previous": None
             }
         },
     },
@@ -211,6 +231,11 @@ ARTICLES = {
                 "index": 3,
                 "previous": "define market potential",
                 "next": "visit a trade show"
+            },
+            "regular": {
+                "index": 2,
+                "next": "analyse the competition",
+                "previous": "define market potential"
             }
         },
     },
@@ -286,6 +311,13 @@ ARTICLES = {
                 "next": "start a joint venture"
             }
         },
+        "export readiness": {
+            "regular": {
+                "index": 5,
+                "next": "start a joint venture",
+                "previous": "license your product or service"
+            }
+        }
     },
     "get export finance": {
         "time to read": 0,
@@ -306,6 +338,11 @@ ARTICLES = {
         "export readiness": {
             "occasional": {
                 "index": 18,
+                "next": "raise money by borrowing",
+                "previous": "choose the right finance"
+            },
+            "regular": {
+                "index": 10,
                 "next": "raise money by borrowing",
                 "previous": "choose the right finance"
             }
@@ -331,6 +368,11 @@ ARTICLES = {
             "occasional": {
                 "index": 22,
                 "next": "consider how you'll get paid",
+                "previous": "raise money with investment"
+            },
+            "regular": {
+                "index": 14,
+                "next": "insure against non-payment",
                 "previous": "raise money with investment"
             }
         }
@@ -414,6 +456,11 @@ ARTICLES = {
                 "index": 36,
                 "next": "next steps for occasional exporters",
                 "previous": "know what IP you have"
+            },
+            "regular": {
+                "index": 17,
+                "next": "next steps for regular exporters",
+                "previous": "know what IP you have"
             }
         }
     },
@@ -438,6 +485,11 @@ ARTICLES = {
                 "index": 27,
                 "next": "use a freight forwarder",
                 "previous": "payment methods"
+            },
+            "regular": {
+                "index": 15,
+                "next": "know what IP you have",
+                "previous": "get government finance support"
             }
         }
     },
@@ -520,6 +572,11 @@ ARTICLES = {
                 "index": 35,
                 "next": "ip protection in multiple countries",
                 "previous": "types of intellectual property"
+            },
+            "regular": {
+                "index": 16,
+                "next": "ip protection in multiple countries",
+                "previous": "insure against non-payment"
             }
         }
     },
@@ -588,6 +645,11 @@ ARTICLES = {
                 "index": 12,
                 "next": "start a joint venture",
                 "previous": "choosing an agent or distributor"
+            },
+            "regular": {
+                "index": 4,
+                "next": "franchise your business",
+                "previous": "analyse the competition"
             }
         }
     },
@@ -719,6 +781,11 @@ ARTICLES = {
                 "index": 37,
                 "next": None,
                 "previous": "ip protection in multiple countries"
+            },
+            "regular": {
+                "index": 18,
+                "next": None,
+                "previous": "ip protection in multiple countries"
             }
         },
     },
@@ -791,6 +858,11 @@ ARTICLES = {
                 "index": 19,
                 "next": "borrow against assets",
                 "previous": "get export finance"
+            },
+            "regular": {
+                "index": 11,
+                "next": "borrow against assets",
+                "previous": "get export finance"
             }
         }
     },
@@ -815,6 +887,11 @@ ARTICLES = {
                 "index": 21,
                 "next": "get government finance support",
                 "previous": "borrow against assets"
+            },
+            "regular": {
+                "index": 13,
+                "next": "get government finance support",
+                "previous": "borrow against assets"
             }
         }
     },
@@ -825,6 +902,13 @@ ARTICLES = {
                 "index": 10,
                 "previous": "start a joint venture",
                 "next": None
+            }
+        },
+        "export readiness": {
+            "regular": {
+                "index": 7,
+                "next": "understand your customer's culture",
+                "previous": "start a joint venture"
             }
         },
     },
@@ -849,6 +933,11 @@ ARTICLES = {
                 "index": 13,
                 "next": "manage language differences",
                 "previous": "license your product or service"
+            },
+            "regular": {
+                "index": 6,
+                "next": "set up an overseas operation",
+                "previous": "franchise your business"
             }
         }
     },
@@ -907,7 +996,12 @@ ARTICLES = {
                 "index": 15,
                 "next": "get money to export",
                 "previous": "manage language differences"
-            }
+            },
+            "regular": {
+                "index": 8,
+                "next": "choose the right finance",
+                "previous": "set up an overseas operation"
+            },
         }
     },
     "use a distributor": {

--- a/tests/exred/registry/articles.py
+++ b/tests/exred/registry/articles.py
@@ -777,11 +777,21 @@ ARTICLES = {
                 "previous": "types of intellectual property",
                 "next": None
             },
+        },
+    },
+    "next steps for occasional exporters": {
+        "time to read": 0,
+        "export readiness": {
             "occasional": {
                 "index": 37,
                 "next": None,
                 "previous": "ip protection in multiple countries"
             },
+        },
+    },
+    "next steps for regular exporters": {
+        "time to read": 0,
+        "export readiness": {
             "regular": {
                 "index": 18,
                 "next": None,

--- a/tests/exred/registry/articles.py
+++ b/tests/exred/registry/articles.py
@@ -18,6 +18,13 @@ ARTICLES = {
                 "next": "know your customers"
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 5,
+                "next": "know your customers",
+                "previous": "visit a trade show"
+            }
+        }
     },
     "borrow against assets": {
         "time to read": 0,
@@ -35,6 +42,13 @@ ARTICLES = {
                 "next": "raise money with investment"
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 20,
+                "next": "raise money with investment",
+                "previous": "raise money by borrowing"
+            }
+        }
     },
     "choose the right finance": {
         "time to read": 0,
@@ -58,6 +72,11 @@ ARTICLES = {
                 "previous": "get money to export",
                 "next": "consider how you'll get paid"
             },
+            "occasional": {
+                "index": 17,
+                "next": "get export finance",
+                "previous": "get money to export"
+            }
         },
     },
     "choosing an agent or distributor": {
@@ -82,6 +101,11 @@ ARTICLES = {
                 "previous": "use a distributor",
                 "next": "meet your customers"
             },
+            "occasional": {
+                "index": 11,
+                "next": "license your product or service",
+                "previous": "use a distributor"
+            }
         },
     },
     "consider how you'll get paid": {
@@ -111,6 +135,11 @@ ARTICLES = {
                 "previous": "choose the right finance",
                 "next": "plan the logistics"
             },
+            "occasional": {
+                "index": 23,
+                "next": "invoice currency and contents",
+                "previous": "get government finance support"
+            }
         },
     },
     "decide when you'll get paid": {
@@ -129,6 +158,13 @@ ARTICLES = {
                 "next": "payment methods"
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 25,
+                "next": "payment methods",
+                "previous": "invoice currency and contents"
+            }
+        }
     },
     "define market potential": {
         "time to read": 0,
@@ -143,6 +179,13 @@ ARTICLES = {
             "occasional": {
                 "index": 1,
                 "previous": None,
+                "next": "do field research"
+            }
+        },
+        "export readiness": {
+            "occasional": {
+                "index": 2,
+                "previous": "do research first",
                 "next": "do field research"
             }
         },
@@ -161,6 +204,13 @@ ARTICLES = {
                 "index": 2,
                 "previous": "define market potential",
                 "next": "analyse the competition"
+            }
+        },
+        "export readiness": {
+            "occasional": {
+                "index": 3,
+                "previous": "define market potential",
+                "next": "visit a trade show"
             }
         },
     },
@@ -185,6 +235,11 @@ ARTICLES = {
                 "index": 1,
                 "previous": None,
                 "next": "know your customers"
+            },
+            "occasional": {
+                "index": 1,
+                "previous": None,
+                "next": "define market potential"
             }
         },
     },
@@ -215,6 +270,11 @@ ARTICLES = {
                 "previous": "make an export plan",
                 "next": "use an overseas agent"
             },
+            "occasional": {
+                "index": 8,
+                "next": "use an overseas agent",
+                "previous": "make an export plan"
+            }
         },
     },
     "franchise your business": {
@@ -243,6 +303,13 @@ ARTICLES = {
                 "next": "raise money by borrowing"
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 18,
+                "next": "raise money by borrowing",
+                "previous": "choose the right finance"
+            }
+        }
     },
     "get government finance support": {
         "time to read": 0,
@@ -260,6 +327,13 @@ ARTICLES = {
                 "next": "make an export plan"
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 22,
+                "next": "consider how you'll get paid",
+                "previous": "raise money with investment"
+            }
+        }
     },
     "get money to export": {
         "time to read": 0,
@@ -288,6 +362,11 @@ ARTICLES = {
                 "previous": "manage language differences",
                 "next": "choose the right finance"
             },
+            "occasional": {
+                "index": 16,
+                "next": "choose the right finance",
+                "previous": "understand your customer's culture"
+            }
         },
     },
     "get your export documents right": {
@@ -306,6 +385,13 @@ ARTICLES = {
                 "next": "match your website to your audience"
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 30,
+                "next": "internationalise your website",
+                "previous": "user incoterms in contracts"
+            }
+        }
     },
     "ip protection in multiple countries": {
         "time to read": 0,
@@ -323,6 +409,13 @@ ARTICLES = {
                 "next": None
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 36,
+                "next": "next steps for occasional exporters",
+                "previous": "know what IP you have"
+            }
+        }
     },
     "insure against non-payment": {
         "time to read": 0,
@@ -340,6 +433,13 @@ ARTICLES = {
                 "next": "use a freight forwarder"
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 27,
+                "next": "use a freight forwarder",
+                "previous": "payment methods"
+            }
+        }
     },
     "internationalise your website": {
         "time to read": 0,
@@ -368,6 +468,11 @@ ARTICLES = {
                 "previous": "plan the logistics",
                 "next": "what intellectual property is"
             },
+            "occasional": {
+                "index": 31,
+                "next": "match your website to your audience",
+                "previous": "get your export documents right"
+            }
         },
     },
     "invoice currency and contents": {
@@ -386,6 +491,13 @@ ARTICLES = {
                 "next": "decide when you'll get paid"
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 24,
+                "next": "decide when you'll get paid",
+                "previous": "consider how you'll get paid"
+            }
+        }
     },
     "know what ip you have": {
         "time to read": 0,
@@ -403,6 +515,13 @@ ARTICLES = {
                 "next": "ip protection in multiple countries"
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 35,
+                "next": "ip protection in multiple countries",
+                "previous": "types of intellectual property"
+            }
+        }
     },
     "know your customers": {
         "time to read": 0,
@@ -430,7 +549,12 @@ ARTICLES = {
                 "index": 2,
                 "previous": "do research first",
                 "next": "make an export plan"
-            }
+            },
+            "occasional": {
+                "index": 6,
+                "next": "make an export plan",
+                "previous": "analyse the competition"
+            },
         },
     },
     "licensing and franchising": {
@@ -459,6 +583,13 @@ ARTICLES = {
                 "next": "start a joint venture"
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 12,
+                "next": "start a joint venture",
+                "previous": "choosing an agent or distributor"
+            }
+        }
     },
     "make an export plan": {
         "time to read": 0,
@@ -487,6 +618,11 @@ ARTICLES = {
                 "previous": "know your customers",
                 "next": "find a route to market"
             },
+            "occasional": {
+                "index": 7,
+                "next": "find a route to market",
+                "previous": "know your customers"
+            }
         },
     },
     "manage language differences": {
@@ -516,6 +652,11 @@ ARTICLES = {
                 "previous": "meet your customers",
                 "next": "get money to export"
             },
+            "occasional": {
+                "index": 14,
+                "next": "understand your customer's culture",
+                "previous": "start a joint venture"
+            }
         },
     },
     "match your website to your audience": {
@@ -534,6 +675,13 @@ ARTICLES = {
                 "next": "internationalise your website"
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 32,
+                "next": "what intellectual property is",
+                "previous": "internationalise your website"
+            }
+        }
     },
     "meet your customers": {
         "time to read": 0,
@@ -567,6 +715,11 @@ ARTICLES = {
                 "previous": "types of intellectual property",
                 "next": None
             },
+            "occasional": {
+                "index": 37,
+                "next": None,
+                "previous": "ip protection in multiple countries"
+            }
         },
     },
     "payment methods": {
@@ -585,6 +738,13 @@ ARTICLES = {
                 "next": "insure against non-payment"
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 26,
+                "next": "insure against non-payment",
+                "previous": "decide when you'll get paid"
+            }
+        }
     },
     "plan the logistics": {
         "time to read": 0,
@@ -626,6 +786,13 @@ ARTICLES = {
                 "next": "borrow against assets"
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 19,
+                "next": "borrow against assets",
+                "previous": "get export finance"
+            }
+        }
     },
     "raise money with investment": {
         "time to read": 0,
@@ -643,6 +810,13 @@ ARTICLES = {
                 "next": "get government finance support"
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 21,
+                "next": "get government finance support",
+                "previous": "borrow against assets"
+            }
+        }
     },
     "set up an overseas operation": {
         "time to read": 0,
@@ -670,6 +844,13 @@ ARTICLES = {
                 "next": "consider how you'll get paid"
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 13,
+                "next": "manage language differences",
+                "previous": "license your product or service"
+            }
+        }
     },
     "types of intellectual property": {
         "time to read": 0,
@@ -698,6 +879,11 @@ ARTICLES = {
                 "previous": "what intellectual property is",
                 "next": "next steps for new to exporting"
             },
+            "occasional": {
+                "index": 34,
+                "next": "know what IP you have",
+                "previous": "what intellectual property is"
+            }
         },
     },
     "understand your customer's culture": {
@@ -716,6 +902,13 @@ ARTICLES = {
                 "next": "get money to export"
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 15,
+                "next": "get money to export",
+                "previous": "manage language differences"
+            }
+        }
     },
     "use a distributor": {
         "time to read": 0,
@@ -744,6 +937,11 @@ ARTICLES = {
                 "previous": "use an overseas agent",
                 "next": "choosing an agent or distributor"
             },
+            "occasional": {
+                "index": 10,
+                "next": "choosing an agent or distributor",
+                "previous": "use an overseas agent"
+            }
         },
     },
     "use a freight forwarder": {
@@ -762,6 +960,13 @@ ARTICLES = {
                 "next": "user incoterms in contracts"
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 28,
+                "next": "user incoterms in contracts",
+                "previous": "insure against non-payment"
+            }
+        }
     },
     "use an overseas agent": {
         "time to read": 0,
@@ -790,6 +995,11 @@ ARTICLES = {
                 "previous": "find a route to market",
                 "next": "use a distributor"
             },
+            "occasional": {
+                "index": 9,
+                "next": "use a distributor",
+                "previous": "find a route to market"
+            }
         },
     },
     "user incoterms in contracts": {
@@ -808,6 +1018,13 @@ ARTICLES = {
                 "next": "get your export documents right"
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 29,
+                "next": "get your export documents right",
+                "previous": "use a freight forwarder"
+            }
+        }
     },
     "visit a trade show": {
         "time to read": 0,
@@ -818,6 +1035,13 @@ ARTICLES = {
                 "next": None
             }
         },
+        "export readiness": {
+            "occasional": {
+                "index": 4,
+                "next": "analyse the competition",
+                "previous": "do field research"
+            }
+        }
     },
     "what intellectual property is": {
         "time to read": 0,
@@ -846,6 +1070,11 @@ ARTICLES = {
                 "previous": "internationalise your website",
                 "next": "types of intellectual property"
             },
+            "occasional": {
+                "index": 33,
+                "next": "types of intellectual property",
+                "previous": "match your website to your audience"
+            }
         },
     },
 }

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -3,7 +3,8 @@
 from behave import then
 
 from steps.then_impl import (
-    exred_should_see_articles,
+    export_readiness_expected_page_elements_should_be_visible,
+    export_readiness_should_see_articles,
     guidance_check_if_link_to_next_category_is_displayed,
     guidance_expected_page_elements_should_be_visible,
     guidance_ribbon_should_be_visible,
@@ -104,4 +105,11 @@ def then_actor_should_be_able_to_answer_again(context, actor_alias):
 
 @then('"{actor_alias}" should see an ordered list of all Export Readiness Articles selected for "{category}" Exporters')
 def then_should_see_exred_articles(context, actor_alias, category):
-    exred_should_see_articles(context, actor_alias, category)
+    export_readiness_should_see_articles(context, actor_alias, category)
+
+
+@then('"{actor_alias}" should see on the Export Reading Articles page "{elements}"')
+def then_expected_export_readiness_page_elements_should_be_visible(
+        context, actor_alias, elements):
+    export_readiness_expected_page_elements_should_be_visible(
+        context, actor_alias, elements.split(", "))

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -108,7 +108,7 @@ def then_should_see_exred_articles(context, actor_alias, category):
     export_readiness_should_see_articles(context, actor_alias, category)
 
 
-@then('"{actor_alias}" should see on the Export Reading Articles page "{elements}"')
+@then('"{actor_alias}" should see on the Export Readiness Articles page "{elements}"')
 def then_expected_export_readiness_page_elements_should_be_visible(
         context, actor_alias, elements):
     export_readiness_expected_page_elements_should_be_visible(

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -3,6 +3,7 @@
 from behave import then
 
 from steps.then_impl import (
+    exred_should_see_articles,
     guidance_check_if_link_to_next_category_is_displayed,
     guidance_expected_page_elements_should_be_visible,
     guidance_ribbon_should_be_visible,
@@ -18,7 +19,6 @@ from steps.then_impl import (
 )
 from steps.when_impl import (
     triage_answer_questions_again,
-    triage_change_answers,
     triage_should_see_answers_to_questions
 )
 
@@ -100,3 +100,8 @@ def then_classified_exporter_should_be_on_personalised_journey_page(
 @then('"{actor_alias}" should be able to answer the triage questions again with his previous answers pre-populated')
 def then_actor_should_be_able_to_answer_again(context, actor_alias):
     triage_answer_questions_again(context, actor_alias)
+
+
+@then('"{actor_alias}" should see an ordered list of all Export Readiness Articles selected for "{category}" Exporters')
+def then_should_see_exred_articles(context, actor_alias, category):
+    exred_should_see_articles(context, actor_alias, category)

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -55,7 +55,7 @@ def then_total_number_of_articles_should_be_visible(context, actor_alias, catego
     guidance_should_see_total_number_of_articles(context, actor_alias, category)
 
 
-@then('"{actor_alias}" should see an ordered list of all articles selected for "{category}" category')
+@then('"{actor_alias}" should see an ordered list of all Guidance Articles selected for "{category}" category')
 def then_should_see_guidance_articles(context, actor_alias, category):
     guidance_should_see_articles(context, actor_alias, category)
 

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -142,10 +142,18 @@ def personalised_should_see_layout_for(
         actor_alias, classification)
 
 
-def exred_should_see_articles(
+def export_readiness_should_see_articles(
         context: Context, actor_alias: str, category: str):
     export_readiness_common.check_if_correct_articles_are_displayed(
         context.driver, category)
     logging.debug(
         "%s can see correct Articles for Guidance '%s' category and link to "
         "the next category wherever possible", actor_alias, category)
+
+
+def export_readiness_expected_page_elements_should_be_visible(
+        context: Context, actor_alias: str, elements: list):
+    export_readiness_common.check_elements_are_visible(context.driver, elements)
+    logging.debug(
+        "%s can see all expected page elements: '%s' on current Guidance "
+        "Articles page: %s", actor_alias, elements, context.driver.current_url)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -4,7 +4,12 @@ import logging
 
 from behave.runner import Context
 
-from pages import guidance_common, home, personalised_journey
+from pages import (
+    export_readiness_common,
+    guidance_common,
+    home,
+    personalised_journey
+)
 from registry.pages import get_page_object
 from steps.when_impl import (
     triage_should_be_classified_as_new,
@@ -135,3 +140,12 @@ def personalised_should_see_layout_for(
     logging.debug(
         "%s saw Personalised Journey page layout tailored for %s exporter",
         actor_alias, classification)
+
+
+def exred_should_see_articles(
+        context: Context, actor_alias: str, category: str):
+    export_readiness_common.check_if_correct_articles_are_displayed(
+        context.driver, category)
+    logging.debug(
+        "%s can see correct Articles for Guidance '%s' category and link to "
+        "the next category wherever possible", actor_alias, category)

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -4,6 +4,7 @@ from behave import when
 
 from steps.then_impl import triage_should_be_classified_as
 from steps.when_impl import (
+    exred_open_category,
     guidance_open_category,
     personalised_journey_create_page,
     start_triage,
@@ -98,3 +99,8 @@ def when_actor_says_whether_he_used_online_marktet_places(
 @when('"{actor_alias}" decides to change his answers')
 def when_actor_decides_to_change_the_answers(context, actor_alias):
     triage_change_answers(context, actor_alias)
+
+
+@when('"{actor_alias}" goes to the Export Readiness Articles for "{category}" Exporters via "{location}"')
+def when_actor_goes_to_exred_articles(context, actor_alias, category, location):
+    exred_open_category(context, actor_alias, category, location)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -424,3 +424,13 @@ def triage_answer_questions_again(context, actor_alias):
             triage_result.should_be_classified_as_new(driver)
         triage_should_see_answers_to_questions(context, actor_alias)
     logging.debug("%s was able to change the Triage answers", actor_alias)
+
+
+def exred_open_category(
+        context: Context, actor_alias: str, category: str, location: str):
+    home.visit(driver=context.driver)
+    logging.debug(
+        "%s is about to open Export Readiness '%s' category from %s",
+        actor_alias, category, location)
+    open_group_element(
+        context, group="personas", element=category, location=location)


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-)

Scenario:
```gherkin
  @ED-2366
  @personas
  @articles
  Scenario Outline: "<exporter_status>" Exporter should be able to get to a relevant Export Readiness Article List from Personas section on the home page
    Given "Robert" classifies himself as "<specific>" exporter

    When "Robert" goes to the Export Readiness Articles for "<specific>" Exporters via "home page"

    Then "Robert" should see an ordered list of all Export Readiness Articles selected for "<specific>" Exporters
    And "Robert" should see on the Export Readiness Articles page "Articles Read counter, Total number of Articles, Time to complete remaining chapters"

    Examples:
      | specific   |
      | New        |
      | Occasional |
      | Regular    |
```
