### PR TITLE
ED-2588, ED-2589 & ED-2590 customised page

### DIFF
--- a/tests/exred/features/home-page.feature
+++ b/tests/exred/features/home-page.feature
@@ -34,7 +34,8 @@ Feature: Home Page
   @ED-2366
   @personas
   @articles
-  Scenario Outline: "<exporter_status>" Exporter should be able to get to a relevant Export Readiness Article List from Personas section on the home page
+  @<specific>
+  Scenario Outline: "<specific>" Exporter should be able to get to a relevant Export Readiness Article List from Personas section on the home page
     Given "Robert" classifies himself as "<specific>" exporter
 
     When "Robert" goes to the Export Readiness Articles for "<specific>" Exporters via "home page"

--- a/tests/exred/features/personalised-page.feature
+++ b/tests/exred/features/personalised-page.feature
@@ -1,0 +1,100 @@
+@customised-page
+Feature: Customised page
+
+
+  @ED-2588
+  @personalised-page
+  @regular
+  Scenario Outline: Regular Exporter should see "<expected>" sections on personalised page
+    Given "Nadia" exports "<goods_or_services>"
+    And "Nadia" was classified as "Regular" Exporter which "<has_or_has_not>" incorporated the company
+
+    When "Nadia" decides to create her personalised journey page
+
+    Then "Nadia" should be on the Personalised Journey page for "regular" exporters
+    And "Nadia" should see "<expected>" sections on "personalised journey" page
+
+    Examples:
+      | goods_or_services | has_or_has_not | expected                                             |
+      | goods             | has            | Top 10, FAB section, SOO tile, ExOpps tile, Guidance |
+      | goods             | has not        | Top 10, SOO tile, ExOpps tile, Guidance              |
+      | services          | has            | FAB section, SOO tile, ExOpps tile, Guidance         |
+      | services          | has not        | SOO tile, ExOpps tile, Guidance                      |
+
+
+  @ED-2589
+  @personalised-page
+  @occasional
+  Scenario Outline: Occasional Exporter should see "<expected>" sections on personalised page
+    Given "Inigo" exports "<goods_or_services>"
+    And "Inigo" "<used_or_not>" online marketplaces before
+    And "Inigo" was classified as "Occasional" Exporter which "<has_or_has_not>" incorporated the company
+
+    When "Inigo" decides to create her personalised journey page
+
+    Then "Inigo" should be on the Personalised Journey page for "occasional" exporters
+    And "Inigo" should see "<expected>" sections on "personalised journey" page
+
+    Examples:
+      | goods_or_services | used_or_not | has_or_has_not | expected                                                     |
+      | goods             | used        | has            | Top 10, Article list, FAB section, SOO section, Case studies |
+      | goods             | used        | has not        | Top 10, Article list, SOO section, Case studies              |
+      | services          | never used  | has            | Article list, FAB section, Case studies                      |
+      | services          | never used  | has not        | Article list, Case studies                                   |
+
+
+  @ED-2590
+  @personalised-page
+  @new
+  Scenario Outline: New Exporter should see "<expected>" sections on personalised page
+    Given "Jonah" exports "<goods_or_services>"
+    And "Jonah" was classified as "New" Exporter which "<has_or_has_not>" incorporated the company
+
+    When "Jonah" decides to create his personalised journey page
+
+    Then "Jonah" should be on the Personalised Journey page for "new" exporters
+    And "Jonah" should see "<expected>" sections on "personalised journey" page
+
+    Examples:
+      | goods_or_services | has_or_has_not | expected                                        |
+      | goods             | has            | Top 10, Article list, FAB section, Case studies |
+      | goods             | has not        | Top 10, Article list, Case studies              |
+      | services          | has            | Article list, FAB section, Case studies         |
+      | services          | has not        | Article list, Case studies                      |
+
+
+  @wip
+  @ED-2591
+  @personalised-page
+  Scenario: Any Exporter should be able to update preferences from personalised page
+    Given "Robert" is on personalised page
+
+    When "Robert" decides to update preferences
+
+    Then "Robert" should be redirected to the triage summary where he can change his answers
+
+
+  @wip
+  @ED-2592
+  @personalised-page
+  Scenario: Any Exporter should see the Banner & Top 10 table specific to the sector they selected in triage
+    Given "Robert" has created the personalised journey page
+
+    Then "Robert" should see the Banner & Top 10 table specific to the sector they selected in triage
+
+
+  @wip
+  @ED-2593
+  @personalised-page
+  Scenario Outline: Any Exporter should get to a relevant case study from Case Studies carousel on the personalised page
+    Given "Robert" is interested in "<case_study_name>" case study
+
+    When "Robert" goes to the relevant "<case_study_name>" link in the Case Studies carousel on the personalised page
+
+    Then "Robert" should see "<case_study_name>" page with a Share widget
+
+    Examples:
+      | case_study_name   |
+      | First case study  |
+      | Second case study |
+      | Third case study  |

--- a/tests/exred/features/triage.feature
+++ b/tests/exred/features/triage.feature
@@ -17,7 +17,7 @@ Feature: Triage
     And "Nadia" can see that she was classified as a "regular" exporter
     And "Nadia" decides to create her personalised journey page
 
-    Then "Nadia" should be on the personalised "regular" exporter journey page
+    Then "Nadia" should be on the Personalised Journey page for "regular" exporters
 
     Examples:
       | company_name_action  |
@@ -41,7 +41,7 @@ Feature: Triage
     And "Nadia" can see that she was classified as a "regular" exporter
     And "Nadia" decides to create her personalised journey page
 
-    Then "Nadia" should be on the personalised "regular" exporter journey page
+    Then "Nadia" should be on the Personalised Journey page for "regular" exporters
 
 
   @ED-2521
@@ -61,7 +61,7 @@ Feature: Triage
     And "Inigo" can see that she was classified as a "occasional" exporter
     And "Inigo" decides to create her personalised journey page
 
-    Then "Inigo" should be on the personalised "occasional" exporter journey page
+    Then "Inigo" should be on the Personalised Journey page for "occasional" exporters
 
     Examples:
       | online_action | company_name_action  |
@@ -89,7 +89,7 @@ Feature: Triage
     And "Inigo" can see that she was classified as a "occasional" exporter
     And "Inigo" decides to create her personalised journey page
 
-    Then "Inigo" should be on the personalised "occasional" exporter journey page
+    Then "Inigo" should be on the Personalised Journey page for "occasional" exporters
 
     Examples:
       | online_action |
@@ -112,7 +112,7 @@ Feature: Triage
     And "Jonah" can see that he was classified as a "new" exporter
     And "Jonah" decides to create his personalised journey page
 
-    Then "Jonah" should be on the personalised "new" exporter journey page
+    Then "Jonah" should be on the Personalised Journey page for "new" exporters
 
     Examples:
       | company_name_action  |
@@ -135,7 +135,7 @@ Feature: Triage
     And "Jonah" can see that he was classified as a "new" exporter
     And "Jonah" decides to create his personalised journey page
 
-    Then "Jonah" should be on the personalised "new" exporter journey page
+    Then "Jonah" should be on the Personalised Journey page for "new" exporters
 
 
   @ED-2523

--- a/tests/exred/pages/personalised_journey.py
+++ b/tests/exred/pages/personalised_journey.py
@@ -57,7 +57,7 @@ SECTIONS = {
         "intro": "section.service-section .intro",
         "other": "#other-services > div > div",
     },
-    "fas section": {
+    "fab section": {
         "heading": "section.service-section.fas h2",
         "fas image": "section.service-section.fas img",
         "intro": "section.service-section.fas .intro",
@@ -217,7 +217,7 @@ def open(driver: webdriver, group: str, element: str):
 
 
 def should_see_section(driver: webdriver, name: str):
-    section = SECTIONS[name]
+    section = SECTIONS[name.lower()]
     for key, selector in section.items():
         with selenium_action(
                 driver, "Could not find: '%s' element in '%s' section using "
@@ -273,7 +273,7 @@ def layout_for_new_exporter(
     check_facts_and_top_10(driver, sector_code)
     should_see_section(driver, "article list")
     if incorporated:
-        should_see_section(driver, "fas section")
+        should_see_section(driver, "fab section")
     should_see_section(driver, "case studies")
 
 
@@ -290,7 +290,7 @@ def layout_for_occasional_exporter(
     check_facts_and_top_10(driver, sector_code)
     should_see_section(driver, "article list")
     if incorporated and use_online_marketplaces:
-        should_see_section(driver, "fas section")
+        should_see_section(driver, "fab section")
         should_see_section(driver, "soo section")
     if not incorporated and use_online_marketplaces:
         should_see_section(driver, "soo section")
@@ -308,7 +308,7 @@ def layout_for_regular_exporter(
     should_see_section(driver, "hero")
     check_facts_and_top_10(driver, sector_code)
     if incorporated:
-        should_see_section(driver, "fas section")
+        should_see_section(driver, "fab section")
     should_see_section(driver, "soo tile")
     should_see_section(driver, "exopps tile")
     should_see_section(driver, "guidance")

--- a/tests/exred/steps/given_def.py
+++ b/tests/exred/steps/given_def.py
@@ -6,6 +6,7 @@ from steps.then_impl import should_be_on_page
 from steps.when_impl import (
     actor_classifies_himself_as,
     guidance_open_category,
+    set_online_marketplace_preference,
     set_sector_preference,
     start_triage,
     triage_classify_as,
@@ -68,3 +69,6 @@ def given_actor_sets_sector_preference(context, actor_alias, goods_or_services):
     set_sector_preference(context, actor_alias, goods_or_services)
 
 
+@given('"{actor_alias}" "{used_or_not}" online marketplaces before')
+def step_impl(context, actor_alias, used_or_not):
+    set_online_marketplace_preference(context, actor_alias, used_or_not)

--- a/tests/exred/steps/given_def.py
+++ b/tests/exred/steps/given_def.py
@@ -64,6 +64,14 @@ def given_actor_decided_to_create_personalised_page(context, actor_alias):
     triage_create_exporting_journey(context, actor_alias)
 
 
+@given('"{actor_alias}" was classified as "{exporter_status}" Exporter which "{is_incorporated}" incorporated the company')
+def given_actor_was_classified_as(
+        context, actor_alias, exporter_status, is_incorporated):
+    triage_classify_as(
+        context, actor_alias, exporter_status=exporter_status,
+        is_incorporated=is_incorporated)
+
+
 @given('"{actor_alias}" exports "{goods_or_services}"')
 def given_actor_sets_sector_preference(context, actor_alias, goods_or_services):
     set_sector_preference(context, actor_alias, goods_or_services)

--- a/tests/exred/steps/given_def.py
+++ b/tests/exred/steps/given_def.py
@@ -6,6 +6,7 @@ from steps.then_impl import should_be_on_page
 from steps.when_impl import (
     actor_classifies_himself_as,
     guidance_open_category,
+    set_sector_preference,
     start_triage,
     triage_classify_as,
     triage_create_exporting_journey,
@@ -60,3 +61,10 @@ def given_actor_starts_exporting_journey(context, actor_alias):
 @given('"{actor_alias}" decided to create his personalised journey page')
 def given_actor_decided_to_create_personalised_page(context, actor_alias):
     triage_create_exporting_journey(context, actor_alias)
+
+
+@given('"{actor_alias}" exports "{goods_or_services}"')
+def given_actor_sets_sector_preference(context, actor_alias, goods_or_services):
+    set_sector_preference(context, actor_alias, goods_or_services)
+
+

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -15,6 +15,7 @@ from steps.then_impl import (
     personalised_journey_should_see_read_counter,
     personalised_should_see_layout_for,
     should_be_on_page,
+    should_see_sections,
     should_see_sections_on_home_page,
     triage_should_be_classified_as
 )
@@ -113,3 +114,8 @@ def then_expected_export_readiness_page_elements_should_be_visible(
         context, actor_alias, elements):
     export_readiness_expected_page_elements_should_be_visible(
         context, actor_alias, elements.split(", "))
+
+
+@then('"{actor_alias}" should see "{sections}" sections on "{page_name}" page')
+def then_should_see_sections(context, actor_alias, sections, page_name):
+    should_see_sections(context, actor_alias, sections.split(", "), page_name)

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -92,7 +92,7 @@ def then_actor_should_see_answers_to_questions(context, actor_alias):
     triage_should_see_answers_to_questions(context, actor_alias)
 
 
-@then('"{actor_alias}" should be on the personalised "{classification}" exporter journey page')
+@then('"{actor_alias}" should be on the Personalised Journey page for "{classification}" exporters')
 def then_classified_exporter_should_be_on_personalised_journey_page(
         context, actor_alias, classification):
     personalised_should_see_layout_for(context, actor_alias, classification)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -157,3 +157,13 @@ def export_readiness_expected_page_elements_should_be_visible(
     logging.debug(
         "%s can see all expected page elements: '%s' on current Guidance "
         "Articles page: %s", actor_alias, elements, context.driver.current_url)
+
+
+def should_see_sections(
+        context: Context, actor_alias: str, sections: list, page_name: str):
+    page = get_page_object(page_name)
+    for section in sections:
+        page.should_see_section(context.driver, section)
+        logging.debug(
+            "%s can see '%s' section on %s page", actor_alias, section,
+            page_name)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -503,3 +503,28 @@ def set_sector_preference(
     logging.debug(
         "%s decided that her/his preffered sector is: %s %s", actor_alias,
         code, sector)
+
+
+def set_online_marketplace_preference(
+        context: Context, actor_alias: str, used_or_not: str):
+    """Will set preference for past usage of Online Marketplaces
+
+     NOTE:
+     It will add new Actor is specified one doesn't exist,
+    """
+    if not get_actor(context, actor_alias):
+        add_actor(context, unauthenticated_actor(actor_alias))
+    if used_or_not.lower() == "used":
+        used = True
+    elif used_or_not.lower() == "never used":
+        used = False
+    else:
+        raise KeyError(
+            "Could not recognise '%s' as valid preference for pass usage of"
+            " Online Marketplaces. Please use 'used' or 'never used'"
+            % used_or_not)
+    update_actor(
+        context, actor_alias, do_you_use_online_marketplaces=used)
+    logging.debug(
+        "%s decided that he/she %s online marketplaces before", actor_alias,
+        used_or_not)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -479,3 +479,27 @@ def exred_open_category(
         actor_alias, category, location)
     open_group_element(
         context, group="personas", element=category, location=location)
+
+
+def set_sector_preference(
+        context: Context, actor_alias: str, goods_or_services: str):
+    if not get_actor(context, actor_alias):
+        add_actor(context, unauthenticated_actor(actor_alias))
+    if goods_or_services.lower() == "goods":
+        sectors = [(code, sector)
+                   for code, sector in EXRED_SECTORS.items()
+                   if code.startswith("HS")]
+    elif goods_or_services.lower() == "services":
+        sectors = [(code, sector)
+                   for code, sector in EXRED_SECTORS.items()
+                   if code.startswith("EB")]
+    else:
+        raise KeyError(
+            "Could not recognise '%s' as valid sector. Please use 'goods' or "
+            "'services'" % goods_or_services)
+    code, sector = random.choice(sectors)
+    update_actor(
+        context, actor_alias, what_do_you_want_to_export=(code, sector))
+    logging.debug(
+        "%s decided that her/his preffered sector is: %s %s", actor_alias,
+        code, sector)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -88,7 +88,8 @@ def triage_say_what_do_you_want_to_export(
         context: Context, actor_alias: str, *, code: str = None,
         sector: str = None):
     driver = context.driver
-    code, sector = triage_what_do_you_want_to_export.enter(driver, code, sector)
+    code, sector = triage_what_do_you_want_to_export.enter(
+        driver, code, sector)
     triage_what_do_you_want_to_export.submit(driver)
     triage_have_you_exported.should_be_here(driver)
     update_actor(
@@ -257,11 +258,14 @@ def triage_create_exporting_journey(context: Context, actor_alias: str):
     update_actor(context, alias=actor_alias, created_personalised_journey=True)
 
 
-def triage_classify_as_new(context: Context, actor_alias: str):
+def triage_classify_as_new(
+        context: Context, actor_alias: str, incorporated: bool, code: str,
+        sector: str):
     start_triage(context, actor_alias)
-    triage_say_what_do_you_want_to_export(context, actor_alias)
+    triage_say_what_do_you_want_to_export(
+        context, actor_alias, code=code, sector=sector)
     triage_say_you_never_exported_before(context, actor_alias)
-    if random.choice([True, False]):
+    if incorporated:
         triage_say_you_are_incorporated(context, actor_alias)
         triage_enter_company_name(context, actor_alias, use_suggestions=True)
     else:
@@ -270,16 +274,19 @@ def triage_classify_as_new(context: Context, actor_alias: str):
     update_actor(context, alias=actor_alias, triage_classification="new")
 
 
-def triage_classify_as_occasional(context: Context, actor_alias: str):
+def triage_classify_as_occasional(
+        context: Context, actor_alias: str, incorporated: bool,
+        use_online_marketplaces: bool, code: str, sector: str):
     start_triage(context, actor_alias)
-    triage_say_what_do_you_want_to_export(context, actor_alias)
+    triage_say_what_do_you_want_to_export(
+        context, actor_alias, code=code, sector=sector)
     triage_say_you_exported_before(context, actor_alias)
     triage_say_you_do_not_export_regularly(context, actor_alias)
-    if random.choice([True, False]):
+    if use_online_marketplaces:
         triage_say_you_use_online_marketplaces(context, actor_alias)
     else:
         triage_say_you_do_not_use_online_marketplaces(context, actor_alias)
-    if random.choice([True, False]):
+    if incorporated:
         triage_say_you_are_incorporated(context, actor_alias)
         triage_enter_company_name(context, actor_alias, use_suggestions=True)
     else:
@@ -288,12 +295,15 @@ def triage_classify_as_occasional(context: Context, actor_alias: str):
     update_actor(context, alias=actor_alias, triage_classification="occasional")
 
 
-def triage_classify_as_regular(context: Context, actor_alias: str):
+def triage_classify_as_regular(
+        context: Context, actor_alias: str, incorporated: bool, code: str,
+        sector: str):
     start_triage(context, actor_alias)
-    triage_say_what_do_you_want_to_export(context, actor_alias)
+    triage_say_what_do_you_want_to_export(
+        context, actor_alias, code=code, sector=sector)
     triage_say_you_exported_before(context, actor_alias)
     triage_say_you_export_regularly(context, actor_alias)
-    if random.choice([True, False]):
+    if incorporated:
         triage_say_you_are_incorporated(context, actor_alias)
         triage_enter_company_name(context, actor_alias, use_suggestions=True)
     else:


### PR DESCRIPTION
These tickets:
* [ED-2588](https://uktrade.atlassian.net/browse/ED-2588)
* [ED-2589](https://uktrade.atlassian.net/browse/ED-2589)
* [ED-2590](https://uktrade.atlassian.net/browse/ED-2590)

Three birds with one stone.

Scenario:
```gherkin
  @ED-2588
  @personalised-page
  @regular
  Scenario Outline: Regular Exporter should see "<expected>" sections on personalised page
    Given "Nadia" exports "<goods_or_services>"
    And "Nadia" was classified as "Regular" Exporter which "<has_or_has_not>" incorporated the company

    When "Nadia" decides to create her personalised journey page

    Then "Nadia" should be on the Personalised Journey page for "regular" exporters
    And "Nadia" should see "<expected>" sections on "personalised journey" page

    Examples:
      | goods_or_services | has_or_has_not | expected                                             |
      | goods             | has            | Top 10, FAB section, SOO tile, ExOpps tile, Guidance |
      | goods             | has not        | Top 10, SOO tile, ExOpps tile, Guidance              |
      | services          | has            | FAB section, SOO tile, ExOpps tile, Guidance         |
      | services          | has not        | SOO tile, ExOpps tile, Guidance                      |


  @ED-2589
  @personalised-page
  @occasional
  Scenario Outline: Occasional Exporter should see "<expected>" sections on personalised page
    Given "Inigo" exports "<goods_or_services>"
    And "Inigo" "<used_or_not>" online marketplaces before
    And "Inigo" was classified as "Occasional" Exporter which "<has_or_has_not>" incorporated the company

    When "Inigo" decides to create her personalised journey page

    Then "Inigo" should be on the Personalised Journey page for "occasional" exporters
    And "Inigo" should see "<expected>" sections on "personalised journey" page

    Examples:
      | goods_or_services | used_or_not | has_or_has_not | expected                                                     |
      | goods             | used        | has            | Top 10, Article list, FAB section, SOO section, Case studies |
      | goods             | used        | has not        | Top 10, Article list, SOO section, Case studies              |
      | services          | never used  | has            | Article list, FAB section, Case studies                      |
      | services          | never used  | has not        | Article list, Case studies                                   |


  @ED-2590
  @personalised-page
  @new
  Scenario Outline: New Exporter should see "<expected>" sections on personalised page
    Given "Jonah" exports "<goods_or_services>"
    And "Jonah" was classified as "New" Exporter which "<has_or_has_not>" incorporated the company

    When "Jonah" decides to create his personalised journey page

    Then "Jonah" should be on the Personalised Journey page for "new" exporters
    And "Jonah" should see "<expected>" sections on "personalised journey" page

    Examples:
      | goods_or_services | has_or_has_not | expected                                        |
      | goods             | has            | Top 10, Article list, FAB section, Case studies |
      | goods             | has not        | Top 10, Article list, Case studies              |
      | services          | has            | Article list, FAB section, Case studies         |
      | services          | has not        | Article list, Case studies                      |
```
