### PR TITLE
ED-2523 change triage answers

### DIFF
--- a/tests/exred/features/triage.feature
+++ b/tests/exred/features/triage.feature
@@ -138,12 +138,18 @@ Feature: Triage
     Then "Jonah" should be on the personalised "new" exporter journey page
 
 
-  @wip
   @ED-2523
   @first-time
-  Scenario: Any Exporter should be able to change their answers to at the end of triage
-    Given "Robert" answered triage questions
+  @<specific>
+  Scenario Outline: "<specific>" Exporter should be able to change their answers to at the end of triage
+    Given "Robert" was classified as "<specific>" exporter in the triage process
 
     When "Robert" decides to change his answers
 
     Then "Robert" should be able to answer the triage questions again with his previous answers pre-populated
+
+    Examples: classifications
+      | specific   |
+      | New        |
+      | Occasional |
+      | Regular    |

--- a/tests/exred/pages/triage_are_you_registered_with_companies_house.py
+++ b/tests/exred/pages/triage_are_you_registered_with_companies_house.py
@@ -11,6 +11,8 @@ from utils import assertion_msg, take_screenshot
 NAME = "ExRed Triage - are you registered with Companies House"
 URL = urljoin(EXRED_UI_URL, "triage")
 
+YES_RADIO = "#id_COMPANIES_HOUSE-is_in_companies_house_0"
+NO_RADIO = "#id_COMPANIES_HOUSE-is_in_companies_house_1"
 YES_CHECKBOX = "#id_COMPANIES_HOUSE-is_in_companies_house_0 ~ label"
 NO_CHECKBOX = "#id_COMPANIES_HOUSE-is_in_companies_house_1 ~ label"
 CONTINUE_BUTTON = ".exred-triage-form button.button"
@@ -53,3 +55,15 @@ def submit(driver: webdriver):
     button = driver.find_element_by_css_selector(CONTINUE_BUTTON)
     button.click()
     take_screenshot(driver, NAME + " after submitting")
+
+
+def is_yes_selected(driver: webdriver):
+    yes = driver.find_element_by_css_selector(YES_RADIO)
+    with assertion_msg("Expected Yes option to be selected"):
+        assert yes.get_property("checked")
+
+
+def is_no_selected(driver: webdriver):
+    no = driver.find_element_by_css_selector(NO_RADIO)
+    with assertion_msg("Expected No option to be selected"):
+        assert no.get_property("checked")

--- a/tests/exred/pages/triage_are_you_regular_exporter.py
+++ b/tests/exred/pages/triage_are_you_regular_exporter.py
@@ -11,6 +11,8 @@ from utils import assertion_msg, take_screenshot
 NAME = "ExRed Triage - are you regular exporter"
 URL = urljoin(EXRED_UI_URL, "triage")
 
+YES_RADIO = "#id_REGULAR_EXPORTER-regular_exporter_0"
+NO_RADIO = "#id_REGULAR_EXPORTER-regular_exporter_1"
 YES_CHECKBOX = "#id_REGULAR_EXPORTER-regular_exporter li:nth-child(1) > label"
 NO_CHECKBOX = "#id_REGULAR_EXPORTER-regular_exporter li:nth-child(2) > label"
 CONTINUE_BUTTON = ".exred-triage-form button.button"
@@ -53,3 +55,15 @@ def submit(driver: webdriver):
     button = driver.find_element_by_css_selector(CONTINUE_BUTTON)
     button.click()
     take_screenshot(driver, NAME + " after submitting")
+
+
+def is_yes_selected(driver: webdriver):
+    yes = driver.find_element_by_css_selector(YES_RADIO)
+    with assertion_msg("Expected Yes option to be selected"):
+        assert yes.get_property("checked")
+
+
+def is_no_selected(driver: webdriver):
+    no = driver.find_element_by_css_selector(NO_RADIO)
+    with assertion_msg("Expected No option to be selected"):
+        assert no.get_property("checked")

--- a/tests/exred/pages/triage_company_name.py
+++ b/tests/exred/pages/triage_company_name.py
@@ -79,3 +79,11 @@ def submit(driver: webdriver):
     button = driver.find_element_by_css_selector(CONTINUE_BUTTON)
     button.click()
     take_screenshot(driver, NAME + " after submitting")
+
+
+def is_company_name(driver: webdriver, company_name: str):
+    given = get_company_name(driver)
+    with assertion_msg(
+            "Expected the company name input box to be prepopulated with: '%s'"
+            " but got '%s' instead", company_name, given):
+        assert given.lower() == company_name.lower()

--- a/tests/exred/pages/triage_do_you_use_online_marketplaces.py
+++ b/tests/exred/pages/triage_do_you_use_online_marketplaces.py
@@ -11,6 +11,8 @@ from utils import assertion_msg, take_screenshot
 NAME = "ExRed Triage - do you use online marketplaces"
 URL = urljoin(EXRED_UI_URL, "triage")
 
+YES_RADIO = "#id_ONLINE_MARKETPLACE-used_online_marketplace_0"
+NO_RADIO = "#id_ONLINE_MARKETPLACE-used_online_marketplace_1"
 YES_CHECKBOX = (".radio label[for=id_ONLINE_MARKETPLACE-"
                 "used_online_marketplace_0]")
 NO_CHECKBOX = "label[for=id_ONLINE_MARKETPLACE-used_online_marketplace_1]"
@@ -52,3 +54,15 @@ def submit(driver: webdriver):
     button = driver.find_element_by_css_selector(CONTINUE_BUTTON)
     button.click()
     take_screenshot(driver, NAME + " after submitting")
+
+
+def is_yes_selected(driver: webdriver):
+    yes = driver.find_element_by_css_selector(YES_RADIO)
+    with assertion_msg("Expected Yes option to be selected"):
+        assert yes.get_property("checked")
+
+
+def is_no_selected(driver: webdriver):
+    no = driver.find_element_by_css_selector(NO_RADIO)
+    with assertion_msg("Expected No option to be selected"):
+        assert no.get_property("checked")

--- a/tests/exred/pages/triage_have_you_exported.py
+++ b/tests/exred/pages/triage_have_you_exported.py
@@ -11,6 +11,8 @@ from utils import assertion_msg, take_screenshot
 NAME = "ExRed Triage - have you exported before"
 URL = urljoin(EXRED_UI_URL, "triage")
 
+YES_RADIO = "#id_EXPORTED_BEFORE-exported_before_0"
+NO_RADIO = "#id_EXPORTED_BEFORE-exported_before_1"
 YES_CHECKBOX = "#id_EXPORTED_BEFORE-exported_before > li:nth-child(1) > label"
 NO_CHECKBOX = "#id_EXPORTED_BEFORE-exported_before > li:nth-child(2) > label"
 CONTINUE_BUTTON = ".exred-triage-form button.button"
@@ -53,3 +55,15 @@ def submit(driver: webdriver):
     button = driver.find_element_by_css_selector(CONTINUE_BUTTON)
     button.click()
     take_screenshot(driver, NAME + " after submitting")
+
+
+def is_yes_selected(driver: webdriver):
+    yes = driver.find_element_by_css_selector(YES_RADIO)
+    with assertion_msg("Expected Yes option to be selected"):
+        assert yes.get_property("checked")
+
+
+def is_no_selected(driver: webdriver):
+    no = driver.find_element_by_css_selector(NO_RADIO)
+    with assertion_msg("Expected No option to be selected"):
+        assert no.get_property("checked")

--- a/tests/exred/pages/triage_what_do_you_want_to_export.py
+++ b/tests/exred/pages/triage_what_do_you_want_to_export.py
@@ -79,3 +79,17 @@ def submit(driver: webdriver):
     assert button.is_displayed()
     button.click()
     take_screenshot(driver, NAME + " after submitting")
+
+
+def is_sector(driver: webdriver, code: str, sector: str):
+    with selenium_action(driver, "Can't find Sector selector input box"):
+        input_field = driver.find_element_by_css_selector(SECTORS_INPUT)
+    input_field_value = input_field.get_attribute("value").lower()
+    with assertion_msg(
+            "Expected the sector input field to be pre-populated with Sector "
+            "Code: '%s' but instead found '%s'", code, input_field_value):
+        assert code.lower() in input_field_value
+    with assertion_msg(
+            "Expected the sector input field to be pre-populated with Sector "
+            "Name: '%s' but instead found '%s'", sector, input_field_value):
+        assert sector.lower() in input_field_value

--- a/tests/exred/registry/articles.py
+++ b/tests/exred/registry/articles.py
@@ -52,6 +52,13 @@ ARTICLES = {
                 "next": "get export finance"
             }
         },
+        "export readiness": {
+            "new": {
+                "index": 11,
+                "previous": "get money to export",
+                "next": "consider how you'll get paid"
+            },
+        },
     },
     "choosing an agent or distributor": {
         "time to read": 0,
@@ -68,6 +75,13 @@ ARTICLES = {
                 "previous": "use a distributor",
                 "next": "license your product or service"
             }
+        },
+        "export readiness": {
+            "new": {
+                "index": 7,
+                "previous": "use a distributor",
+                "next": "meet your customers"
+            },
         },
     },
     "consider how you'll get paid": {
@@ -90,6 +104,13 @@ ARTICLES = {
                 "previous": "start a joint venture",
                 "next": "invoice currency and contents"
             }
+        },
+        "export readiness": {
+            "new": {
+                "index": 12,
+                "previous": "choose the right finance",
+                "next": "plan the logistics"
+            },
         },
     },
     "decide when you'll get paid": {
@@ -159,6 +180,13 @@ ARTICLES = {
                 "next": "know your customers"
             }
         },
+        "export readiness": {
+            "new": {
+                "index": 1,
+                "previous": None,
+                "next": "know your customers"
+            }
+        },
     },
     "find a route to market": {
         "time to read": 0,
@@ -180,6 +208,13 @@ ARTICLES = {
                 "previous": "make an export plan",
                 "next": "use an overseas agent"
             }
+        },
+        "export readiness": {
+            "new": {
+                "index": 4,
+                "previous": "make an export plan",
+                "next": "use an overseas agent"
+            },
         },
     },
     "franchise your business": {
@@ -246,6 +281,13 @@ ARTICLES = {
                 "previous": "understand your customer's culture",
                 "next": "choose the right finance"
             }
+        },
+        "export readiness": {
+            "new": {
+                "index": 10,
+                "previous": "manage language differences",
+                "next": "choose the right finance"
+            },
         },
     },
     "get your export documents right": {
@@ -320,6 +362,13 @@ ARTICLES = {
                 "next": "what intellectual property is"
             }
         },
+        "export readiness": {
+            "new": {
+                "index": 14,
+                "previous": "plan the logistics",
+                "next": "what intellectual property is"
+            },
+        },
     },
     "invoice currency and contents": {
         "time to read": 0,
@@ -374,6 +423,13 @@ ARTICLES = {
                 "index": 4,
                 "previous": "analyse the competition",
                 "next": "manage language differences"
+            },
+        },
+        "export readiness": {
+            "new": {
+                "index": 2,
+                "previous": "do research first",
+                "next": "make an export plan"
             }
         },
     },
@@ -425,6 +481,13 @@ ARTICLES = {
                 "next": "find a route to market"
             }
         },
+        "export readiness": {
+            "new": {
+                "index": 3,
+                "previous": "know your customers",
+                "next": "find a route to market"
+            },
+        },
     },
     "manage language differences": {
         "time to read": 0,
@@ -446,6 +509,13 @@ ARTICLES = {
                 "previous": "know your customers",
                 "next": "understand your customer's culture"
             }
+        },
+        "export readiness": {
+            "new": {
+                "index": 9,
+                "previous": "meet your customers",
+                "next": "get money to export"
+            },
         },
     },
     "match your website to your audience": {
@@ -481,6 +551,23 @@ ARTICLES = {
                 "next": "manage language differences"
             }
         },
+        "export readiness": {
+            "new": {
+                "index": 8,
+                "previous": "choosing an agent or distributor",
+                "next": "manage language differences"
+            },
+        },
+    },
+    "next steps for new to exporting": {
+        "time to read": 0,
+        "export readiness": {
+            "new": {
+                "index": 17,
+                "previous": "types of intellectual property",
+                "next": None
+            },
+        },
     },
     "payment methods": {
         "time to read": 0,
@@ -514,6 +601,13 @@ ARTICLES = {
                 "previous": "consider how you'll get paid",
                 "next": "internationalise your website"
             }
+        },
+        "export readiness": {
+            "new": {
+                "index": 13,
+                "previous": "consider how you'll get paid",
+                "next": "internationalise your website"
+            },
         },
     },
     "raise money by borrowing": {
@@ -598,6 +692,13 @@ ARTICLES = {
                 "next": "know what ip you have"
             }
         },
+        "export readiness": {
+            "new": {
+                "index": 16,
+                "previous": "what intellectual property is",
+                "next": "next steps for new to exporting"
+            },
+        },
     },
     "understand your customer's culture": {
         "time to read": 0,
@@ -637,6 +738,13 @@ ARTICLES = {
                 "next": "choosing an agent or distributor"
             }
         },
+        "export readiness": {
+            "new": {
+                "index": 6,
+                "previous": "use an overseas agent",
+                "next": "choosing an agent or distributor"
+            },
+        },
     },
     "use a freight forwarder": {
         "time to read": 0,
@@ -675,6 +783,13 @@ ARTICLES = {
                 "previous": "find a route to market",
                 "next": "use a distributor"
             }
+        },
+        "export readiness": {
+            "new": {
+                "index": 5,
+                "previous": "find a route to market",
+                "next": "use a distributor"
+            },
         },
     },
     "user incoterms in contracts": {
@@ -724,6 +839,13 @@ ARTICLES = {
                 "previous": "internationalise your website",
                 "next": "types of intellectual property"
             }
+        },
+        "export readiness": {
+            "new": {
+                "index": 15,
+                "previous": "internationalise your website",
+                "next": "types of intellectual property"
+            },
         },
     },
 }

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -16,7 +16,11 @@ from steps.then_impl import (
     should_see_sections_on_home_page,
     triage_should_be_classified_as
 )
-from steps.when_impl import triage_should_see_answers_to_questions
+from steps.when_impl import (
+    triage_answer_questions_again,
+    triage_change_answers,
+    triage_should_see_answers_to_questions
+)
 
 
 @then('"{actor_name}" should see the "{sections}" sections on home page')
@@ -91,3 +95,8 @@ def then_actor_should_see_answers_to_questions(context, actor_alias):
 def then_classified_exporter_should_be_on_personalised_journey_page(
         context, actor_alias, classification):
     personalised_should_see_layout_for(context, actor_alias, classification)
+
+
+@then('"{actor_alias}" should be able to answer the triage questions again with his previous answers pre-populated')
+def then_actor_should_be_able_to_answer_again(context, actor_alias):
+    triage_answer_questions_again(context, actor_alias)


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2523)

Scenario:
```gherkin
  @ED-2523
  @first-time
  @<specific>
  Scenario Outline: "<specific>" Exporter should be able to change their answers to at the end of triage
    Given "Robert" was classified as "<specific>" exporter in the triage process

    When "Robert" decides to change his answers

    Then "Robert" should be able to answer the triage questions again with his previous answers pre-populated

    Examples: classifications
      | specific   |
      | New        |
      | Occasional |
      | Regular    |
```
