### PR TITLE
ED-2606 navigate through guidance articles

### DIFF
--- a/tests/exred/features/articles.feature
+++ b/tests/exred/features/articles.feature
@@ -1,0 +1,339 @@
+@articles
+Feature: Articles
+
+
+  @ED-2606
+  @guidance
+  @articles
+  Scenario Outline: Any Exporter accessing Articles through the Guidance Article List should be able to navigate to the next article
+    Given "Robert" accessed "<category>" guidance articles using "home page"
+    And "Robert" opened first Article from the list
+
+    When "Robert" decides to read through all Articles from selected list
+
+    Then "Robert" should be able to navigate to the next article from the List following the Article Order
+
+    Examples: home page
+      | category                  |
+      | Market research           |
+      | Customer insight          |
+      | Finance                   |
+      | Business planning         |
+      | Getting paid              |
+      | Operations and Compliance |
+
+
+  @wip
+  @guidance
+  @articles
+  Scenario Outline: Any Exporter accessing the last Article from the Guidance Article List should not be able to navigate to the next article
+    Given "Robert" accessed "<category>" guidance articles using "home page"
+    And "Robert" opened any Article which is not the last one
+
+    When "Robert" decides to read an Article from the list
+    And "Robert" reaches the last one from the List of Articles for "<guidance_category>"
+
+    Then "Robert" should not see the link to the next Article
+    And "Robert" should not see the Personas End Pages
+
+    Examples:
+      | category                  |
+      | Market research           |
+      | Customer insight          |
+      | Finance                   |
+      | Business planning         |
+      | Getting paid              |
+      | Operations and Compliance |
+
+
+  @wip
+  @personas
+  @articles
+  Scenario Outline: Any Exporter accessing Articles through the Guidance Article List should be able to navigate to the next article
+    Given "Robert" classifies himself as "<specific>" Exporter
+    And "Robert" accessed Export Readiness articles for "<specific>" Exporters via "home page"
+    And "Robert" opened any Article which is not the last one
+
+    When "Robert" decides to read an Article from the list
+
+    Then "Robert" should be able to navigate to the next article from the List following the Article Order for "<exporting_status>" Exporter
+
+    Examples:
+      | specific         |
+      | New              |
+      | Occasional       |
+      | Regular          |
+
+
+  @wip
+  @articles
+  Scenario Outline: Any Exporter should see relevant article list from "<link_location>"
+    Given "Robert" classifies himself as "<specific>" exporter
+
+    When "Robert" goes to the relevant "<specific>" exporter link from "<link_location>"
+
+    Then "Robert" should see an ordered list of first 5 articles selected for "<exporter_status>" exporter
+    And "Robert" should see a Articles Read counter, Total number of Articles, Time to complete remaining chapters, Tasks completed counter and task Total number
+
+    Examples:
+      | specific   | link_location |
+      | New        | header menu   |
+      | Occasional | header menu   |
+      | Regular    | header menu   |
+      | New        | page body     |
+      | Occasional | page body     |
+      | Regular    | page body     |
+      | New        | footer links  |
+      | Occasional | footer links  |
+      | Regular    | footer links  |
+
+
+  @wip
+  @articles
+  Scenario Outline:  A triaged Exporter should see relevant article list on the customised page
+    Given "Robert" was classified as "<relevant>" exporter in the triage process
+
+    When "Robert" goes to the personalised page
+
+    Then "Robert" should see an ordered list of "first 5" articles selected for "<exporter_status>" exporter
+    And "Robert" should see a Articles Read counter, Total number of Articles, Time to complete remaining chapters, Tasks completed counter and task Total number
+
+    Examples:
+      | relevant   |
+      | New        |
+      | Occasional |
+      | Regular    |
+
+
+  @wip
+  @articles
+  Scenario Outline: Any Exporter should be able to get to the relevant article list using link from "<link_location>"
+    Given "Robert" classifies himself as "<exporter_status>" exporter
+    And "Robert" is on the Articles list page
+
+    When "Robert" decides to show more articles
+
+    Then "Robert" should see an ordered list of "previous + next 5" articles selected for "<exporter_status>" exporter
+    And "Robert" should see a Articles Read counter, Total number of Articles, Time to complete remaining chapters, Tasks completed counter and task Total number
+
+    Examples:
+      | exporter_status | link_location |
+      | New             | header menu   |
+      | Occasional      | header menu   |
+      | Regular         | header menu   |
+      | New             | page body     |
+      | Occasional      | page body     |
+      | Regular         | page body     |
+      | New             | footer links  |
+      | Occasional      | footer links  |
+      | Regular         | footer links  |
+
+
+  @wip
+  @articles
+  Scenario Outline: A triaged Exporter should be able to show more relevant articles on the customised page
+    Given "Robert" was classified as "<relevant>" exporter in the triage process
+    And "Robert" is on the "Personalised Journey" page
+
+    When "Robert" decides to show more articles
+
+    Then "Robert" should see an ordered list of "previous + next 5" articles selected for "<exporter_status>" exporter
+    And "Robert" should see a Articles Read counter, Total number of Articles, Time to complete remaining chapters, Tasks completed counter and task Total number
+
+    Examples:
+      | relevant   |
+      | New        |
+      | Occasional |
+      | Regular    |
+
+
+  @wip
+  @ED-2605
+  Scenario: Any Exporter should see his progress through the articles list
+    Given "Robert" is on the Article List page
+
+    When "Robert" views any article on the list
+    And "Robert" goes back to the Article List page
+
+    Then "Robert" should see this article as read (ticked)
+    And Chapters read counter should increase by 1
+    And Time to complete remaining chapters should decrease
+
+
+  @wip
+  Scenario: An Exporter should be able to register from the Articles list page in order to save their progress
+    Given "Robert" is on the Article List page
+    And "Robert" read some of the articles
+
+    When "Robert" decides to "register"
+    And "Robert" completes registration and email verification process
+    And "Robert" signs in
+
+    Then "Robert"'s current progress should be saved
+
+
+  @wip
+  Scenario: An Exporter should be able to sing in from the Articles list page in order to save their progress
+    Given "Robert" is on the Article List page
+    And "Robert" read some of the articles
+
+    When "Robert" decides to "sign in"
+    And "Robert" signs in
+
+    Then "Robert"'s current progress should be saved
+
+
+  @wip
+  Scenario: An Exporter should be able to register from the specific Article page in order to save their progress
+    Given "Robert" read some of the articles
+    And "Robert" is on the specific Article page
+
+    When "Robert" decides to "register"
+    And "Robert" completes registration and email verification process
+    And "Robert" signs in
+
+    Then "Robert"'s current progress should be saved
+
+
+  @wip
+  Scenario: A logged in Exporter should not see the register link on Article page
+    Given "Robert" is signed in
+    And "Robert" is on the specific Article page
+
+    Then "Robert"'s should not see the link to register
+
+
+  @wip
+  Scenario: A logged in Exporter should not see the register link on Article List page
+    Given "Robert" is signed in
+    And "Robert" is on the specific Article List page
+
+    Then "Robert"'s should not see the link to register
+
+
+  @wip
+  Scenario: An Exporter should be able to sign in from the specific Article page in order to save their progress
+    Given "Robert" read some of the articles
+    And "Robert" is on the specific Article page
+
+    When "Robert" decides to "sign in"
+    And "Robert" signs in
+
+    Then "Robert"'s current progress should be saved
+
+
+  @wip
+  Scenario: A signed in Exporter's progress should be updated with temporary information (cookie data merged with persistent storage)
+    Given "Robert" is signed in
+    And "Robert" reads some articles
+    And "Robert" completes some tasks
+    And "Robert"'s current progress is saved
+
+    When "Robert" decides to "sign out"
+    And "Robert" reads some more articles
+    And "Robert" completes some more tasks
+    And "Robert" decides to "sign in"
+
+    Then "Robert"'s current progress should be updated without overwriting (merged / accumulated)
+
+
+  @wip
+  Scenario Outline: Article read counter on the specific Article page and Articles list page should be the same
+    Given "Robert" accessed the article list from "<link_location>"
+
+    When "Robert" views any article on that list
+
+    Then "Robert" should see the same "Articles Read counter, Total number of Articles, Time to complete remaining chapters" as on the Articles list page
+
+    Examples:
+      | link_location             |
+      | header menu               |
+      | home page body            |
+      | personalised journey page |
+      | footer links              |
+
+
+  @wip
+  Scenario: Any Exporter should see his task completion progress on the articles list page
+    Given "Robert" is on the Article page
+
+    When "Robert" marks any task as completed
+    And "Robert" goes back to the Article List page
+
+    Then "Robert" should see the tasks completed counter increased by 1
+
+
+  @wip
+  Scenario: Any Exporter should see his task completion progress on the article page
+    Given "Robert" is on the Article page
+    And "Robert" marks any task as completed
+    And "Robert" went back to the Article List page
+
+    When "Robert" views the same article
+
+    Then "Robert" should see the tasks he already marked as completed
+
+
+  @articles
+  @wip
+  Scenario Outline: Any Exporter should be able to tell us whether they found the article useful or not
+    Given "Robert" is on the Article page
+
+    When "Robert" decides to tell us that he "<article_feedback_action>" this article useful
+
+    Then "Robert" feedback widget should disappear
+    And "Robert" should thanked for his feeback
+
+    Examples:
+      | article_feedback_action |
+      | found                   |
+      | did not find            |
+  @wip
+  @triage
+  @articles
+  Scenario Outline: Any Exporter accessing Articles through the Triage should be able to navigate to the next article for his Persona
+    Given "Robert" was classified as "<specific>" exporter in the triage process
+
+    When "Robert" opens any Article from the Personalised Page which is not the last one
+
+    Then "Robert" should be able to navigate to the next article from the List following the Article Order for "<exporting_status>" Persona
+    And "Robert" should not see any Articles that are not relevant to his "<exporting_status>" Persona
+
+    Examples:
+      | specific   |
+      | New        |
+      | Occasional |
+
+
+  @wip
+  @triage
+  @articles
+  Scenario Outline: Any Exporter that reads through all the Articles specific to his Persona should be presented with a dedicated Persona End Page
+    Given "Robert" was classified as "<specific>" exporter in the triage process
+    And "Robert" opens any Article from the Personalised Page which is not the last one
+    And "Robert" navigates through Articles
+
+    When "Robert" reaches the last Article from the List of Articles for "<exporting_status>" Persona
+
+    Then "Robert" should see the End Page for "<exporting_status>" Persona
+    And "Robert" should not see the link to the next Article
+
+    Examples:
+      | specific   |
+      | New        |
+      | Occasional |
+
+
+  @wip
+  Scenario Outline: Any Exporter should be able to share the article via Facebook, Twitter, Linked and email on the article page
+    Given "Robert" is on the Article page
+    And "Robert" decides to share the article via "<sharing_option>"
+
+    Then "Robert" should be taken to a new tab with the "<sharing_option>" opened and pre-populated message with the link to the article
+
+    Examples:
+      | sharing_option |
+      | Facebook       |
+      | Twitter        |
+      | Linked         |
+      | email          |

--- a/tests/exred/features/articles.feature
+++ b/tests/exred/features/articles.feature
@@ -24,6 +24,39 @@ Feature: Articles
 
 
   @wip
+  @ED-2613
+  @personas
+  @articles
+  Scenario Outline: Any Exporter accessing Articles through the Guidance Article List should be able to navigate to the next article
+    Given "Robert" classifies himself as "<specific>" Exporter
+    And "Robert" accessed Export Readiness articles for "<specific>" Exporters via "home page"
+    And "Robert" opened any Article which is not the last one
+
+    When "Robert" decides to read an Article from the list
+
+    Then "Robert" should be able to navigate to the next article from the List following the Article Order for "<exporting_status>" Exporter
+
+    Examples:
+      | specific         |
+      | New              |
+      | Occasional       |
+      | Regular          |
+
+
+  @wip
+  @ED-2605
+  Scenario: Any Exporter should see his progress through the articles list
+    Given "Robert" is on the Article List page
+
+    When "Robert" views any article on the list
+    And "Robert" goes back to the Article List page
+
+    Then "Robert" should see this article as read (ticked)
+    And Chapters read counter should increase by 1
+    And Time to complete remaining chapters should decrease
+
+
+  @wip
   @guidance
   @articles
   Scenario Outline: Any Exporter accessing the last Article from the Guidance Article List should not be able to navigate to the next article
@@ -44,25 +77,6 @@ Feature: Articles
       | Business planning         |
       | Getting paid              |
       | Operations and Compliance |
-
-
-  @wip
-  @personas
-  @articles
-  Scenario Outline: Any Exporter accessing Articles through the Guidance Article List should be able to navigate to the next article
-    Given "Robert" classifies himself as "<specific>" Exporter
-    And "Robert" accessed Export Readiness articles for "<specific>" Exporters via "home page"
-    And "Robert" opened any Article which is not the last one
-
-    When "Robert" decides to read an Article from the list
-
-    Then "Robert" should be able to navigate to the next article from the List following the Article Order for "<exporting_status>" Exporter
-
-    Examples:
-      | specific         |
-      | New              |
-      | Occasional       |
-      | Regular          |
 
 
   @wip
@@ -145,19 +159,6 @@ Feature: Articles
       | New        |
       | Occasional |
       | Regular    |
-
-
-  @wip
-  @ED-2605
-  Scenario: Any Exporter should see his progress through the articles list
-    Given "Robert" is on the Article List page
-
-    When "Robert" views any article on the list
-    And "Robert" goes back to the Article List page
-
-    Then "Robert" should see this article as read (ticked)
-    And Chapters read counter should increase by 1
-    And Time to complete remaining chapters should decrease
 
 
   @wip

--- a/tests/exred/pages/article_common.py
+++ b/tests/exred/pages/article_common.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""ExRed Common Articles Page Object."""
+import logging
+
+from selenium import webdriver
+from selenium.webdriver import ActionChains
+
+from registry.articles import get_articles
+from utils import assertion_msg, selenium_action, take_screenshot
+
+NAME = "ExRed Common Articles"
+URL = None
+
+
+ARTICLE_NAME = "#top > h1"
+TOTAL_NUMBER_OF_ARTICLES = "#top dd.position > span.to"
+ARTICLES_TO_READ_COUNTER = "#top dd.position > span.from"
+TIME_TO_COMPLETE = "#top dd.time span.value"
+NEXT_ARTICLE_LINK = "#next-article-link"
+SHARE_MENU = "ul.sharing-links"
+
+SCOPE_ELEMENTS = {
+    "total number of articles": TOTAL_NUMBER_OF_ARTICLES,
+    "articles read counter": ARTICLES_TO_READ_COUNTER,
+    "time to complete remaining chapters": TIME_TO_COMPLETE,
+    "share menu": SHARE_MENU,
+}
+
+
+def correct_total_number_of_articles(
+        driver: webdriver, group: str, category: str):
+    expected = len(get_articles(group, category))
+    total = driver.find_element_by_css_selector(TOTAL_NUMBER_OF_ARTICLES)
+    with assertion_msg(
+            "Total Number of Articles to read for %s '%s' category is "
+            "not visible", group, category):
+        assert total.is_displayed()
+    given = int(total.text)
+    with assertion_msg(
+            "Expected Total Number of Articles to read in %s '%s' "
+            "category to be %d but got %s", group, category, expected, given):
+        assert given == expected
+
+
+def correct_article_read_counter(driver: webdriver, expected: int):
+    counter = driver.find_element_by_css_selector(ARTICLES_TO_READ_COUNTER)
+    with assertion_msg("Article Read Counter is not visible"):
+        assert counter.is_displayed()
+    given = int(counter.text)
+    with assertion_msg(
+            "Expected Article Read Counter to be %d but got %s",
+            expected, given):
+        assert given == expected
+
+
+def check_if_link_to_next_article_is_displayed(
+        driver: webdriver, next_article: str):
+    """Check if link to the next Guidance Article is displayed, except on
+    the last one.
+
+    :param driver: selenium webdriver
+    :param next_article: Category for which "next" link should be visible
+    """
+    if next_article.lower() == "last":
+        link = driver.find_element_by_css_selector(NEXT_ARTICLE_LINK)
+        with assertion_msg(
+                "Found a link to the next Article on '%s' page: '%s'",
+                next_article, driver.current_url):
+            assert not link.is_displayed()
+    else:
+        link = driver.find_element_by_css_selector(NEXT_ARTICLE_LINK)
+        with assertion_msg(
+                "Link to the next Article is not visible on '%s'",
+                driver.current_url):
+            assert link.is_displayed()
+        with assertion_msg(
+                "Expected to see a link to '%s' but got '%s'",
+                next_article, link.text):
+            assert link.text.lower() == next_article.lower()
+
+
+def check_elements_are_visible(driver: webdriver, elements: list):
+    take_screenshot(driver, NAME)
+    for element in elements:
+        selector = SCOPE_ELEMENTS[element.lower()]
+        with selenium_action(
+                driver, "Could not find '%s' on '%s' using '%s' selector",
+                element, driver.current_url, selector):
+            page_element = driver.find_element_by_css_selector(selector)
+            if "firefox" not in driver.capabilities["browserName"].lower():
+                logging.debug("Moving focus to '%s' element", element)
+                action_chains = ActionChains(driver)
+                action_chains.move_to_element(page_element)
+                action_chains.perform()
+        with assertion_msg("Expected to see '%s' but can't see it", element):
+            assert page_element.is_displayed()
+
+
+def get_article_name(driver: webdriver) -> str:
+    current_article = driver.find_element_by_css_selector(ARTICLE_NAME)
+    return current_article.text.lower()
+
+
+def should_see_article(driver: webdriver, name: str):
+    current_article = get_article_name(driver)
+    with assertion_msg(
+            "Expected to see '%s' Article but got '%s'", name,
+            current_article):
+        assert current_article.lower() == name.lower()
+
+
+def go_to_next_article(driver: webdriver):
+    next_article = driver.find_element_by_css_selector(NEXT_ARTICLE_LINK)
+    assert next_article.is_displayed()
+    next_article.click()
+    take_screenshot(driver, "After going to the next Article")

--- a/tests/exred/pages/guidance_common.py
+++ b/tests/exred/pages/guidance_common.py
@@ -27,6 +27,7 @@ TIME_TO_COMPLETE = "#articles div.scope-indicator dd.time > span.value"
 SHOW_MORE_BUTTON = "#js-paginate-list-more"
 ARTICLES_LIST = "#js-paginate-list > li"
 NEXT_CATEGORY_LINK = ""
+FIRST_ARTICLE = "#js-paginate-list > li:nth-child(1) > a"
 
 SCOPE_ELEMENTS = {
     "total number of articles": TOTAL_NUMBER_OF_ARTICLES,
@@ -174,3 +175,15 @@ def check_elements_are_visible(driver: webdriver, elements: list):
                 action_chains.perform()
         with assertion_msg("Expected to see '%s' but can't see it", element):
             assert page_element.is_displayed()
+
+
+def open_first_article(driver: webdriver):
+    with selenium_action(
+            driver,
+            "Could not find link to the first article using '%s' selector",
+            FIRST_ARTICLE):
+        first_article = driver.find_element_by_css_selector(FIRST_ARTICLE)
+    with assertion_msg("The link to the first article is not visible"):
+        assert first_article.is_displayed()
+    first_article.click()
+    take_screenshot(driver, "after opening first article")

--- a/tests/exred/registry/articles.py
+++ b/tests/exred/registry/articles.py
@@ -1230,3 +1230,43 @@ def get_articles(group: str, category: str) -> list:
     """
     filtered = filter_articles(group.lower(), category.lower())
     return sorted(filtered, key=get_article_index)
+
+
+def find_article(group: str, category: str, name: str) -> dict:
+    result = {}
+    articles = get_articles(group, category)
+    for idx, article in enumerate(articles):
+        current = list(article.keys())[0]
+        if current == name:
+            if (idx - 1) >= 0:
+                prev_name = list(articles[idx-1].keys())[0]
+                prev_article = {
+                    "index": articles[idx-1][prev_name]['index'],
+                    "name": prev_name,
+                    "next": articles[idx-1][prev_name]['next'],
+                    "previous": articles[idx-1][prev_name]['previous'],
+                    "time to read": articles[idx-1][prev_name]['time to read'],
+                }
+            else:
+                prev_article = None
+
+            if (idx + 1) < len(articles):
+                next_name = list(articles[idx+1].keys())[0]
+                next_article = {
+                    "index": articles[idx+1][next_name]['index'],
+                    "name": next_name,
+                    "next": articles[idx+1][next_name]['next'],
+                    "previous": articles[idx+1][next_name]['previous'],
+                    "time to read": articles[idx+1][next_name]['time to read'],
+                }
+            else:
+                next_article = None
+
+            result = {
+                "index": article[current]['index'],
+                "name": current,
+                "next": next_article,
+                "previous": prev_article,
+                "time to read": article[current]['time to read']
+            }
+    return result

--- a/tests/exred/registry/articles.py
+++ b/tests/exred/registry/articles.py
@@ -1270,3 +1270,9 @@ def find_article(group: str, category: str, name: str) -> dict:
                 "time to read": article[current]['time to read']
             }
     return result
+
+
+def get_first_article(group: str, category: str) -> dict:
+    articles = get_articles(group, category)
+    name = list(articles[0].keys())[0]
+    return find_article(group, category, name)

--- a/tests/exred/registry/articles.py
+++ b/tests/exred/registry/articles.py
@@ -153,7 +153,7 @@ ARTICLES = {
             "occasional": {
                 "index": 23,
                 "next": "invoice currency and contents",
-                "previous": "get government finance support"
+                "previous": "get finance support from government"
             }
         },
     },
@@ -348,7 +348,7 @@ ARTICLES = {
             }
         }
     },
-    "get government finance support": {
+    "get finance support from government": {
         "time to read": 0,
         "guidance": {
             "finance": {
@@ -489,7 +489,7 @@ ARTICLES = {
             "regular": {
                 "index": 15,
                 "next": "know what IP you have",
-                "previous": "get government finance support"
+                "previous": "get finance support from government"
             }
         }
     },
@@ -670,7 +670,7 @@ ARTICLES = {
             },
             "occasional": {
                 "index": 14,
-                "previous": "get government finance support",
+                "previous": "get finance support from government",
                 "next": "find a route to market"
             }
         },
@@ -889,18 +889,18 @@ ARTICLES = {
             "occasional": {
                 "index": 12,
                 "previous": "borrow against assets",
-                "next": "get government finance support"
+                "next": "get finance support from government"
             }
         },
         "export readiness": {
             "occasional": {
                 "index": 21,
-                "next": "get government finance support",
+                "next": "get finance support from government",
                 "previous": "borrow against assets"
             },
             "regular": {
                 "index": 13,
-                "next": "get government finance support",
+                "next": "get finance support from government",
                 "previous": "borrow against assets"
             }
         }

--- a/tests/exred/registry/articles.py
+++ b/tests/exred/registry/articles.py
@@ -98,7 +98,7 @@ ARTICLES = {
         "time to read": 0,
         "guidance": {
             "business planning": {
-                "index": 5,
+                "index": 6,
                 "previous": "use a distributor",
                 "next": "licensing and franchising"
             }
@@ -274,7 +274,7 @@ ARTICLES = {
             "business planning": {
                 "index": 2,
                 "previous": "make an export plan",
-                "next": "use an overseas agent"
+                "next": "sell overseas directly"
             }
         },
         "personalised journey": {
@@ -306,7 +306,7 @@ ARTICLES = {
         "time to read": 0,
         "guidance": {
             "business planning": {
-                "index": 8,
+                "index": 9,
                 "previous": "license your product or service",
                 "next": "start a joint venture"
             }
@@ -618,7 +618,7 @@ ARTICLES = {
         "time to read": 0,
         "guidance": {
             "business planning": {
-                "index": 6,
+                "index": 7,
                 "previous": "choosing an agent or distributor",
                 "next": "license your product or service"
             }
@@ -628,7 +628,7 @@ ARTICLES = {
         "time to read": 0,
         "guidance": {
             "business planning": {
-                "index": 7,
+                "index": 8,
                 "previous": "licensing and franchising",
                 "next": "franchise your business"
             }
@@ -905,11 +905,21 @@ ARTICLES = {
             }
         }
     },
+    "sell overseas directly": {
+        "time to read": 0,
+        "guidance": {
+            "business planning": {
+                "index": 3,
+                "previous": "find a route to market",
+                "next": "use an overseas agent"
+            }
+        },
+    },
     "set up an overseas operation": {
         "time to read": 0,
         "guidance": {
             "business planning": {
-                "index": 10,
+                "index": 11,
                 "previous": "start a joint venture",
                 "next": None
             }
@@ -926,7 +936,7 @@ ARTICLES = {
         "time to read": 0,
         "guidance": {
             "business planning": {
-                "index": 9,
+                "index": 10,
                 "previous": "franchise your business",
                 "next": "set up an overseas operation"
             }
@@ -1018,7 +1028,7 @@ ARTICLES = {
         "time to read": 0,
         "guidance": {
             "business planning": {
-                "index": 4,
+                "index": 5,
                 "previous": "use an overseas agent",
                 "next": "choosing an agent or distributor"
             }
@@ -1076,8 +1086,8 @@ ARTICLES = {
         "time to read": 0,
         "guidance": {
             "business planning": {
-                "index": 3,
-                "previous": "find a route to market",
+                "index": 4,
+                "previous": "sell overseas directly",
                 "next": "use a distributor"
             }
         },

--- a/tests/exred/steps/given_def.py
+++ b/tests/exred/steps/given_def.py
@@ -6,6 +6,7 @@ from steps.then_impl import should_be_on_page
 from steps.when_impl import (
     actor_classifies_himself_as,
     guidance_open_category,
+    guidance_open_first_article,
     set_online_marketplace_preference,
     set_sector_preference,
     start_triage,
@@ -78,5 +79,11 @@ def given_actor_sets_sector_preference(context, actor_alias, goods_or_services):
 
 
 @given('"{actor_alias}" "{used_or_not}" online marketplaces before')
-def step_impl(context, actor_alias, used_or_not):
+def given_actor_set_preferences_for_online_marketplaces(
+        context, actor_alias, used_or_not):
     set_online_marketplace_preference(context, actor_alias, used_or_not)
+
+
+@given('"{actor_alias}" opened first Article from the list')
+def given_actor_opened_first_article(context, actor_alias):
+    guidance_open_first_article(context, actor_alias)

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -3,6 +3,7 @@
 from behave import then
 
 from steps.then_impl import (
+    articles_should_see_in_correct_order,
     export_readiness_expected_page_elements_should_be_visible,
     export_readiness_should_see_articles,
     guidance_check_if_link_to_next_category_is_displayed,
@@ -119,3 +120,8 @@ def then_expected_export_readiness_page_elements_should_be_visible(
 @then('"{actor_alias}" should see "{sections}" sections on "{page_name}" page')
 def then_should_see_sections(context, actor_alias, sections, page_name):
     should_see_sections(context, actor_alias, sections.split(", "), page_name)
+
+
+@then('"{actor_alias}" should be able to navigate to the next article from the List following the Article Order')
+def then_actor_should_see_articles_in_correct_order(context, actor_alias):
+    articles_should_see_in_correct_order(context, actor_alias)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -10,13 +10,14 @@ from pages import (
     home,
     personalised_journey
 )
+from registry.articles import find_article, get_articles
 from registry.pages import get_page_object
 from steps.when_impl import (
     triage_should_be_classified_as_new,
     triage_should_be_classified_as_occasional,
     triage_should_be_classified_as_regular
 )
-from utils import get_actor
+from utils import assertion_msg, get_actor
 
 
 def should_see_sections_on_home_page(
@@ -167,3 +168,20 @@ def should_see_sections(
         logging.debug(
             "%s can see '%s' section on %s page", actor_alias, section,
             page_name)
+
+
+def articles_should_see_in_correct_order(context: Context, actor_alias: str):
+    actor = get_actor(context, actor_alias)
+    group = actor.article_group
+    category = actor.article_category
+    visited_articles = actor.visited_articles
+    for idx, visited_article in enumerate(visited_articles):
+        expected_article = find_article(group, category, visited_article)
+        with assertion_msg(
+                "Expected to see '%s' '%s' article '%s' on position %d but %s "
+                "viewed it as %d", group, category, visited_article,
+                expected_article["index"], idx + 1):
+            assert expected_article["index"] == (idx + 1)
+        logging.debug(
+            "%s saw '%s' '%s' article '%s' at correct position %d",
+            actor_alias, group, category, visited_article, idx + 1)

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -6,6 +6,7 @@ from steps.then_impl import triage_should_be_classified_as
 from steps.when_impl import (
     exred_open_category,
     guidance_open_category,
+    guidance_read_through_all_articles,
     personalised_journey_create_page,
     start_triage,
     triage_are_you_incorporated,
@@ -104,3 +105,8 @@ def when_actor_decides_to_change_the_answers(context, actor_alias):
 @when('"{actor_alias}" goes to the Export Readiness Articles for "{category}" Exporters via "{location}"')
 def when_actor_goes_to_exred_articles(context, actor_alias, category, location):
     exred_open_category(context, actor_alias, category, location)
+
+
+@when('"{actor_alias}" decides to read through all Articles from selected list')
+def when_actor_reads_through_all_guidance_articles(context, actor_alias):
+    guidance_read_through_all_articles(context, actor_alias)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -74,13 +74,18 @@ def open_group_element(
 
 
 def guidance_open_category(
-        context: Context, actor: str, category: str, location: str):
+        context: Context, actor_alias: str, category: str, location: str):
+    if not get_actor(context, actor_alias):
+        add_actor(context, unauthenticated_actor(actor_alias))
     home.visit(driver=context.driver)
     logging.debug(
         "%s is about to open Guidance '%s' category from %s",
-        actor, category, location)
+        actor_alias, category, location)
     open_group_element(
         context, group="guidance", element=category, location=location)
+    update_actor(
+        context, actor_alias, article_group="guidance",
+        article_category=category, article_location=location)
 
 
 def start_triage(context: Context, actor_alias: str):

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -549,3 +549,39 @@ def guidance_open_first_article(context: Context, actor_alias: str):
     logging.debug(
         "%s is on the first article %s: %s", actor_alias,
         first_article["name"], driver.current_url)
+
+
+def guidance_read_through_all_articles(context: Context, actor_alias: str):
+    driver = context.driver
+    actor = get_actor(context, actor_alias)
+    group = actor.article_group
+    category = actor.article_category
+
+    visited_articles = []
+
+    current_article_name = article_common.get_article_name(driver)
+    logging.debug("%s is on '%s' article", actor_alias, current_article_name)
+    current_article = find_article(group, category, current_article_name)
+    assert current_article, "Could not find Article: %s" % current_article_name
+    visited_articles.append(current_article_name)
+    next_article = current_article["next"]
+
+    while next_article is not None:
+        visited_articles.append(next_article["name"])
+        article_common.check_if_link_to_next_article_is_displayed(
+            driver, next_article["name"])
+        article_common.go_to_next_article(driver)
+        current_article_name = article_common.get_article_name(driver)
+        logging.debug(
+            "%s is on '%s' article", actor_alias, current_article_name)
+        current_article = find_article(group, category, current_article_name)
+        assert current_article, ("Could not find Article: %s" %
+                                 current_article_name)
+        next_article = current_article["next"]
+        if next_article:
+            logging.debug(
+                "The next article to visit is: %s", next_article["name"])
+        else:
+            logging.debug("There's no more articles to see")
+
+    update_actor(context, actor_alias, visited_articles=visited_articles)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -7,7 +7,9 @@ from behave.runner import Context
 from retrying import retry
 
 from pages import (
+    article_common,
     footer,
+    guidance_common,
     header,
     home,
     personalised_journey,
@@ -19,6 +21,7 @@ from pages import (
     triage_result,
     triage_what_do_you_want_to_export
 )
+from registry.articles import find_article, get_articles, get_first_article
 from registry.pages import get_page_object
 from settings import EXRED_SECTORS
 from utils import (
@@ -528,3 +531,16 @@ def set_online_marketplace_preference(
     logging.debug(
         "%s decided that he/she %s online marketplaces before", actor_alias,
         used_or_not)
+
+
+def guidance_open_first_article(context: Context, actor_alias: str):
+    driver = context.driver
+    actor = get_actor(context, actor_alias)
+    group = actor.article_group
+    category = actor.article_category
+    first_article = get_first_article(group, category)
+    guidance_common.open_first_article(driver)
+    article_common.should_see_article(driver, first_article["name"])
+    logging.debug(
+        "%s is on the first article %s: %s", actor_alias,
+        first_article["name"], driver.current_url)

--- a/tests/exred/utils/__init__.py
+++ b/tests/exred/utils/__init__.py
@@ -40,7 +40,9 @@ Actor = namedtuple(
         "triage_classification", "what_do_you_want_to_export",
         "have_you_exported_before", "do_you_export_regularly",
         "are_you_incorporated", "company_name",
-        "do_you_use_online_marketplaces", "created_personalised_journey"
+        "do_you_use_online_marketplaces", "created_personalised_journey",
+        "article_group", "article_category", "article_location",
+        "visited_articles"
     ]
 )
 


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2606)

Scenario:
```gherkin
  @ED-2606
  @guidance
  @articles
  Scenario Outline: Any Exporter accessing Articles through the Guidance Article List should be able to navigate to the next article
    Given "Robert" accessed "<category>" guidance articles using "home page"
    And "Robert" opened first Article from the list

    When "Robert" decides to read through all Articles from selected list

    Then "Robert" should be able to navigate to the next article from the List following the Article Order

    Examples: home page
      | category                  |
      | Market research           |
      | Customer insight          |
      | Finance                   |
      | Business planning         |
      | Getting paid              |
      | Operations and Compliance |
```
