### PR TITLE
ED-2616 there should be no link to next article when Exporter reaches last article

### DIFF
--- a/tests/exred/features/articles.feature
+++ b/tests/exred/features/articles.feature
@@ -57,7 +57,27 @@ Feature: Articles
   @ED-2616
   @guidance
   @articles
-  Scenario Outline: Any Exporter accessing the last Article from the Guidance Article "<category>" List should not be able to navigate to the next article
+  Scenario Outline: Any Exporter accessing the last Article from the Guidance Article "<category>" List should be able to navigate to the "<next>" Articles
+    Given "Robert" accessed "<category>" guidance articles using "home page"
+    And "Robert" opened any Article but the last one
+
+    When "Robert" decides to read through all remaining Articles from selected list
+
+    Then "Robert" should see a link to the fist article from the "<next>" category
+
+    Examples:
+      | category                  | next                      |
+      | Market research           | Customer insight          |
+      | Customer insight          | Finance                   |
+      | Finance                   | Business planning         |
+      | Business planning         | Getting paid              |
+      | Getting paid              | Operations and Compliance |
+
+
+  @ED-2616
+  @guidance
+  @articles
+  Scenario Outline: Any Exporter accessing the last Article from the last Guidance Article category "<category>" should not see link to the next article
     Given "Robert" accessed "<category>" guidance articles using "home page"
     And "Robert" opened any Article but the last one
 
@@ -68,11 +88,6 @@ Feature: Articles
 
     Examples:
       | category                  |
-      | Market research           |
-      | Customer insight          |
-      | Finance                   |
-      | Business planning         |
-      | Getting paid              |
       | Operations and Compliance |
 
 

--- a/tests/exred/features/articles.feature
+++ b/tests/exred/features/articles.feature
@@ -35,10 +35,10 @@ Feature: Articles
     Then "Robert" should be able to navigate to the next article from the List following the Article Order
 
     Examples:
-      | relevant         |
-      | New              |
-      | Occasional       |
-      | Regular          |
+      | relevant   |
+      | New        |
+      | Occasional |
+      | Regular    |
 
 
   @wip
@@ -54,18 +54,17 @@ Feature: Articles
     And Time to complete remaining chapters should decrease
 
 
-  @wip
+  @ED-2616
   @guidance
   @articles
-  Scenario Outline: Any Exporter accessing the last Article from the Guidance Article List should not be able to navigate to the next article
+  Scenario Outline: Any Exporter accessing the last Article from the Guidance Article "<category>" List should not be able to navigate to the next article
     Given "Robert" accessed "<category>" guidance articles using "home page"
-    And "Robert" opened any Article which is not the last one
+    And "Robert" opened any Article but the last one
 
-    When "Robert" decides to read an Article from the list
-    And "Robert" reaches the last one from the List of Articles for "<guidance_category>"
+    When "Robert" decides to read through all remaining Articles from selected list
 
     Then "Robert" should not see the link to the next Article
-    And "Robert" should not see the Personas End Pages
+    And "Robert" should not see the Personas End Page
 
     Examples:
       | category                  |

--- a/tests/exred/pages/article_common.py
+++ b/tests/exred/pages/article_common.py
@@ -3,6 +3,7 @@
 import logging
 
 from selenium import webdriver
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver import ActionChains
 
 from registry.articles import get_articles
@@ -129,3 +130,12 @@ def go_to_next_article(driver: webdriver):
     assert next_article.is_displayed()
     next_article.click()
     take_screenshot(driver, "After going to the next Article")
+
+
+def should_not_see_link_to_next_article(driver: webdriver):
+    try:
+        next_article = driver.find_element_by_css_selector(NEXT_ARTICLE_LINK)
+        with assertion_msg("Link to the next article is visible"):
+            assert not next_article.is_displayed()
+    except NoSuchElementException:
+        logging.debug("As expected link to the next article, is not present")

--- a/tests/exred/pages/article_common.py
+++ b/tests/exred/pages/article_common.py
@@ -25,6 +25,7 @@ SCOPE_ELEMENTS = {
     "articles read counter": ARTICLES_TO_READ_COUNTER,
     "time to complete remaining chapters": TIME_TO_COMPLETE,
     "share menu": SHARE_MENU,
+    "article name": ARTICLE_NAME
 }
 
 
@@ -139,3 +140,8 @@ def should_not_see_link_to_next_article(driver: webdriver):
             assert not next_article.is_displayed()
     except NoSuchElementException:
         logging.debug("As expected link to the next article, is not present")
+
+
+def should_not_see_personas_end_page(driver: webdriver):
+    """Check if Actor is stil on an Article page."""
+    check_elements_are_visible(driver, ["article name"])

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -4,6 +4,7 @@ from behave import then
 
 from steps.then_impl import (
     articles_should_not_see_link_to_next_article,
+    articles_should_not_see_personas_end_page,
     articles_should_see_in_correct_order,
     export_readiness_expected_page_elements_should_be_visible,
     export_readiness_should_see_articles,
@@ -131,3 +132,8 @@ def then_actor_should_see_articles_in_correct_order(context, actor_alias):
 @then('"{actor_alias}" should not see the link to the next Article')
 def then_there_should_no_link_to_the_next_article(context, actor_alias):
     articles_should_not_see_link_to_next_article(context, actor_alias)
+
+
+@then('"{actor_alias}" should not see the Personas End Page')
+def then_actor_should_not_see_pesonas_end_page(context, actor_alias):
+    articles_should_not_see_personas_end_page(context, actor_alias)

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -3,6 +3,7 @@
 from behave import then
 
 from steps.then_impl import (
+    articles_should_not_see_link_to_next_article,
     articles_should_see_in_correct_order,
     export_readiness_expected_page_elements_should_be_visible,
     export_readiness_should_see_articles,
@@ -125,3 +126,8 @@ def then_should_see_sections(context, actor_alias, sections, page_name):
 @then('"{actor_alias}" should be able to navigate to the next article from the List following the Article Order')
 def then_actor_should_see_articles_in_correct_order(context, actor_alias):
     articles_should_see_in_correct_order(context, actor_alias)
+
+
+@then('"{actor_alias}" should not see the link to the next Article')
+def then_there_should_no_link_to_the_next_article(context, actor_alias):
+    articles_should_not_see_link_to_next_article(context, actor_alias)

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -6,6 +6,7 @@ from steps.then_impl import (
     articles_should_not_see_link_to_next_article,
     articles_should_not_see_personas_end_page,
     articles_should_see_in_correct_order,
+    articles_should_see_link_to_first_article_from_next_category,
     export_readiness_expected_page_elements_should_be_visible,
     export_readiness_should_see_articles,
     guidance_check_if_link_to_next_category_is_displayed,
@@ -137,3 +138,10 @@ def then_there_should_no_link_to_the_next_article(context, actor_alias):
 @then('"{actor_alias}" should not see the Personas End Page')
 def then_actor_should_not_see_pesonas_end_page(context, actor_alias):
     articles_should_not_see_personas_end_page(context, actor_alias)
+
+
+@then('"{actor_alias}" should see a link to the fist article from the "{next_category}" category')
+def then_actor_should_see_link_to_next_category(
+        context, actor_alias, next_category):
+    articles_should_see_link_to_first_article_from_next_category(
+        context, actor_alias, next_category)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -5,6 +5,7 @@ import logging
 from behave.runner import Context
 
 from pages import (
+    article_common,
     export_readiness_common,
     guidance_common,
     home,
@@ -185,3 +186,8 @@ def articles_should_see_in_correct_order(context: Context, actor_alias: str):
         logging.debug(
             "%s saw '%s' '%s' article '%s' at correct position %d",
             actor_alias, group, category, visited_article, position)
+
+
+def articles_should_not_see_link_to_next_article(
+        context: Context, actor_alias: str):
+    article_common.should_not_see_link_to_next_article(context.driver)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -191,3 +191,8 @@ def articles_should_see_in_correct_order(context: Context, actor_alias: str):
 def articles_should_not_see_link_to_next_article(
         context: Context, actor_alias: str):
     article_common.should_not_see_link_to_next_article(context.driver)
+
+
+def articles_should_not_see_personas_end_page(
+        context: Context, actor_alias: str):
+    article_common.should_not_see_personas_end_page(context.driver)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -11,7 +11,7 @@ from pages import (
     home,
     personalised_journey
 )
-from registry.articles import get_article
+from registry.articles import get_article, get_articles
 from registry.pages import get_page_object
 from steps.when_impl import (
     triage_should_be_classified_as_new,
@@ -196,3 +196,16 @@ def articles_should_not_see_link_to_next_article(
 def articles_should_not_see_personas_end_page(
         context: Context, actor_alias: str):
     article_common.should_not_see_personas_end_page(context.driver)
+
+
+def articles_should_see_link_to_first_article_from_next_category(
+        context: Context, actor_alias: str, next_category: str):
+    driver = context.driver
+    actor = get_actor(context, actor_alias)
+    group = actor.article_group
+    first_article = get_articles(group, next_category)[0]
+    article_common.check_if_link_to_next_article_is_displayed(
+        driver, first_article.title)
+    logging.debug(
+        "%s can see link to the first article '%s' from '%s' category",
+        actor_alias, first_article.title, next_category)


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2616)

Scenario:
```gherkin
  @ED-2616
  @guidance
  @articles
  Scenario Outline: Any Exporter accessing the last Article from the Guidance Article "<category>" List should be able to navigate to the "<next>" Articles
    Given "Robert" accessed "<category>" guidance articles using "home page"
    And "Robert" opened any Article but the last one

    When "Robert" decides to read through all remaining Articles from selected list

    Then "Robert" should see a link to the fist article from the "<next>" category

    Examples:
      | category                  | next                      |
      | Market research           | Customer insight          |
      | Customer insight          | Finance                   |
      | Finance                   | Business planning         |
      | Business planning         | Getting paid              |
      | Getting paid              | Operations and Compliance |


  @ED-2616
  @guidance
  @articles
  Scenario Outline: Any Exporter accessing the last Article from the last Guidance Article category "<category>" should not see link to the next article
    Given "Robert" accessed "<category>" guidance articles using "home page"
    And "Robert" opened any Article but the last one

    When "Robert" decides to read through all remaining Articles from selected list

    Then "Robert" should not see the link to the next Article
    And "Robert" should not see the Personas End Page

    Examples:
      | category                  |
      | Operations and Compliance |
```
