### PR TITLE
ED-2628 relevant list of export readiness articles

### DIFF
--- a/tests/exred/features/articles.feature
+++ b/tests/exred/features/articles.feature
@@ -96,24 +96,24 @@ Feature: Articles
       | Operations and Compliance |
 
 
-  @wip
+  @ED-2628
   @articles
-  Scenario Outline: Any Exporter should see relevant article list from "<link_location>"
+  Scenario Outline: "<relevant>" Exporter should see a list of relevant Export Readiness Articles when accessed via "<location>"
     Given "Robert" classifies himself as "<specific>" exporter
 
-    When "Robert" goes to the relevant "<specific>" exporter link from "<link_location>"
+    When "Robert" goes to the Export Readiness Articles for "<relevant>" Exporters via "<location>"
 
-    Then "Robert" should see an ordered list of first 5 articles selected for "<exporter_status>" exporter
-    And "Robert" should see a Articles Read counter, Total number of Articles, Time to complete remaining chapters, Tasks completed counter and task Total number
+    Then "Robert" should see an ordered list of all Export Readiness Articles selected for "<relevant>" Exporters
+    And "Robert" should see on the Export Readiness Articles page "Articles Read counter, Total number of Articles, Time to complete remaining chapters"
 
     Examples:
-      | specific   | link_location |
+      | relevant   | location      |
       | New        | header menu   |
       | Occasional | header menu   |
       | Regular    | header menu   |
-      | New        | page body     |
-      | Occasional | page body     |
-      | Regular    | page body     |
+      | New        | home page     |
+      | Occasional | home page     |
+      | Regular    | home page     |
       | New        | footer links  |
       | Occasional | footer links  |
       | Regular    | footer links  |

--- a/tests/exred/features/articles.feature
+++ b/tests/exred/features/articles.feature
@@ -5,6 +5,7 @@ Feature: Articles
   @ED-2606
   @guidance
   @articles
+  @<category>
   Scenario Outline: Any Exporter accessing Articles through the Guidance Article List should be able to navigate to the next article
     Given "Robert" accessed "<category>" guidance articles using "home page"
     And "Robert" opened first Article from the list
@@ -26,6 +27,7 @@ Feature: Articles
   @ED-2613
   @personas
   @articles
+  @<relevant>
   Scenario Outline: "<relevant>" Exporter accessing Articles through the Export Readiness Article List should be able to navigate to the next article
     Given "Robert" accessed Export Readiness articles for "<relevant>" Exporters via "home page"
     And "Robert" opened any Article but the last one
@@ -43,6 +45,7 @@ Feature: Articles
 
   @ED-2605
   @progress
+  @<group>
   Scenario Outline: Any Exporter should see his progress through the articles list
     Given "Robert" is on the "<group>" Article List for randomly selected category
 
@@ -62,6 +65,7 @@ Feature: Articles
   @ED-2616
   @guidance
   @articles
+<<<<<<< c9bd7d3850c6c0ea143db6f91057c8e50ee5e15b
   Scenario Outline: Any Exporter accessing the last Article from the Guidance Article "<category>" List should be able to navigate to the "<next>" Articles
     Given "Robert" accessed "<category>" guidance articles using "home page"
     And "Robert" opened any Article but the last one
@@ -82,6 +86,7 @@ Feature: Articles
   @ED-2616
   @guidance
   @articles
+  @<category>
   Scenario Outline: Any Exporter accessing the last Article from the last Guidance Article category "<category>" should not see link to the next article
     Given "Robert" accessed "<category>" guidance articles using "home page"
     And "Robert" opened any Article but the last one
@@ -98,6 +103,8 @@ Feature: Articles
 
   @ED-2628
   @articles
+  @<relevant>
+  @<location>
   Scenario Outline: "<relevant>" Exporter should see a list of relevant Export Readiness Articles when accessed via "<location>"
     Given "Robert" classifies himself as "<specific>" exporter
 

--- a/tests/exred/features/articles.feature
+++ b/tests/exred/features/articles.feature
@@ -65,7 +65,6 @@ Feature: Articles
   @ED-2616
   @guidance
   @articles
-<<<<<<< c9bd7d3850c6c0ea143db6f91057c8e50ee5e15b
   Scenario Outline: Any Exporter accessing the last Article from the Guidance Article "<category>" List should be able to navigate to the "<next>" Articles
     Given "Robert" accessed "<category>" guidance articles using "home page"
     And "Robert" opened any Article but the last one


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2628)

Scenario:
```gherkin
  @ED-2628
  @articles
  @<relevant>
  @<location>
  Scenario Outline: "<relevant>" Exporter should see a list of relevant Export Readiness Articles when accessed via "<location>"
    Given "Robert" classifies himself as "<specific>" exporter

    When "Robert" goes to the Export Readiness Articles for "<relevant>" Exporters via "<location>"

    Then "Robert" should see an ordered list of all Export Readiness Articles selected for "<relevant>" Exporters
    And "Robert" should see on the Export Readiness Articles page "Articles Read counter, Total number of Articles, Time to complete remaining chapters"

    Examples:
      | relevant   | location      |
      | New        | header menu   |
      | Occasional | header menu   |
      | Regular    | header menu   |
      | New        | home page     |
      | Occasional | home page     |
      | Regular    | home page     |
      | New        | footer links  |
      | Occasional | footer links  |
      | Regular    | footer links  |
```
