### PR TITLE
ED-2605 read progress

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,8 +16,6 @@ test:
   post:
     - mkdir $CIRCLE_ARTIFACTS/exred_reports
     - mkdir $CIRCLE_ARTIFACTS/fabs_reports
-    - mkdir $CIRCLE_ARTIFACTS/exred_screenshots
     - mv tests/exred/reports/*.log $CIRCLE_ARTIFACTS/exred_reports
     - mv tests/functional/reports/*.log $CIRCLE_ARTIFACTS/fabs_reports
-    - mv tests/exred/screenshots/*.png $CIRCLE_ARTIFACTS/exred_screenshots
 

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,6 @@ dependencies:
 test:
   override:
     - make exred_docker_browserstack_first_browser_set
-    - make exred_docker_browserstack_second_browser_set
     - make docker_integration_tests
   post:
     - mkdir $CIRCLE_ARTIFACTS/exred_reports

--- a/tests/exred/environment.py
+++ b/tests/exred/environment.py
@@ -69,7 +69,7 @@ def before_scenario(context: Context, scenario: Scenario):
         }
         # start the browser
         context.driver = drivers[browser_name.lower()]()
-    context.driver.set_page_load_timeout(time_to_wait=30)
+    context.driver.set_page_load_timeout(time_to_wait=20)
     try:
         context.driver.maximize_window()
         logging.debug("Maximized the window.")

--- a/tests/exred/features/articles.feature
+++ b/tests/exred/features/articles.feature
@@ -41,17 +41,22 @@ Feature: Articles
       | Regular    |
 
 
-  @wip
   @ED-2605
-  Scenario: Any Exporter should see his progress through the articles list
-    Given "Robert" is on the Article List page
+  @progress
+  Scenario Outline: Any Exporter should see his progress through the articles list
+    Given "Robert" is on the "<group>" Article List for randomly selected category
 
-    When "Robert" views any article on the list
+    When "Robert" opens any article on the list
     And "Robert" goes back to the Article List page
 
-    Then "Robert" should see this article as read (ticked)
-    And Chapters read counter should increase by 1
-    And Time to complete remaining chapters should decrease
+    Then "Robert" should see this article as read
+    And "Robert" should see that Article Read Counter increased by "1"
+    And "Robert" should see that Time to Complete remaining chapters decreased
+
+    Examples: article groups
+      | group            |
+      | Export Readiness |
+      | Guidance         |
 
 
   @ED-2616

--- a/tests/exred/pages/article_common.py
+++ b/tests/exred/pages/article_common.py
@@ -100,7 +100,9 @@ def check_elements_are_visible(driver: webdriver, elements: list):
 
 
 def show_all_articles(driver: webdriver):
-    show_more_button = driver.find_element_by_css_selector(SHOW_MORE_BUTTON)
+    with selenium_action(
+            driver, "Can't find 'Show more' button @'%s'", driver.current_url):
+        show_more_button = driver.find_element_by_css_selector(SHOW_MORE_BUTTON)
     max_clicks = 10
     counter = 0
     # click up to 11 times - see bug ED-2561

--- a/tests/exred/pages/article_common.py
+++ b/tests/exred/pages/article_common.py
@@ -19,6 +19,7 @@ ARTICLES_TO_READ_COUNTER = "#top dd.position > span.from"
 TIME_TO_COMPLETE = "#top dd.time span.value"
 NEXT_ARTICLE_LINK = "#next-article-link"
 SHARE_MENU = "ul.sharing-links"
+SHOW_MORE_BUTTON = "#js-paginate-list-more"
 
 SCOPE_ELEMENTS = {
     "total number of articles": TOTAL_NUMBER_OF_ARTICLES,
@@ -96,6 +97,22 @@ def check_elements_are_visible(driver: webdriver, elements: list):
                 action_chains.perform()
         with assertion_msg("Expected to see '%s' but can't see it", element):
             assert page_element.is_displayed()
+
+
+def show_all_articles(driver: webdriver):
+    show_more_button = driver.find_element_by_css_selector(SHOW_MORE_BUTTON)
+    max_clicks = 10
+    counter = 0
+    # click up to 11 times - see bug ED-2561
+    while show_more_button.is_displayed() and counter <= max_clicks:
+        show_more_button.click()
+        counter += 1
+    if counter > max_clicks:
+        with assertion_msg(
+                "'Show more' button didn't disappear after clicking on it for"
+                " %d times", counter):
+            assert counter == max_clicks
+    take_screenshot(driver, NAME + " after showing all articles")
 
 
 def go_to_article(driver: webdriver, title: str):

--- a/tests/exred/pages/article_common.py
+++ b/tests/exred/pages/article_common.py
@@ -14,9 +14,9 @@ URL = None
 
 
 ARTICLE_NAME = "#top > h1"
-TOTAL_NUMBER_OF_ARTICLES = "#top dd.position > span.to"
-ARTICLES_TO_READ_COUNTER = "#top dd.position > span.from"
-TIME_TO_COMPLETE = "#top dd.time span.value"
+TOTAL_NUMBER_OF_ARTICLES = "dd.position > span.to"
+ARTICLES_TO_READ_COUNTER = "dd.position > span.from"
+TIME_TO_COMPLETE = "dd.time span.value"
 NEXT_ARTICLE_LINK = "#next-article-link"
 SHARE_MENU = "ul.sharing-links"
 SHOW_MORE_BUTTON = "#js-paginate-list-more"

--- a/tests/exred/pages/article_common.py
+++ b/tests/exred/pages/article_common.py
@@ -174,3 +174,26 @@ def go_back_to_article_list(driver: webdriver):
     with assertion_msg("Go back link is not visible"):
         go_back_link.is_displayed()
     go_back_link.click()
+
+
+def should_see_article_as_read(driver: webdriver, title: str):
+    with selenium_action(driver, "Could not find article: %s", title):
+        article = driver.find_element_by_link_text(title)
+    with assertion_msg(
+            "It looks like '%s' article is marked as unread", title):
+        assert "article-read" in article.get_attribute("class")
+
+
+def get_read_counter(driver: webdriver) -> int:
+    counter = driver.find_element_by_css_selector(ARTICLES_TO_READ_COUNTER)
+    with assertion_msg("Article Read Counter is not visible"):
+        assert counter.is_displayed()
+    return int(counter.text)
+
+
+def get_time_to_complete(driver: webdriver) -> int:
+    ttc = driver.find_element_by_css_selector(TIME_TO_COMPLETE)
+    with assertion_msg("Time To Complete Reading Articles is not visible"):
+        assert ttc.is_displayed()
+    ttc_value = [int(word) for word in ttc.text.split() if word.isdigit()][0]
+    return ttc_value

--- a/tests/exred/pages/article_common.py
+++ b/tests/exred/pages/article_common.py
@@ -185,7 +185,13 @@ def should_see_article_as_read(driver: webdriver, title: str):
 
 
 def get_read_counter(driver: webdriver) -> int:
-    counter = driver.find_element_by_css_selector(ARTICLES_TO_READ_COUNTER)
+    with selenium_action(driver, "Could not find Article Read Counter"):
+        counter = driver.find_element_by_css_selector(ARTICLES_TO_READ_COUNTER)
+        if "firefox" not in driver.capabilities["browserName"].lower():
+            logging.debug("Moving focus to Article Read Counter")
+            action_chains = ActionChains(driver)
+            action_chains.move_to_element(counter)
+            action_chains.perform()
     with assertion_msg("Article Read Counter is not visible"):
         assert counter.is_displayed()
     return int(counter.text)

--- a/tests/exred/pages/article_common.py
+++ b/tests/exred/pages/article_common.py
@@ -20,6 +20,7 @@ TIME_TO_COMPLETE = "dd.time span.value"
 NEXT_ARTICLE_LINK = "#next-article-link"
 SHARE_MENU = "ul.sharing-links"
 SHOW_MORE_BUTTON = "#js-paginate-list-more"
+GO_BACK_LINK = "#category-link"
 
 SCOPE_ELEMENTS = {
     "total number of articles": TOTAL_NUMBER_OF_ARTICLES,
@@ -164,3 +165,12 @@ def should_not_see_link_to_next_article(driver: webdriver):
 def should_not_see_personas_end_page(driver: webdriver):
     """Check if Actor is stil on an Article page."""
     check_elements_are_visible(driver, ["article name"])
+
+
+def go_back_to_article_list(driver: webdriver):
+    with selenium_action(
+            driver, "Could not find Go back link on '%s'", driver.current_url):
+        go_back_link = driver.find_element_by_css_selector(GO_BACK_LINK)
+    with assertion_msg("Go back link is not visible"):
+        go_back_link.is_displayed()
+    go_back_link.click()

--- a/tests/exred/pages/export_readiness_common.py
+++ b/tests/exred/pages/export_readiness_common.py
@@ -12,9 +12,9 @@ NAME = "ExRed Common Export Readiness"
 URL = None
 
 
-TOTAL_NUMBER_OF_ARTICLES = "#articles div.scope-indicator dd.position > span.to"
-ARTICLES_TO_READ_COUNTER = "#articles div.scope-indicator dd.position > span.from"
-TIME_TO_COMPLETE = "#articles div.scope-indicator dd.time > span.value"
+TOTAL_NUMBER_OF_ARTICLES = "dd.position > span.to"
+ARTICLES_TO_READ_COUNTER = "dd.position > span.from"
+TIME_TO_COMPLETE = "dd.time > span.value"
 SHOW_MORE_BUTTON = "#js-paginate-list-more"
 ARTICLES_LIST = "#js-paginate-list > li"
 

--- a/tests/exred/pages/footer.py
+++ b/tests/exred/pages/footer.py
@@ -12,6 +12,9 @@ URL = None
 SECTIONS = {
     "export readiness": {
         "label": "#footer-links-2",
+        "new": "#footer-links-2  ~ ul > li:nth-child(1) > a",
+        "occasional": "#footer-links-2  ~ ul > li:nth-child(2) > a",
+        "regular": "#footer-links-2  ~ ul > li:nth-child(3) > a",
         "i'm new to exporting": "#footer-links-2  ~ ul > li:nth-child(1) > a",
         "i export occasionally": "#footer-links-2  ~ ul > li:nth-child(2) > a",
         "i'm a regular exporter": "#footer-links-2  ~ ul > li:nth-child(3) > a"

--- a/tests/exred/pages/guidance_common.py
+++ b/tests/exred/pages/guidance_common.py
@@ -21,9 +21,9 @@ RIBBON = {
     "getting paid": ".navigation-ribbon a[href='/getting-paid']",
     "operations and compliance": ".navigation-ribbon a[href='/operations-and-compliance']"
 }
-TOTAL_NUMBER_OF_ARTICLES = "#articles div.scope-indicator dd.position > span.to"
-ARTICLES_TO_READ_COUNTER = "#articles div.scope-indicator dd.position > span.from"
-TIME_TO_COMPLETE = "#articles div.scope-indicator dd.time > span.value"
+TOTAL_NUMBER_OF_ARTICLES = "dd.position > span.to"
+ARTICLES_TO_READ_COUNTER = "dd.position > span.from"
+TIME_TO_COMPLETE = "dd.time > span.value"
 SHOW_MORE_BUTTON = "#js-paginate-list-more"
 ARTICLES_LIST = "#js-paginate-list > li"
 NEXT_CATEGORY_LINK = ""

--- a/tests/exred/pages/header.py
+++ b/tests/exred/pages/header.py
@@ -18,6 +18,9 @@ HOME_LINK = "#menu > ul > li:nth-child(1) > a"
 SECTIONS = {
     "export readiness": {
         "menu": "#nav-export-readiness",
+        "new": "#nav-export-readiness-list a[href='/new']",
+        'occasional': "#nav-export-readiness-list a[href='/occasional']",
+        "regular": "#nav-export-readiness-list a[href='/regular']",
         "i'm new to exporting": "#nav-export-readiness-list a[href='/new']",
         'i export occasionally': "#nav-export-readiness-list a[href='/occasional']",
         "i'm a regular exporter": "#nav-export-readiness-list a[href='/regular']"

--- a/tests/exred/pages/home.py
+++ b/tests/exred/pages/home.py
@@ -3,6 +3,7 @@
 import logging
 from urllib.parse import urljoin
 
+from retrying import retry
 from selenium import webdriver
 
 from settings import EXRED_UI_URL

--- a/tests/exred/pages/home.py
+++ b/tests/exred/pages/home.py
@@ -49,6 +49,9 @@ SECTIONS = {
         "new": NEW_TO_EXPORTING_LINK,
         "occasional": OCCASIONAL_EXPORTER_LINK,
         "regular": REGULAR_EXPORTED_LINK,
+        "i'm new to exporting": NEW_TO_EXPORTING_LINK,
+        "i export occasionally": OCCASIONAL_EXPORTER_LINK,
+        "i'm a regular exporter": REGULAR_EXPORTED_LINK,
     },
     "guidance": {
         "itself": "#resource-guidance",

--- a/tests/exred/steps/given_def.py
+++ b/tests/exred/steps/given_def.py
@@ -7,6 +7,7 @@ from steps.when_impl import (
     actor_classifies_himself_as,
     articles_open_any_but_the_last,
     articles_open_first,
+    articles_open_group,
     export_readiness_open_category,
     guidance_open_category,
     set_online_marketplace_preference,
@@ -100,3 +101,8 @@ def given_actor_goes_to_export_readiness_articles(
 @given('"{actor_alias}" opened any Article but the last one')
 def given_actor_opens_any_article_but_the_last_one(context, actor_alias):
     articles_open_any_but_the_last(context, actor_alias)
+
+
+@given('"{actor_alias}" is on the "{group}" Article List for randomly selected category')
+def given_actor_is_on_article_list(context, actor_alias, group):
+    articles_open_group(context, actor_alias, group)

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -5,8 +5,11 @@ from behave import then
 from steps.then_impl import (
     articles_should_not_see_link_to_next_article,
     articles_should_not_see_personas_end_page,
+    articles_should_see_article_as_read,
     articles_should_see_in_correct_order,
     articles_should_see_link_to_first_article_from_next_category,
+    articles_should_see_read_counter_increase,
+    articles_should_see_time_to_complete_decrease,
     export_readiness_expected_page_elements_should_be_visible,
     export_readiness_should_see_articles,
     guidance_check_if_link_to_next_category_is_displayed,
@@ -145,3 +148,19 @@ def then_actor_should_see_link_to_next_category(
         context, actor_alias, next_category):
     articles_should_see_link_to_first_article_from_next_category(
         context, actor_alias, next_category)
+
+
+@then('"{actor_alias}" should see this article as read')
+def then_actor_should_see_article_as_read(context, actor_alias):
+    articles_should_see_article_as_read(context, actor_alias)
+
+
+@then('"{actor_alias}" should see that Article Read Counter increased by "{increase:d}"')
+def then_actor_should_see_read_counter_increase(
+        context, actor_alias, increase: int):
+    articles_should_see_read_counter_increase(context, actor_alias, increase)
+
+
+@then('"{actor_alias}" should see that Time to Complete remaining chapters decreased')
+def then_actor_should_see_time_to_complete_decrease(context, actor_alias):
+    articles_should_see_time_to_complete_decrease(context, actor_alias)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -191,6 +191,8 @@ def articles_should_see_in_correct_order(context: Context, actor_alias: str):
 def articles_should_not_see_link_to_next_article(
         context: Context, actor_alias: str):
     article_common.should_not_see_link_to_next_article(context.driver)
+    logging.debug(
+        "As expected %s didn't see link to the next article", actor_alias)
 
 
 def articles_should_not_see_personas_end_page(
@@ -209,3 +211,41 @@ def articles_should_see_link_to_first_article_from_next_category(
     logging.debug(
         "%s can see link to the first article '%s' from '%s' category",
         actor_alias, first_article.title, next_category)
+    logging.debug("%s wasn't presented with Personas end page", actor_alias)
+
+
+def articles_should_see_article_as_read(context: Context, actor_alias: str):
+    actor = get_actor(context, actor_alias)
+    _, visited_article = actor.visited_articles[0]
+    article_common.show_all_articles(context.driver)
+    article_common.should_see_article_as_read(context.driver, visited_article)
+    logging.debug(
+        "%s can see that '%s' articles is marked as read", actor_alias,
+        visited_article)
+
+
+def articles_should_see_read_counter_increase(
+        context: Context, actor_alias: str, increase: int):
+    actor = get_actor(context, actor_alias)
+    previous_read_counter = actor.articles_read_counter
+    current_read_counter = article_common.get_read_counter(context.driver)
+    difference = current_read_counter - previous_read_counter
+    with assertion_msg(
+            "Expected the Read Counter to increase by '%s', but it increased"
+            " by '%s'", increase, difference):
+        assert difference == increase
+
+
+def articles_should_see_time_to_complete_decrease(
+        context: Context, actor_alias: str):
+    actor = get_actor(context, actor_alias)
+    previous_time_to_complete = actor.articles_time_to_complete
+    current_time_to_complete = article_common.get_time_to_complete(context.driver)
+    difference = current_time_to_complete - previous_time_to_complete
+    logging.debug(
+        "Time to Complete remaining Articles changed by %d mins", difference)
+    with assertion_msg(
+            "Expected the Time to Complete reading remaining articles to "
+            "decrease, not to increase or stay the same. Time difference: %d",
+            difference):
+        assert difference < 0

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -4,6 +4,7 @@ from behave import when
 
 from steps.then_impl import triage_should_be_classified_as
 from steps.when_impl import (
+    articles_open_any,
     articles_open_any_but_the_last,
     export_readiness_open_category,
     guidance_open_category,
@@ -121,3 +122,8 @@ def when_actor_opens_any_article_but_the_last_one(context, actor_alias):
 @when('"{actor_alias}" decides to read through all remaining Articles from selected list')
 def when_actor_reads_through_all_remaining_articles(context, actor_alias):
     guidance_read_through_all_articles(context, actor_alias)
+
+
+@when('"{actor_alias}" opens any article on the list')
+def given_actor_opens_any_article(context, actor_alias):
+    articles_open_any(context, actor_alias)

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -4,6 +4,7 @@ from behave import when
 
 from steps.then_impl import triage_should_be_classified_as
 from steps.when_impl import (
+    articles_go_back_to_article_list,
     articles_open_any,
     articles_open_any_but_the_last,
     export_readiness_open_category,
@@ -127,3 +128,8 @@ def when_actor_reads_through_all_remaining_articles(context, actor_alias):
 @when('"{actor_alias}" opens any article on the list')
 def given_actor_opens_any_article(context, actor_alias):
     articles_open_any(context, actor_alias)
+
+
+@when('"{actor_alias}" goes back to the Article List page')
+def when_actor_goes_back_to_article_list(context, actor_alias):
+    articles_go_back_to_article_list(context, actor_alias)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -78,6 +78,8 @@ def guidance_open_category(
         context: Context, actor_alias: str, category: str, location: str):
     if not get_actor(context, actor_alias):
         add_actor(context, unauthenticated_actor(actor_alias))
+    if location.lower() != "personalised journey":
+        home.visit(driver=context.driver)
     logging.debug(
         "%s is about to open Guidance '%s' category from %s",
         actor_alias, category, location)
@@ -484,7 +486,8 @@ def export_readiness_open_category(
         context: Context, actor_alias: str, category: str, location: str):
     if not get_actor(context, actor_alias):
         add_actor(context, unauthenticated_actor(actor_alias))
-    home.visit(driver=context.driver)
+    if location.lower() != "personalised journey":
+        home.visit(driver=context.driver)
     logging.debug(
         "%s is about to open Export Readiness '%s' category from %s",
         actor_alias, category, location)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -60,6 +60,7 @@ def actor_classifies_himself_as(
     add_actor(context, actor)
 
 
+@retry(wait_fixed=10000, stop_max_attempt_number=3)
 def open_group_element(
         context: Context, group: str, element: str, location: str):
     driver = context.driver
@@ -87,6 +88,7 @@ def guidance_open_category(
         article_category=category, article_location=location)
 
 
+@retry(wait_fixed=10000, stop_max_attempt_number=3)
 def start_triage(context: Context, actor_alias: str):
     home.start_exporting_journey(context.driver)
     logging.debug("%s started triage process", actor_alias)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -582,6 +582,8 @@ def articles_open_any(context: Context, actor_alias: str):
     logging.debug(
         "%s is on '%s' article page: %s", actor_alias,
         any_article .title, driver.current_url)
+    visited_articles = [(any_article.index, any_article.title)]
+    update_actor(context, actor_alias, visited_articles=visited_articles)
 
 
 def guidance_read_through_all_articles(context: Context, actor_alias: str):
@@ -656,3 +658,8 @@ def articles_open_group(context: Context, actor_alias: str, group: str):
         raise KeyError(
             "Did not recognize '{}'. Please use: 'Guidance' or 'Export "
             "Readiness'".format(group))
+    articles_read_counter = article_common.get_read_counter(context.driver)
+    time_to_complete = article_common.get_time_to_complete(context.driver)
+    update_actor(
+        context, actor_alias, articles_read_counter=articles_read_counter,
+        articles_time_to_complete=time_to_complete)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -663,3 +663,8 @@ def articles_open_group(context: Context, actor_alias: str, group: str):
     update_actor(
         context, actor_alias, articles_read_counter=articles_read_counter,
         articles_time_to_complete=time_to_complete)
+
+
+def articles_go_back_to_article_list(context: Context, actor_alias: str):
+    article_common.go_back_to_article_list(context.driver)
+    logging.debug("%s went back to the Article List page", actor_alias)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -33,7 +33,7 @@ from utils import (
 )
 
 
-@retry(wait_fixed=31000, stop_max_attempt_number=3)
+@retry(wait_fixed=15000, stop_max_attempt_number=3)
 def visit_page(
         context: Context, actor_alias: str, page_name: str, *,
         first_time: bool = False):

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -570,6 +570,20 @@ def articles_open_any_but_the_last(context: Context, actor_alias: str):
         any_article_but_the_last.title, driver.current_url)
 
 
+def articles_open_any(context: Context, actor_alias: str):
+    driver = context.driver
+    actor = get_actor(context, actor_alias)
+    group = actor.article_group
+    category = actor.article_category
+    articles = get_articles(group, category)
+    any_article = random.choice(articles)
+    article_common.show_all_articles(driver)
+    article_common.go_to_article(driver, any_article .title)
+    logging.debug(
+        "%s is on '%s' article page: %s", actor_alias,
+        any_article .title, driver.current_url)
+
+
 def guidance_read_through_all_articles(context: Context, actor_alias: str):
     driver = context.driver
     actor = get_actor(context, actor_alias)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -618,3 +618,41 @@ def guidance_read_through_all_articles(context: Context, actor_alias: str):
             logging.debug("There's no more articles to see")
 
     update_actor(context, actor_alias, visited_articles=visited_articles)
+
+
+def articles_open_group(context: Context, actor_alias: str, group: str):
+    categories = {
+        "guidance": [
+            "market research",
+            "customer insight",
+            "finance",
+            "business planning",
+            "getting paid",
+            "operations and compliance"
+        ],
+        "export readiness": [
+            "new",
+            "occasional",
+            "regular"
+        ]
+    }
+    category = random.choice(categories[group.lower()])
+    location = random.choice(["header menu", "footer links", "home page"])
+
+    if not get_actor(context, actor_alias):
+        add_actor(context, unauthenticated_actor(actor_alias))
+    update_actor(
+        context, actor_alias, article_group=group, article_category=category)
+
+    logging.debug(
+        "%s decided to open '%s' '%s' Articles via '%s'", actor_alias,
+        category, group, location)
+    if group.lower() == "export readiness":
+        export_readiness_open_category(
+            context, actor_alias, category=category, location=location)
+    elif group.lower() == "guidance":
+        guidance_open_category(context, actor_alias, category, location)
+    else:
+        raise KeyError(
+            "Did not recognize '{}'. Please use: 'Guidance' or 'Export "
+            "Readiness'".format(group))

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -77,7 +77,6 @@ def guidance_open_category(
         context: Context, actor_alias: str, category: str, location: str):
     if not get_actor(context, actor_alias):
         add_actor(context, unauthenticated_actor(actor_alias))
-    home.visit(driver=context.driver)
     logging.debug(
         "%s is about to open Guidance '%s' category from %s",
         actor_alias, category, location)

--- a/tests/exred/utils/__init__.py
+++ b/tests/exred/utils/__init__.py
@@ -42,7 +42,8 @@ Actor = namedtuple(
         "are_you_incorporated", "company_name",
         "do_you_use_online_marketplaces", "created_personalised_journey",
         "article_group", "article_category", "article_location",
-        "visited_articles"
+        "visited_articles", "articles_read_counter",
+        "articles_time_to_complete"
     ]
 )
 

--- a/tests/exred/utils/__init__.py
+++ b/tests/exred/utils/__init__.py
@@ -15,6 +15,7 @@ from os.path import abspath, join
 
 import requests
 from behave.runner import Context
+from retrying import retry
 from selenium import webdriver
 from selenium.common.exceptions import (
     WebDriverException,
@@ -121,6 +122,7 @@ def update_actor(context: Context, alias: str, **kwargs):
         "Successfully updated %s's details: %s", alias, actors[alias])
 
 
+@retry(stop_max_attempt_number=3)
 def take_screenshot(driver: webdriver, page_name: str):
     """Will take a screenshot of current page.
 

--- a/tests/functional/pages/sso_ui_login.py
+++ b/tests/functional/pages/sso_ui_login.py
@@ -11,7 +11,7 @@ from tests.functional.utils.request import Method, check_response, make_request
 URL = get_absolute_url("sso:login")
 EXPECTED_STRINGS = [
     "Sign in", "If you have not created an account yet, then please",
-    "register", "first.", "Email:", "Password:", "Remember me:", "Login",
+    "register", "first", "Email", "Password", "Remember me", "Login",
     "Reset your password"
 ]
 


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2605)

Scenario:
```gherkin
  @ED-2605
  @progress
  Scenario Outline: Any Exporter should see his progress through the articles list
    Given "Robert" is on the "<group>" Article List for randomly selected category

    When "Robert" opens any article on the list
    And "Robert" goes back to the Article List page

    Then "Robert" should see this article as read
    And "Robert" should see that Article Read Counter increased by "1"
    And "Robert" should see that Time to Complete remaining chapters decreased

    Examples: article groups
      | group            |
      | Export Readiness |
      | Guidance         |
```
