### PR TITLE
ED-2770 & ED-2770 sign in to save progress

### DIFF
--- a/requirements_exred.ini
+++ b/requirements_exred.ini
@@ -4,5 +4,5 @@ paver==1.2.4
 psycopg2==2.7.3.1
 retrying==1.3.3
 requests==2.18.4
-selenium==3.7.0
+selenium==3.8.0
 termcolor==1.1.0

--- a/requirements_exred.txt
+++ b/requirements_exred.txt
@@ -17,7 +17,7 @@ psycopg2==2.7.3.1
 pytz==2017.2              # via django
 requests==2.18.4
 retrying==1.3.3
-selenium==3.7.0
+selenium==3.8.0
 six==1.11.0               # via parse-type, retrying
 termcolor==1.1.0
 urllib3==1.22             # via requests

--- a/tests/exred/features/accessing-services.feature
+++ b/tests/exred/features/accessing-services.feature
@@ -5,7 +5,7 @@ Feature: Accessing Services
   @ED-2659
   @home-page
   @accessing-services
-  Scenario Outline: Any Exporter visiting the home page should be able to see links to Services
+  Scenario Outline: Any Exporter visiting the home page should be able to see links to selected Services in/on "<link_location>"
     Given "Robert" visits the "Home" page
 
     Then "Robert" should see links to following Services "<services>" in "<link_location>"
@@ -22,7 +22,7 @@ Feature: Accessing Services
   @accessing-services
   @interim-pages
   @<service>
-  Scenario Outline: Any Exporter should be presented with interim pages leading to "<service>" Service page
+  Scenario Outline: Any Exporter should be presented with interim pages leading to "<service>" Service page when accessed via "<link_location>"
     Given "Robert" visits the "Home" page
 
     When "Robert" goes to "<service>" using "Services" links in "<link_location>"
@@ -43,7 +43,7 @@ Feature: Accessing Services
   @accessing-services
   @interim-pages
   @<service>
-  Scenario Outline: Any Exporter should be presented with interim pages leading to "<service>" Service page
+  Scenario Outline: Any Exporter should be presented with an interim page leading to "<service>" Service page which was accessed via "<link_location>"
     Given "Robert" visits the "Home" page
 
     When "Robert" goes to "<service>" using "Services" links in "<link_location>"
@@ -65,7 +65,7 @@ Feature: Accessing Services
   @accessing-services
   @interim-pages
   @<service_name>
-  Scenario Outline: Any Exporter should be able to get to the "<service>" Service page via interim page
+  Scenario Outline: Any Exporter should be able to get to the "<service>" Service page via interim page which was accessed via "<link_location>"
     Given "Robert" visits the "Home" page
 
     When "Robert" goes to "<service>" using "Services" links in "<link_location>"

--- a/tests/exred/features/accessing-services.feature
+++ b/tests/exred/features/accessing-services.feature
@@ -22,6 +22,7 @@ Feature: Accessing Services
   @accessing-services
   @interim-pages
   @<service>
+  @external-service
   Scenario Outline: Any Exporter should be presented with interim pages leading to "<service>" Service page when accessed via "<link_location>"
     Given "Robert" visits the "Home" page
 
@@ -65,6 +66,7 @@ Feature: Accessing Services
   @accessing-services
   @interim-pages
   @<service_name>
+  @external-service
   Scenario Outline: Any Exporter should be able to get to the "<service>" Service page via interim page which was accessed via "<link_location>"
     Given "Robert" visits the "Home" page
 
@@ -87,6 +89,7 @@ Feature: Accessing Services
   @home-page
   @accessing-services
   @<service_name>
+  @external-service
   Scenario Outline: Any Exporter should be able to get to the "<service>" Service page using "<link_location>"
     Given "Robert" visits the "Home" page
 

--- a/tests/exred/features/articles.feature
+++ b/tests/exred/features/articles.feature
@@ -6,7 +6,7 @@ Feature: Articles
   @guidance
   @articles
   @<category>
-  Scenario Outline: Any Exporter accessing Articles through the Guidance Article List should be able to navigate to the next article
+  Scenario Outline: Any Exporter accessing "<category>" Articles through the Guidance Article List should be able to navigate to the next article
     Given "Robert" accessed "<category>" guidance articles using "home page"
     And "Robert" opened first Article from the list
 
@@ -46,7 +46,7 @@ Feature: Articles
   @ED-2605
   @progress
   @<group>
-  Scenario Outline: Any Exporter should see his progress through the articles list
+  Scenario Outline: Any Exporter should see his reading progress through the "<group>" articles list
     Given "Robert" is on the "<group>" Article List for randomly selected category
 
     When "Robert" opens any article on the list
@@ -236,7 +236,7 @@ Feature: Articles
   @ED-2639
   @feedback
   @<relevant>
-  Scenario Outline: "<relevant>" Exporters should be able to tell us that they "<found_or_not>" the "<group>" article useful
+  Scenario Outline: "<relevant>" Exporters should be able to tell us that they "<found_or_not>" the article useful
     Given "Robert" was classified as "<relevant>" exporter in the triage process
     And "Robert" decided to create her personalised journey page
     And "Robert" went to randomly selected Guidance Articles category
@@ -258,7 +258,7 @@ Feature: Articles
   @counters
   @<group>
   @<location>
-  Scenario Outline: Article Indicators should be updated accordingly after opening "<group>" Article
+  Scenario Outline: Article Indicators should be updated accordingly after opening "<group>" Article via "<location>"
     Given "Robert" went to randomly selected "<group>" Article category via "<location>"
 
     When "Robert" opens any article on the list
@@ -326,7 +326,7 @@ Feature: Articles
   @real-sso-email-verification
   @<group>
   @<location>
-  Scenario Outline: Any Exporter should be able to register from the "<group>" Articles list page in order to save their progress
+  Scenario Outline: Any Exporter should be able to register via link in "<element>" present on the "<group>" Article list page, in order to save their progress
     Given "Robert" went to randomly selected "<group>" Article category via "<location>"
     And "Robert" read "<number>" of articles
     And "Robert" is on the "Article list" page
@@ -360,7 +360,7 @@ Feature: Articles
   @session
   @register
   @real-sso-email-verification
-  Scenario Outline: An Exporter should be able to register from the Article page in order to save their progress
+  Scenario Outline: An Exporter should be able to register via link in "<element>" present on the "<group>" Article page in order to save their progress
     Given "Robert" went to randomly selected "<group>" Article category via "<location>"
     And "Robert" read "<a number>" of articles and stays on the last read article page
     And "Robert" is on the "Article" page

--- a/tests/exred/features/articles.feature
+++ b/tests/exred/features/articles.feature
@@ -387,30 +387,58 @@ Feature: Articles
       | Guidance         | footer links | a third   | top bar |
 
 
-  @wip
+  @bug
+  @ED-2807
+  @fixme
   @ED-2770
   @session
-  Scenario: An Exporter should be able to sing in from the Articles list page in order to save their progress
-    Given "Robert" read some of the articles
+  Scenario Outline: An Exporter should be able to sing in from the Articles list page using "<element>" Sign-in link in order to save their reading progress for "<group>" articles
+    Given "Robert" is a registered and verified user
+    And "Robert" went to the "Home" page
+    And "Robert" went to randomly selected "<group>" Article category via "<location>"
+    And "Robert" read "<a number>" of articles
     And "Robert" is on the "Article list" page
 
-    When "Robert" decides to "sign in"
-    And "Robert" signs in
+    When "Robert" signs in using link visible in the "<element>"
 
-    Then "Robert"'s current progress should be saved
+    Then "Robert" should be on the "Article List" page
+    And "Robert" should see his reading progress same as before signing in
+
+    Examples:
+      | group            | location     | a number  | element      |
+      | Export Readiness | header menu  | a sixth   | article list |
+      | Export Readiness | home page    | a quarter | top bar      |
+      | Export Readiness | footer links | a third   | article list |
+      | Guidance         | header menu  | a fifth   | top bar      |
+      | Guidance         | home page    | a quarter | article list |
+      | Guidance         | footer links | a third   | top bar      |
 
 
-  @wip
+  @bug
+  @ED-2807
+  @fixme
   @ED-2771
   @session
-  Scenario: An Exporter should be able to sign in from the specific Article page in order to save their progress
-    Given "Robert" read some of the articles
+  Scenario Outline: An Exporter should be able to sing in from the Article page using "<element>" Sign-in link in order to save their reading progress for "<group>" articles
+    Given "Robert" is a registered and verified user
+    And "Robert" went to the "Home" page
+    And "Robert" went to randomly selected "<group>" Article category via "<location>"
+    And "Robert" read "<a number>" of articles and stays on the last read article page
     And "Robert" is on the "Article" page
 
-    When "Robert" decides to "sign in"
-    And "Robert" signs in
+    When "Robert" signs in using link visible in the "<element>"
 
-    Then "Robert"'s current progress should be saved
+    Then "Robert" should be on the "Article" page
+    And "Robert" should see his reading progress same as before signing in
+
+    Examples:
+      | group            | location     | a number  | element |
+      | Export Readiness | header menu  | a sixth   | article |
+      | Export Readiness | home page    | a quarter | top bar |
+      | Export Readiness | footer links | a third   | article |
+      | Guidance         | header menu  | a fifth   | top bar |
+      | Guidance         | home page    | a quarter | article |
+      | Guidance         | footer links | a third   | top bar |
 
 
   @wip

--- a/tests/exred/features/guidance.feature
+++ b/tests/exred/features/guidance.feature
@@ -69,7 +69,7 @@ Feature: Guidance articles
   @articles
   @regular
   @optimize
-  Scenario Outline: Regular Exporter should see article read count for each tile in the Guidance section on the personalised page
+  Scenario Outline: Regular Exporter should see article read count for each tile in the "<specific>" Guidance section on the personalised page
     Given "Nadia" was classified as "regular" exporter in the triage process
     And "Nadia" decided to create her personalised journey page
 

--- a/tests/exred/features/personalised-page.feature
+++ b/tests/exred/features/personalised-page.feature
@@ -5,7 +5,7 @@ Feature: Customised page
   @ED-2588
   @personalised-page
   @regular
-  Scenario Outline: Regular Exporter should see "<expected>" sections on personalised page
+  Scenario Outline: Regular Exporter which exports "<goods_or_services>" and "<has_or_has_not>" incorporated his company should see "<expected>" sections on personalised page
     Given "Nadia" exports "<goods_or_services>"
     And "Nadia" was classified as "Regular" Exporter which "<has_or_has_not>" incorporated the company
 
@@ -25,7 +25,7 @@ Feature: Customised page
   @ED-2589
   @personalised-page
   @occasional
-  Scenario Outline: Occasional Exporter should see "<expected>" sections on personalised page
+  Scenario Outline: Occasional Exporter which exports "<goods_or_services>", "<used_or_not>" online marketplaces and "<has_or_has_not>" incorporated his company should see "<expected>" sections on personalised page
     Given "Inigo" exports "<goods_or_services>"
     And "Inigo" "<used_or_not>" online marketplaces before
     And "Inigo" was classified as "Occasional" Exporter which "<has_or_has_not>" incorporated the company
@@ -46,7 +46,7 @@ Feature: Customised page
   @ED-2590
   @personalised-page
   @new
-  Scenario Outline: New Exporter should see "<expected>" sections on personalised page
+  Scenario Outline: New Exporter which exports "<goods_or_services>" and "<has_or_has_not>" incorporated his company should see "<expected>" sections on personalised page
     Given "Jonah" exports "<goods_or_services>"
     And "Jonah" was classified as "New" Exporter which "<has_or_has_not>" incorporated the company
 

--- a/tests/exred/features/triage.feature
+++ b/tests/exred/features/triage.feature
@@ -47,7 +47,7 @@ Feature: Triage
   @ED-2521
   @first-time
   @occasional
-  Scenario Outline: Occasional Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
+  Scenario Outline: Occasional Exporter which "<online_action>" used online marketplaces and visiting the home page for the 1st time should be able to get to personalised page after going through triage process
     Given "Inigo" visits the "home" page for the first time
     And "Inigo" decided to build his exporting journey
 
@@ -76,7 +76,7 @@ Feature: Triage
   @ED-2521
   @first-time
   @occasional
-  Scenario Outline: Not incorporated Occasional Exporter visiting the home page for the 1st time should be able to get to personalised page after going through triage process
+  Scenario Outline: Not incorporated Occasional Exporter which "<online_action>" used online marketplaces and visiting the home page for the 1st time should be able to get to personalised page after going through triage process
     Given "Inigo" visits the "home" page for the first time
     And "Inigo" decided to build his exporting journey
 

--- a/tests/exred/pages/events.py
+++ b/tests/exred/pages/events.py
@@ -6,14 +6,17 @@ from urllib.parse import urljoin
 from selenium import webdriver
 
 from settings import EVENTS_UI_URL
-from utils import assertion_msg, take_screenshot
+from utils import assertion_msg, take_screenshot, wait_for_visibility
 
 NAME = "Events Home page"
 URL = urljoin(EVENTS_UI_URL, "")
 PAGE_TITLE = "Department for International Trade (DIT): exporting from or investing in the UK"
 
+WELCOME_MESSAGE = "#feature > div.contain.slider > article.tile.initial.visible > div > h2"
+
 
 def should_be_here(driver: webdriver):
+    wait_for_visibility(driver, by_css=WELCOME_MESSAGE, time_to_wait=15)
     with assertion_msg(
             "Expected page title to be: '%s' but got '%s'", PAGE_TITLE,
             driver.title):

--- a/tests/exred/pages/export_opportunities.py
+++ b/tests/exred/pages/export_opportunities.py
@@ -6,14 +6,17 @@ from urllib.parse import urljoin
 from selenium import webdriver
 
 from settings import EXPORT_OPPORTUNITIES_UI_URL
-from utils import assertion_msg, take_screenshot
+from utils import assertion_msg, take_screenshot, wait_for_visibility
 
 NAME = "Export Opportunities Home page"
 URL = urljoin(EXPORT_OPPORTUNITIES_UI_URL, "")
 PAGE_TITLE = "Exporting is GREAT"
 
+WELCOME_MESSAGE = "#content-top > div.hero__specialContainer > h1"
+
 
 def should_be_here(driver: webdriver):
+    wait_for_visibility(driver, by_css=WELCOME_MESSAGE, time_to_wait=15)
     with assertion_msg(
             "Expected page title to be: '%s' but got '%s'", PAGE_TITLE,
             driver.title):

--- a/tests/exred/pages/export_opportunities.py
+++ b/tests/exred/pages/export_opportunities.py
@@ -10,7 +10,7 @@ from utils import assertion_msg, take_screenshot, wait_for_visibility
 
 NAME = "Export Opportunities Home page"
 URL = urljoin(EXPORT_OPPORTUNITIES_UI_URL, "")
-PAGE_TITLE = "Exporting is GREAT"
+PAGE_TITLE = "Export opportunities"
 
 WELCOME_MESSAGE = "#content-top > div.hero__specialContainer > h1"
 

--- a/tests/exred/pages/get_finance.py
+++ b/tests/exred/pages/get_finance.py
@@ -10,10 +10,10 @@ from selenium.common.exceptions import (
 )
 
 from settings import EXRED_UI_URL
-from utils import assertion_msg, find_element, take_screenshot
+from utils import assertion_msg, take_screenshot
 
 NAME = "Get Finance Home page"
-URL = urljoin(EXRED_UI_URL, "finance/get-finance-support-from-government")
+URL = urljoin(EXRED_UI_URL, "get-finance")
 
 TOTAL_NUMBER_OF_ARTICLES = "dd.position > span.to"
 ARTICLES_TO_READ_COUNTER = "dd.position > span.from"

--- a/tests/exred/pages/header.py
+++ b/tests/exred/pages/header.py
@@ -80,15 +80,9 @@ def should_see_link_to(driver: webdriver, section: str, item_name: str):
         logging.debug("Open the menu by sending 'Right Arrow' key")
         menu_selector = SECTIONS[section.lower()]["menu"]
         menu = find_element(driver, by_css=menu_selector)
-        if "firefox" in driver.capabilities["browserName"].lower():
-            logging.debug("Opening '%s' menu under Firefox", section)
-            action_chains = ActionChains(driver)
-            action_chains.move_to_element(menu)
-            action_chains.send_keys(Keys.ENTER)
-            action_chains.perform()
-        else:
-            menu.send_keys(Keys.ENTER)
+        menu.send_keys(Keys.ENTER)
     menu_item = find_element(driver, by_css=item_selector)
+    wait_for_visibility(driver, by_css=item_selector)
     with assertion_msg(
             "It looks like '%s' in '%s' section is not visible", item_name,
             section):

--- a/tests/exred/pages/header.py
+++ b/tests/exred/pages/header.py
@@ -3,6 +3,7 @@
 import logging
 
 from selenium import webdriver
+from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
@@ -83,7 +84,13 @@ def should_see_link_to(driver: webdriver, section: str, item_name: str):
         logging.debug("Open the menu by sending 'Right Arrow' key")
         menu_selector = SECTIONS[section.lower()]["menu"]
         menu = find_element(driver, by_css=menu_selector)
-        menu.send_keys(Keys.RIGHT)
+        if "firefox" not in driver.capabilities["browserName"].lower():
+            logging.debug("Opening '%s' menu under Firefox", section)
+            action_chains = ActionChains(driver)
+            action_chains.move_to_element(menu)
+            action_chains.perform()
+        else:
+            menu.send_keys(Keys.ENTER)
     menu_item = find_element(driver, by_css=item_selector)
     with assertion_msg(
             "It looks like '%s' in '%s' section is not visible", item_name,
@@ -106,7 +113,13 @@ def open(driver: webdriver, group: str, element: str):
         # Open the menu by sending "Down Arrow" key
         menu_selector = SECTIONS[group.lower()]["menu"]
         menu = driver.find_element_by_css_selector(menu_selector)
-        menu.send_keys(Keys.RIGHT)
+        if "firefox" not in driver.capabilities["browserName"].lower():
+            logging.debug("Opening '%s' menu under Firefox", group)
+            action_chains = ActionChains(driver)
+            action_chains.move_to_element(menu)
+            action_chains.perform()
+        else:
+            menu.send_keys(Keys.ENTER)
     menu_item_selector = SECTIONS[group.lower()][element.lower()]
     with selenium_action(
             driver, "Could not find %s element in %s group with '%s' selector",

--- a/tests/exred/pages/header.py
+++ b/tests/exred/pages/header.py
@@ -107,17 +107,10 @@ def open(driver: webdriver, group: str, element: str):
     the focus of the menu and which will make menu to fold.
     """
     if "menu" in SECTIONS[group.lower()]:
-        # Open the menu by sending "Down Arrow" key
+        # Open the menu by sending "Enter" key
         menu_selector = SECTIONS[group.lower()]["menu"]
         menu = driver.find_element_by_css_selector(menu_selector)
-        if "firefox" in driver.capabilities["browserName"].lower():
-            logging.debug("Opening '%s' menu under Firefox", group)
-            action_chains = ActionChains(driver)
-            action_chains.move_to_element(menu)
-            action_chains.send_keys(Keys.ENTER)
-            action_chains.perform()
-        else:
-            menu.send_keys(Keys.ENTER)
+        menu.send_keys(Keys.ENTER)
     menu_item_selector = SECTIONS[group.lower()][element.lower()]
     menu_item = find_element(driver, by_css=menu_item_selector)
     wait_for_visibility(driver, by_css=menu_item_selector)

--- a/tests/exred/pages/header.py
+++ b/tests/exred/pages/header.py
@@ -4,15 +4,11 @@ import logging
 
 from selenium import webdriver
 from selenium.webdriver import ActionChains
-from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.wait import WebDriverWait
 
 from utils import (
     assertion_msg,
     find_element,
-    selenium_action,
     take_screenshot,
     wait_for_visibility
 )

--- a/tests/exred/pages/header.py
+++ b/tests/exred/pages/header.py
@@ -84,7 +84,7 @@ def should_see_link_to(driver: webdriver, section: str, item_name: str):
         logging.debug("Open the menu by sending 'Right Arrow' key")
         menu_selector = SECTIONS[section.lower()]["menu"]
         menu = find_element(driver, by_css=menu_selector)
-        if "firefox" not in driver.capabilities["browserName"].lower():
+        if "firefox" in driver.capabilities["browserName"].lower():
             logging.debug("Opening '%s' menu under Firefox", section)
             action_chains = ActionChains(driver)
             action_chains.move_to_element(menu)
@@ -113,7 +113,7 @@ def open(driver: webdriver, group: str, element: str):
         # Open the menu by sending "Down Arrow" key
         menu_selector = SECTIONS[group.lower()]["menu"]
         menu = driver.find_element_by_css_selector(menu_selector)
-        if "firefox" not in driver.capabilities["browserName"].lower():
+        if "firefox" in driver.capabilities["browserName"].lower():
             logging.debug("Opening '%s' menu under Firefox", group)
             action_chains = ActionChains(driver)
             action_chains.move_to_element(menu)
@@ -121,13 +121,8 @@ def open(driver: webdriver, group: str, element: str):
         else:
             menu.send_keys(Keys.ENTER)
     menu_item_selector = SECTIONS[group.lower()][element.lower()]
-    with selenium_action(
-            driver, "Could not find %s element in %s group with '%s' selector",
-            element, group, menu_item_selector):
-        menu_item = driver.find_element_by_css_selector(menu_item_selector)
-        WebDriverWait(driver, 5).until(
-            EC.visibility_of_element_located((By.CSS_SELECTOR,
-                                              menu_item_selector)))
+    menu_item = find_element(driver, by_css=menu_item_selector)
+    wait_for_visibility(driver, by_css=menu_item_selector)
     with assertion_msg("%s menu item: '%s' is not visible", group, element):
         assert menu_item.is_displayed()
     menu_item.click()

--- a/tests/exred/pages/header.py
+++ b/tests/exred/pages/header.py
@@ -84,6 +84,7 @@ def should_see_link_to(driver: webdriver, section: str, item_name: str):
             logging.debug("Opening '%s' menu under Firefox", section)
             action_chains = ActionChains(driver)
             action_chains.move_to_element(menu)
+            action_chains.send_keys(Keys.ENTER)
             action_chains.perform()
         else:
             menu.send_keys(Keys.ENTER)
@@ -113,6 +114,7 @@ def open(driver: webdriver, group: str, element: str):
             logging.debug("Opening '%s' menu under Firefox", group)
             action_chains = ActionChains(driver)
             action_chains.move_to_element(menu)
+            action_chains.send_keys(Keys.ENTER)
             action_chains.perform()
         else:
             menu.send_keys(Keys.ENTER)

--- a/tests/exred/pages/home.py
+++ b/tests/exred/pages/home.py
@@ -4,7 +4,6 @@ import logging
 import random
 from urllib.parse import urljoin
 
-from retrying import retry
 from selenium import webdriver
 
 from settings import EXRED_UI_URL
@@ -18,7 +17,7 @@ from utils import (
 )
 
 NAME = "ExRed Home"
-URL = urljoin(EXRED_UI_URL, "")
+URL = urljoin(EXRED_UI_URL, "?lang=en-gb")
 
 GET_STARTED_BUTTON = ".triage a.button-cta"
 CONTINUE_EXPORT_JOURNEY = "#continue-export-journey"

--- a/tests/exred/pages/home.py
+++ b/tests/exred/pages/home.py
@@ -20,7 +20,7 @@ NAME = "ExRed Home"
 URL = urljoin(EXRED_UI_URL, "?lang=en-gb")
 
 GET_STARTED_BUTTON = ".triage a.button-cta"
-CONTINUE_EXPORT_JOURNEY = "#continue-export-journey"
+CONTINUE_EXPORT_JOURNEY = ".triage a.button-cta"
 NEW_TO_EXPORTING_LINK = "#personas > .container > .group div:nth-child(1) a"
 OCCASIONAL_EXPORTER_LINK = "#personas > .container > .group div:nth-child(2) a"
 REGULAR_EXPORTED_LINK = "#personas > .container > .group div:nth-child(3) a"

--- a/tests/exred/pages/interim_exporting_opportunities.py
+++ b/tests/exred/pages/interim_exporting_opportunities.py
@@ -6,7 +6,12 @@ from urllib.parse import urljoin
 from selenium import webdriver
 
 from settings import EXRED_UI_URL
-from utils import assertion_msg, find_element, take_screenshot
+from utils import (
+    assertion_msg,
+    find_element,
+    take_screenshot,
+    wait_for_visibility
+)
 
 NAME = "ExRed Interim Export Opportunities"
 URL = urljoin(EXRED_UI_URL, "export-opportunities")
@@ -35,5 +40,6 @@ def should_be_here(driver: webdriver):
 
 def go_to_service(driver: webdriver):
     service_button = find_element(driver, by_css=SERVICE_BUTTON)
+    wait_for_visibility(driver, by_css=SERVICE_BUTTON, time_to_wait=10)
     service_button.click()
     take_screenshot(driver, NAME + " after going to Export Opportunities")

--- a/tests/exred/pages/triage_are_you_registered_with_companies_house.py
+++ b/tests/exred/pages/triage_are_you_registered_with_companies_house.py
@@ -11,10 +11,10 @@ from utils import assertion_msg, take_screenshot
 NAME = "ExRed Triage - are you registered with Companies House"
 URL = urljoin(EXRED_UI_URL, "triage/companies_house")
 
-YES_RADIO = "#id_companies_house-is_in_companies_house_0"
-NO_RADIO = "#id_companies_house-is_in_companies_house_1"
-YES_CHECKBOX = "#id_companies_house-is_in_companies_house_0 ~ label"
-NO_CHECKBOX = "#id_companies_house-is_in_companies_house_1 ~ label"
+YES_RADIO = "#id_companies-house-is_in_companies_house_0"
+NO_RADIO = "#id_companies-house-is_in_companies_house_1"
+YES_CHECKBOX = "#id_companies-house-is_in_companies_house_0 ~ label"
+NO_CHECKBOX = "#id_companies-house-is_in_companies_house_1 ~ label"
 CONTINUE_BUTTON = ".exred-triage-form button.button"
 PREVIOUS_STEP_BUTTON = ".exred-triage-form button.previous-step"
 BACK_TO_HOME_LINK = ".home-link a"

--- a/tests/exred/steps/given_def.py
+++ b/tests/exred/steps/given_def.py
@@ -28,6 +28,7 @@ from steps.when_impl import (
 )
 
 
+@given('"{actor_alias}" went to the "{page_name}" page')
 @given('"{actor_alias}" goes to the "{page_name}" page')
 @given('"{actor_alias}" visits the "{page_name}" page')
 def given_actor_visits_page(context, actor_alias, page_name):

--- a/tests/exred/steps/given_def.py
+++ b/tests/exred/steps/given_def.py
@@ -17,6 +17,7 @@ from steps.when_impl import (
     export_readiness_open_category,
     guidance_open_category,
     guidance_open_random_category,
+    registration_submit_form_and_verify_account,
     set_online_marketplace_preference,
     set_sector_preference,
     start_triage,

--- a/tests/exred/steps/given_def.py
+++ b/tests/exred/steps/given_def.py
@@ -17,6 +17,7 @@ from steps.when_impl import (
     export_readiness_open_category,
     guidance_open_category,
     guidance_open_random_category,
+    registration_create_and_verify_account,
     registration_submit_form_and_verify_account,
     set_online_marketplace_preference,
     set_sector_preference,
@@ -163,3 +164,9 @@ def given_actor_reads_few_articles(context, actor_alias, number):
 @given('"{actor_alias}" read "{number}" of articles')
 def given_actor_reads_few_articles(context, actor_alias, number):
     articles_read_a_number_of_them(context, actor_alias, number)
+
+
+@given('"{actor_alias}" is a registered and verified user')
+def given_actor_is_registered_and_verified(context, actor_alias):
+    registration_create_and_verify_account(
+        context, actor_alias, fake_verification=True)

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -233,6 +233,7 @@ def then_reading_progress_should_be_gone(context, actor_alias):
     articles_should_see_read_counter_set_to(context, actor_alias, 0)
 
 
+@then('"{actor_alias}" should see his reading progress same as before signing in')
 @then('"{actor_alias}" should see his reading progress same as before registration')
 def then_actor_should_see_previous_reading_progress(context, actor_alias):
     articles_read_counter_same_as_before_registration(context, actor_alias)

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -20,8 +20,8 @@ from steps.when_impl import (
     open_service_link_on_interim_page,
     personalised_journey_create_page,
     personalised_journey_update_preference,
-    registration_create_and_verify_account,
     registration_go_to,
+    registration_submit_form_and_verify_account,
     set_sector_preference,
     sign_in,
     start_triage,
@@ -204,13 +204,13 @@ def when_actor_decides_to_register(context, actor_alias, location):
 
 @when('"{actor_alias}" completes the registration and fake email verification process')
 def when_actor_registers(context, actor_alias):
-    registration_create_and_verify_account(
+    registration_submit_form_and_verify_account(
         context, actor_alias, fake_verification=True)
 
 
 @when('"{actor_alias}" completes the registration and real email verification process')
 def when_actor_registers(context, actor_alias):
-    registration_create_and_verify_account(
+    registration_submit_form_and_verify_account(
         context, actor_alias, fake_verification=False)
 
 

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -6,6 +6,7 @@ from steps.then_impl import triage_should_be_classified_as
 from steps.when_impl import (
     articles_found_useful_or_not,
     articles_go_back_to_article_list,
+    articles_go_back_to_last_read_article,
     articles_go_back_to_same_group,
     articles_open_any,
     articles_open_any_but_the_last,
@@ -24,6 +25,7 @@ from steps.when_impl import (
     registration_submit_form_and_verify_account,
     set_sector_preference,
     sign_in,
+    sign_in_go_to,
     start_triage,
     triage_are_you_incorporated,
     triage_change_answers,
@@ -35,8 +37,7 @@ from steps.when_impl import (
     triage_say_whether_you_use_online_marketplaces,
     triage_should_see_answers_to_questions,
     triage_what_is_your_company_name,
-    visit_page,
-    articles_go_back_to_last_read_article
+    visit_page
 )
 
 

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -953,7 +953,7 @@ def registration_open_email_confirmation_link(context, actor_alias):
     logging.debug("Supplier is on the SSO Confirm your email address page")
 
 
-def registration_create_and_verify_account(
+def registration_submit_form_and_verify_account(
         context: Context, actor_alias: str, *, fake_verification: bool = True):
     driver = context.driver
     actor = get_actor(context, actor_alias)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -9,6 +9,7 @@ from selenium.common.exceptions import WebDriverException
 
 from pages import (
     article_common,
+    article_list,
     footer,
     guidance_common,
     header,
@@ -26,19 +27,18 @@ from pages import (
     triage_do_you_use_online_marketplaces,
     triage_have_you_exported,
     triage_summary,
-    triage_what_do_you_want_to_export,
-    article_list
+    triage_what_do_you_want_to_export
 )
 from registry.articles import GUIDANCE, get_article, get_articles
 from registry.pages import get_page_object
 from settings import EXRED_SECTORS
 from utils import (
+    VisitedArticle,
     add_actor,
     assertion_msg,
     get_actor,
     unauthenticated_actor,
-    update_actor,
-    VisitedArticle
+    update_actor
 )
 from utils.mail_gun import get_verification_link
 
@@ -917,7 +917,7 @@ def registration_go_to(context: Context, actor_alias: str, location: str):
     else:
         raise KeyError(
             "Could not recognise registration link location: %s. Please use "
-            "'article' or 'top bar'".format(location))
+            "'article', 'article list' or 'top bar'".format(location))
     sso_registration.should_be_here(context.driver)
 
 
@@ -989,15 +989,19 @@ def clear_the_cookies(context: Context, actor_alias: str):
         logging.error("Failed to clear cookies for %s", actor_alias)
 
 
-def sign_in_go_to(context, actor_alias, location):
+def sign_in_go_to(context: Context, actor_alias: str, location: str):
+    logging.debug(
+        "%s decided to go to sign in page via %s link", actor_alias, location)
     if location.lower() == "article":
         article_common.go_to_sign_in(context.driver)
+    elif location.lower() == "article list":
+        article_list.go_to_sign_in(context.driver)
     elif location.lower() == "top bar":
         header.go_to_sign_in(context.driver)
     else:
         raise KeyError(
-            "Could not recognise registration link location: %s. Please use "
-            "'article' or 'top bar'".format(location))
+            "Could not recognise 'sign in' link location: %s. Please use "
+            "'article', 'article list' or 'top bar'".format(location))
     sso_sign_in.should_be_here(context.driver)
 
 

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -971,6 +971,14 @@ def registration_submit_form_and_verify_account(
     update_actor(context, actor_alias, registered=True)
 
 
+def registration_create_and_verify_account(
+        context: Context, actor_alias: str, *, fake_verification: bool = True):
+    visit_page(context, actor_alias, "Home")
+    registration_go_to(context, actor_alias, "top bar")
+    registration_submit_form_and_verify_account(
+        context, actor_alias, fake_verification=fake_verification)
+
+
 def clear_the_cookies(context: Context, actor_alias: str):
     try:
         cookies = context.driver.get_cookies()


### PR DESCRIPTION
These tickets:
* [ED-2770](https://uktrade.atlassian.net/browse/ED-2770)
* [ED-2771](https://uktrade.atlassian.net/browse/ED-2771)

Scenario:
```gherkin
  @bug
  @ED-2807
  @fixme
  @ED-2770
  @session
  Scenario Outline: An Exporter should be able to sing in from the Articles list page using "<element>" Sign-in link in order to save their reading progress for "<group>" articles
    Given "Robert" is a registered and verified user
    And "Robert" went to the "Home" page
    And "Robert" went to randomly selected "<group>" Article category via "<location>"
    And "Robert" read "<a number>" of articles
    And "Robert" is on the "Article list" page

    When "Robert" signs in using link visible in the "<element>"

    Then "Robert" should be on the "Article List" page
    And "Robert" should see his reading progress same as before signing in

    Examples:
      | group            | location     | a number  | element      |
      | Export Readiness | header menu  | a sixth   | article list |
      | Export Readiness | home page    | a quarter | top bar      |
      | Export Readiness | footer links | a third   | article list |
      | Guidance         | header menu  | a fifth   | top bar      |
      | Guidance         | home page    | a quarter | article list |
      | Guidance         | footer links | a third   | top bar      |


  @bug
  @ED-2807
  @fixme
  @ED-2771
  @session
  Scenario Outline: An Exporter should be able to sing in from the Article page using "<element>" Sign-in link in order to save their reading progress for "<group>" articles
    Given "Robert" is a registered and verified user
    And "Robert" went to the "Home" page
    And "Robert" went to randomly selected "<group>" Article category via "<location>"
    And "Robert" read "<a number>" of articles and stays on the last read article page
    And "Robert" is on the "Article" page

    When "Robert" signs in using link visible in the "<element>"

    Then "Robert" should be on the "Article" page
    And "Robert" should see his reading progress same as before signing in

    Examples:
      | group            | location     | a number  | element |
      | Export Readiness | header menu  | a sixth   | article |
      | Export Readiness | home page    | a quarter | top bar |
      | Export Readiness | footer links | a third   | article |
      | Guidance         | header menu  | a fifth   | top bar |
      | Guidance         | home page    | a quarter | article |
      | Guidance         | footer links | a third   | top bar |
```
