### PR TITLE
ED-2773 merge reading progress

### DIFF
--- a/tests/exred/environment.py
+++ b/tests/exred/environment.py
@@ -3,7 +3,7 @@
 import logging
 
 from behave.contrib.scenario_autoretry import patch_scenario_with_autoretry
-from behave.model import Scenario, Step
+from behave.model import Feature, Scenario, Step
 from behave.runner import Context
 from retrying import retry
 from selenium import webdriver
@@ -80,7 +80,7 @@ def after_step(context: Context, step: Step):
                     flag_browserstack_session_as_failed(session_id, message)
 
 
-def before_feature(context, feature):
+def before_feature(context: Context, feature: Feature):
     """Use autoretry feature of upcoming Behave 1.2.6 which automatically
     retries failing scenarios.
     Here PR for it https://github.com/behave/behave/pull/328
@@ -92,12 +92,12 @@ def before_feature(context, feature):
         start_driver_session(context, feature.name)
 
 
-def after_feature(context: Context, feature):
+def after_feature(context: Context, feature: Feature):
     if RESTART_BROWSER == "feature":
         context.driver.quit()
         if feature.status == "failed":
-            message = ("Feature '%s %s' failed. Reason: '%s'" %
-                       (feature.step_type, feature.name, feature.exception))
+            message = ("Feature '%s' failed. Reason: '%s': '%s'" %
+                       (feature.name, feature.exception, feature.error_message))
             logging.error(message)
             logging.debug(context.scenario_data)
             if "browserstack" in CONFIG_NAME:

--- a/tests/exred/environment.py
+++ b/tests/exred/environment.py
@@ -116,7 +116,8 @@ def before_scenario(context: Context, scenario: Scenario):
     """
     logging.debug('Starting scenario: %s', scenario.name)
     context.scenario_data = initialize_scenario_data()
-    start_driver_session(context, scenario.name)
+    if RESTART_BROWSER == "scenario":
+        start_driver_session(context, scenario.name)
 
 
 def after_scenario(context: Context, scenario: Scenario):

--- a/tests/exred/features/articles.feature
+++ b/tests/exred/features/articles.feature
@@ -335,7 +335,7 @@ Feature: Articles
     And "Robert" completes the registration and real email verification process
     Then "Robert" should see his reading progress same as before registration
 
-    When "Robert" logs out and forgets the article reading history by clearing the cookies
+    When "Robert" signs out and forgets the article reading history by clearing the cookies
     And "Robert" goes to the "home" page
     And "Robert" goes back to the same "<group>" Article category via "<location>"
     Then "Robert" should see that his reading progress is gone
@@ -369,7 +369,7 @@ Feature: Articles
     And "Robert" completes the registration and real email verification process
     Then "Robert" should see his reading progress same as before registration
 
-    When "Robert" logs out and forgets the article reading history by clearing the cookies
+    When "Robert" signs out and forgets the article reading history by clearing the cookies
     And "Robert" goes to the "home" page
     And "Robert" goes back to the same "<group>" Article category via "<location>"
     Then "Robert" should see that his reading progress is gone

--- a/tests/exred/features/articles.feature
+++ b/tests/exred/features/articles.feature
@@ -484,21 +484,66 @@ Feature: Articles
       | Regular  | home page   |
 
 
-  @wip
   @ED-2773
   @session
-  Scenario: A signed in Exporter's progress should be updated with temporary information (cookie data merged with persistent storage)
-    Given "Robert" is signed in
-    And "Robert" reads some articles
-    And "Robert" completes some tasks
-    And "Robert"'s current progress is saved
+  @<group>
+  @<location>
+  Scenario Outline: A signed in Exporter's progress should be updated with temporary information (cookie data merged with persistent storage)
+    Given "Robert" is a registered and verified user
+    And "Robert" is signed in
+    And "Robert" went to the "Home" page
+    And "Robert" went to randomly selected "<group>" Article category via "<location>"
+    And "Robert" read "<a number>" of articles and stays on the last read article page
 
-    When "Robert" decides to "sign out"
-    And "Robert" reads some more articles
-    And "Robert" completes some more tasks
-    And "Robert" decides to "sign in"
+    When "Robert" signs out
+    And "Robert" goes to the "Home" page
+    And "Robert" goes back to the same "<group>" Article category via "<location>"
+    And "Robert" opens any Article but the last one
+    And "Robert" decides to read through all remaining Articles from selected list
+    And "Robert" signs in
 
-    Then "Robert"'s current progress should be updated without overwriting (merged / accumulated)
+    Then "Robert" should be on the "Article" page
+    And "Robert"'s current reading progress should be merged with the one from before signing out without any overwriting
+
+    Examples:
+      | group            | location     | a number  |
+      | Export Readiness | header menu  | a sixth   |
+      | Export Readiness | home page    | a quarter |
+      | Export Readiness | footer links | a third   |
+      | Guidance         | header menu  | a fifth   |
+      | Guidance         | home page    | a quarter |
+      | Guidance         | footer links | a third   |
+
+
+  @ED-2773
+  @session
+  @<group>
+  @<location>
+  Scenario Outline: A signed in Exporter's progress should be updated with temporary information (cookie data merged with persistent storage)
+    Given "Robert" is a registered and verified user
+    And "Robert" is signed in
+    And "Robert" went to the "Home" page
+    And "Robert" went to randomly selected "<group>" Article category via "<location>"
+    And "Robert" read "<a number>" of articles and stays on the last read article page
+
+    When "Robert" signs out and forgets the article reading history by clearing the cookies
+    And "Robert" goes to the "Home" page
+    And "Robert" goes back to the same "<group>" Article category via "<location>"
+    And "Robert" opens any Article but the last one
+    And "Robert" decides to read through all remaining Articles from selected list
+    And "Robert" signs in
+
+    Then "Robert" should be on the "Article" page
+    And "Robert"'s current reading progress should be merged with the one from before signing out without any overwriting
+
+    Examples:
+      | group            | location     | a number  |
+      | Export Readiness | header menu  | a sixth   |
+      | Export Readiness | home page    | a quarter |
+      | Export Readiness | footer links | a third   |
+      | Guidance         | header menu  | a fifth   |
+      | Guidance         | home page    | a quarter |
+      | Guidance         | footer links | a third   |
 
 
   @wip

--- a/tests/exred/features/articles.feature
+++ b/tests/exred/features/articles.feature
@@ -183,7 +183,7 @@ Feature: Articles
     And "Robert" decided to create her personalised journey page
 
     When "Robert" goes to the "<specific>" Guidance Articles via "personalised journey"
-    When "Robert" opens any Article but the last one
+    And "Robert" opens any Article but the last one
     And "Robert" decides to read through all remaining Articles from selected list
 
     Then "Robert" should be able to navigate to the next article from the List following the Article Order

--- a/tests/exred/pages/article_common.py
+++ b/tests/exred/pages/article_common.py
@@ -11,6 +11,7 @@ from utils import (
     assertion_msg,
     check_if_element_is_not_present,
     find_element,
+    find_elements,
     selenium_action,
     take_screenshot
 )

--- a/tests/exred/pages/article_common.py
+++ b/tests/exred/pages/article_common.py
@@ -31,6 +31,7 @@ IS_THERE_ANYTHING_WRONG_WITH_THIS_PAGE_LINK = "section.error-reporting a"
 NEXT_ARTICLE_LINK = "#next-article-link"
 NOT_USEFUL_BUTTON = "#js-feedback-negative"
 REGISTRATION_LINK = "#top > div > p > a:nth-child(1)"
+READ_ARTICLES = "a.article-read"
 SHARE_MENU = "ul.sharing-links"
 SHOW_MORE_BUTTON = "#js-paginate-list-more"
 SIGN_IN_LINK = "#top > div > p > a:nth-child(2)"
@@ -337,3 +338,7 @@ def should_not_see_link_to_register(driver: webdriver):
 def should_not_see_link_to_sign_in(driver: webdriver):
     check_if_element_is_not_present(
         driver, by_css=SIGN_IN_LINK, element_name="Sign in link")
+
+
+def get_read_articles(driver: webdriver) -> list:
+    return [art.text for art in find_elements(driver, by_css=READ_ARTICLES)]

--- a/tests/exred/pages/header.py
+++ b/tests/exred/pages/header.py
@@ -3,7 +3,6 @@
 import logging
 
 from selenium import webdriver
-from selenium.webdriver import ActionChains
 from selenium.webdriver.common.keys import Keys
 
 from utils import (
@@ -20,6 +19,8 @@ URL = None
 HOME_LINK = "#menu > ul > li:nth-child(1) > a"
 REGISTRATION_LINK = "#header-bar a.register"
 SIGN_IN_LINK = "#header-bar a.signin"
+PROFILE_LINK = "#header-bar a.profile"
+SIGN_OUT_LINK = "#header-bar a.signout"
 SECTIONS = {
     "export readiness": {
         "menu": "#export-readiness-links",
@@ -121,5 +122,15 @@ def go_to_registration(driver: webdriver):
 
 
 def go_to_sign_in(driver: webdriver):
-    registration_link = find_element(driver, by_css=SIGN_IN_LINK)
-    registration_link.click()
+    sign_in = find_element(driver, by_css=SIGN_IN_LINK)
+    sign_in.click()
+
+
+def go_to_profile(driver: webdriver):
+    profile_link = find_element(driver, by_css=PROFILE_LINK)
+    profile_link.click()
+
+
+def go_to_sign_out(driver: webdriver):
+    sign_out_link = find_element(driver, by_css=SIGN_OUT_LINK)
+    sign_out_link.click()

--- a/tests/exred/pages/home.py
+++ b/tests/exred/pages/home.py
@@ -48,14 +48,14 @@ SECTIONS = {
         "itself": "section.hero-campaign-section > div > div",
         "teaser_title": "section.hero-campaign-section > div > div > h1",
         "teaser description": "section.hero-campaign-section > div > div > p:nth-child(2)",
-        "teaser_logo": "section.hero-campaign-section > div > div > img",
+        "teaser_logo": "section.hero-campaign-section picture > img",
     },
     "exporting journey": {
         "itself": "#content > section.triage.triage-section",
         "heading": "#content > section.triage.triage-section .heading",
         "introduction": "#content > section.triage.triage-section .intro",
         "get_started_button": GET_STARTED_BUTTON,
-        "image": "#content > section.triage.triage-section .container > img"
+        "image": "section.triage.triage-section  picture > img"
     },
     "export readiness": {
         "itself": "#personas",

--- a/tests/exred/pages/personalised_journey.py
+++ b/tests/exred/pages/personalised_journey.py
@@ -70,13 +70,13 @@ SECTIONS = {
     },
     "exopps tile": {
         "heading": "#other-services div.lg-2:nth-child(2) h3",
-        "soo image": "#other-services div.lg-2:nth-child(2) img",
+        "exopps image": "#other-services div.lg-2:nth-child(2) img",
         "intro": "#other-services div.lg-2:nth-child(2) p",
         "find marketplaces link": "#other-services div.lg-2:nth-child(2) a",
     },
     "exopps section": {
         "heading": "section.service-section.soo h2",
-        "soo image": "section.service-section.soo img",
+        "exopps image": "section.service-section.soo img",
         "intro": "section.service-section.soo .intro",
         "find marketplaces button": "section.service-section.soo .intro .button",
     },

--- a/tests/exred/pages/sso_sign_out.py
+++ b/tests/exred/pages/sso_sign_out.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""SSO Sign Out Page Object."""
+import logging
+from urllib.parse import urljoin
+
+from selenium import webdriver
+
+from settings import DIRECTORY_UI_SSO_URL
+from utils import assertion_msg, find_element, take_screenshot
+
+NAME = "SSO Sign out page"
+URL = urljoin(DIRECTORY_UI_SSO_URL, "accounts/logout/")
+
+SIGN_OUT_BUTTON = "#content > div > div > form > button"
+EXPECTED_ELEMENTS = {
+    "title": "#content > div > div > h1",
+    "sign in button": SIGN_OUT_BUTTON,
+}
+
+
+def should_be_here(driver: webdriver):
+    take_screenshot(driver, NAME)
+    for element_name, element_selector in EXPECTED_ELEMENTS.items():
+        element = find_element(driver, by_css=element_selector)
+        with assertion_msg(
+                "It looks like '%s' element is not visible on %s",
+                element_name, NAME):
+            assert element.is_displayed()
+    logging.debug("All expected elements are visible on '%s' page", NAME)
+
+
+def submit(driver: webdriver):
+    sign_out_button = find_element(driver, by_css=SIGN_OUT_BUTTON)
+    sign_out_button.click()
+    take_screenshot(driver, NAME + "after signing out")

--- a/tests/exred/registry/articles.py
+++ b/tests/exred/registry/articles.py
@@ -21,8 +21,8 @@ class Article:
             "index: {index}, "
             "title: {title}, "
             "time_to_read: {time_to_read}, "
-            "previous: {previous.title}, "
-            "next: {next.title}"
+            "previous: {previous}, "
+            "next: {next}"
         ).format(**self.__dict__)
 
 

--- a/tests/exred/registry/articles.py
+++ b/tests/exred/registry/articles.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """ExRed Articles Registry"""
+import random
 from collections import namedtuple
+from copy import copy
 
 ArticleParent = namedtuple('ArticleParent', ['uuid', 'title'])
 
@@ -431,16 +433,46 @@ GROUPS = {
 def get_articles(group: str, category: str, *, sub_category: str = None) -> list:
     """Get an ordered list of articles for specific group & category.
 
+    NOTE:
+    in order to avoid the trouble with creating overly nested structure of
+    related articles, a `copy` of article object is created inside the loop,
+    that find `previous` and `next` article.
+
     :param group: Article Group: Guidance, Export Readiness, Triage
     :param category: Category of Articles that belong to a specific Group
     :param sub_category: an article sub-category for Regular exporters
     :return: a list of matching Articles sorted by their category index
     """
+    ret = []
     if sub_category is not None:
-        result = GROUPS[group.lower()][category.lower()][sub_category.lower()]
+        articles = GROUPS[group.lower()][category.lower()][sub_category.lower()]
     else:
-        result = GROUPS[group.lower()][category.lower()]
-    return result
+        articles = GROUPS[group.lower()][category.lower()]
+
+    for idx, article in enumerate(articles):
+        article = copy(article)
+        previous_article = None
+        next_article = None
+
+        if (idx - 1) >= 0:
+            previous_article = articles[idx - 1]
+            previous_article.index = idx - 1
+
+        if (idx + 1) < len(articles):
+            next_article = articles[idx + 1]
+            next_article.index = idx + 1
+
+        article.index = idx
+        article.previous = previous_article
+        article.next = next_article
+        ret.append(article)
+    return ret
+
+
+def get_random_article(
+        group: str, category: str, *, sub_category: str = None) -> Article:
+    group_articles = get_articles(group, category, sub_category=sub_category)
+    return random.choice(group_articles)
 
 
 def get_article(group: str, category: str, name: str) -> Article:
@@ -448,19 +480,5 @@ def get_article(group: str, category: str, name: str) -> Article:
     articles = get_articles(group, category)
     for idx, article in enumerate(articles):
         if article.title.lower() == name.lower():
-            previous_article = None
-            next_article = None
-
-            if (idx - 1) >= 0:
-                previous_article = articles[idx - 1]
-                previous_article.index = idx - 1
-
-            if (idx + 1) < len(articles):
-                next_article = articles[idx + 1]
-                next_article.index = idx + 1
-
-            article.index = idx
-            article.previous = previous_article
-            article.next = next_article
             result = article
     return result

--- a/tests/exred/registry/articles.py
+++ b/tests/exred/registry/articles.py
@@ -16,6 +16,15 @@ class Article:
         self.next = next
         self.index = index
 
+    def __str__(self):
+        return (
+            "index: {index}, "
+            "title: {title}, "
+            "time_to_read: {time_to_read}, "
+            "previous: {previous.title}, "
+            "next: {next.title}"
+        ).format(**self.__dict__)
+
 
 RESEARCH_YOUR_MARKET = Article(
     title='Research your market',

--- a/tests/exred/registry/pages.py
+++ b/tests/exred/registry/pages.py
@@ -17,6 +17,7 @@ from pages import (
     sso_registration,
     sso_registration_confirmation,
     sso_sign_in,
+    sso_sign_out,
     triage_are_you_registered_with_companies_house,
     triage_are_you_regular_exporter,
     triage_company_name,
@@ -106,6 +107,10 @@ EXRED_PAGE_REGISTRY = {
     "sso sign in": {
         "url": sso_sign_in.URL,
         "po": sso_sign_in
+    },
+    "sso sign out": {
+        "url": sso_sign_out.URL,
+        "po": sso_sign_out
     },
     "sso registration confirmation": {
         "url": sso_registration_confirmation.URL,

--- a/tests/exred/settings.py
+++ b/tests/exred/settings.py
@@ -15,6 +15,7 @@ CONFIG_NAME = os.environ.get("CONFIG", "local")
 TASK_ID = int(os.environ.get("TASK_ID", 0))
 
 # optional variables set by user
+RESTART_BROWSER = os.environ.get("RESTART_BROWSER", "feature")
 BROWSERS = os.environ.get("BROWSERS", "").split()
 BROWSERS_VERSIONS = os.environ.get("VERSIONS", "").split()
 HUB_URL = os.environ.get("HUB_URL", None)

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -4,6 +4,7 @@ from behave import then
 
 from steps.then_impl import (
     articles_read_counter_same_as_before_registration,
+    articles_read_counter_should_be_merged,
     articles_should_be_thanked_for_feedback,
     articles_should_not_see_feedback_widget,
     articles_should_not_see_link_to_next_article,
@@ -249,3 +250,8 @@ def then_actor_should_not_see_register_link(context, actor_alias, page_name):
 @then('"{actor_alias}" should not see the link to register on the "{page_name}" page')
 def then_actor_should_not_see_register_link(context, actor_alias, page_name):
     articles_should_not_see_link_to_register(context, actor_alias, page_name)
+
+
+@then('"{actor_alias}"\'s current reading progress should be merged with the one from before signing out without any overwriting')
+def then_actror_should_see_reading_progress_merged(context, actor_alias):
+    articles_read_counter_should_be_merged(context, actor_alias)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -371,3 +371,15 @@ def articles_should_not_see_link_to_register(
     logging.debug(
         "As expected %s did not see 'Register' link on the '%s' page",
         actor_alias, page_name)
+
+
+def articles_read_counter_should_be_merged(context: Context, actor_alias: str):
+    actor = get_actor(context, actor_alias)
+    visited_articles = actor.visited_articles
+    current_read_counter = article_common.get_read_counter(context.driver)
+    number_of_visited_articles = len(set(visited_articles))
+    with assertion_msg(
+            "%s expected to see current article reading counter to be %d but "
+            "got %d", actor_alias, number_of_visited_articles,
+            current_read_counter):
+        assert current_read_counter == number_of_visited_articles

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -216,8 +216,9 @@ def when_actor_clears_the_cookies(context, actor_alias):
     clear_the_cookies(context, actor_alias)
 
 
+@when('"{actor_alias}" signs in')
 @when('"{actor_alias}" signs in using link visible in the "{location}"')
-def step_impl(context, actor_alias, location):
+def when_actor_signs_in(context, actor_alias, *, location="top bar"):
     sign_in(context, actor_alias, location)
 
 

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -25,7 +25,7 @@ from steps.when_impl import (
     registration_submit_form_and_verify_account,
     set_sector_preference,
     sign_in,
-    sign_in_go_to,
+    sign_out,
     start_triage,
     triage_are_you_incorporated,
     triage_change_answers,
@@ -237,3 +237,8 @@ def when_actor_goes_to_the_same_article_group(
 @when('"{actor_alias}" goes back to the last Article she read')
 def when_actor_goes_to_last_read_article(context, actor_alias):
     articles_go_back_to_last_read_article(context, actor_alias)
+
+
+@when('"{actor_alias}" signs out')
+def when_actor_signs_out(context, actor_alias):
+    sign_out(context, actor_alias)

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -131,6 +131,7 @@ def when_actor_goes_to_exred_articles(context, actor_alias, category, location):
     export_readiness_open_category(context, actor_alias, category, location)
 
 
+@when('"{actor_alias}" decides to read through all remaining Articles from selected list')
 @when('"{actor_alias}" decides to read through all Articles from selected list')
 def when_actor_reads_through_all_guidance_articles(context, actor_alias):
     guidance_read_through_all_articles(context, actor_alias)
@@ -139,11 +140,6 @@ def when_actor_reads_through_all_guidance_articles(context, actor_alias):
 @when('"{actor_alias}" opens any Article but the last one')
 def when_actor_opens_any_article_but_the_last_one(context, actor_alias):
     articles_open_any_but_the_last(context, actor_alias)
-
-
-@when('"{actor_alias}" decides to read through all remaining Articles from selected list')
-def when_actor_reads_through_all_remaining_articles(context, actor_alias):
-    guidance_read_through_all_articles(context, actor_alias)
 
 
 @when('"{actor_alias}" opens any article on the list')

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -211,7 +211,7 @@ def when_actor_registers(context, actor_alias):
         context, actor_alias, fake_verification=False)
 
 
-@when('"{actor_alias}" logs out and forgets the article reading history by clearing the cookies')
+@when('"{actor_alias}" signs out and forgets the article reading history by clearing the cookies')
 def when_actor_clears_the_cookies(context, actor_alias):
     clear_the_cookies(context, actor_alias)
 

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -242,3 +242,8 @@ def when_actor_goes_to_last_read_article(context, actor_alias):
 @when('"{actor_alias}" signs out')
 def when_actor_signs_out(context, actor_alias):
     sign_out(context, actor_alias)
+
+
+@when('"{actor_alias}" goes to randomly selected "{group}" Article category via "{location}"')
+def when_actor_is_on_article_list(context, actor_alias, group, location):
+    articles_open_group(context, actor_alias, group, location=location)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -673,10 +673,7 @@ def articles_open_specific(context: Context, actor_alias: str, name: str):
     logging.debug(
         "%s is on '%s' article: %s", actor_alias, name, driver.current_url)
     just_read = VisitedArticle(article.index, article.title, time_to_read)
-    if visited_articles:
-        visited_articles.append(just_read)
-    else:
-        visited_articles = [just_read]
+    visited_articles.append(just_read)
     update_actor(
         context, actor_alias, articles_read_counter=articles_read_counter,
         articles_time_to_complete=time_to_complete,
@@ -710,10 +707,7 @@ def articles_open_any(context: Context, actor_alias: str):
         any_article .title, driver.current_url)
     just_read = VisitedArticle(
         any_article.index, any_article.title, time_to_read)
-    if visited_articles:
-        visited_articles.append(just_read)
-    else:
-        visited_articles = [just_read]
+    visited_articles.append(just_read)
     update_actor(
         context, actor_alias,
         articles_read_counter=articles_read_counter,

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -999,6 +999,8 @@ def clear_the_cookies(context: Context, actor_alias: str):
         logging.debug("COOKIES: %s", cookies)
         context.driver.delete_all_cookies()
         logging.debug("Successfully cleared cookies for %s", actor_alias)
+        cookies = context.driver.get_cookies()
+        logging.debug("Driver cookies after clearing them: %s", cookies)
     except WebDriverException:
         logging.error("Failed to clear cookies for %s", actor_alias)
 

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -1015,6 +1015,12 @@ def sign_in(context, actor_alias, location):
     sso_sign_in.submit(context.driver)
 
 
+def sign_out(context: Context, actor_alias: str):
+    header.go_to_sign_out(context.driver)
+    sso_sign_out.submit(context.driver)
+    logging.debug("%s signed out", actor_alias)
+
+
 def articles_go_back_to_last_read_article(context: Context, actor_alias: str):
     actor = get_actor(context, actor_alias)
     group = actor.article_group

--- a/tests/exred/utils/__init__.py
+++ b/tests/exred/utils/__init__.py
@@ -98,7 +98,7 @@ def unauthenticated_actor(
                        for _ in range(password_length))
     return Actor(
         alias=alias, email=email, password=password,
-        self_classification=self_classification)
+        self_classification=self_classification, visited_articles=[])
 
 
 def add_actor(context: Context, actor: Actor):

--- a/tests/exred/utils/__init__.py
+++ b/tests/exred/utils/__init__.py
@@ -359,3 +359,15 @@ def find_elements(
         else:
             elements = driver.find_elements_by_id(by_id)
     return elements
+
+
+def clear_driver_cookies(driver: webdriver):
+    try:
+        cookies = driver.get_cookies()
+        logging.debug("COOKIES: %s", cookies)
+        driver.delete_all_cookies()
+        logging.debug("Successfully cleared cookies")
+        cookies = driver.get_cookies()
+        logging.debug("Driver cookies after clearing them: %s", cookies)
+    except WebDriverException as ex:
+        logging.error("Failed to clear cookies: '%s'", ex.msg)

--- a/tests/functional/features/sso/password.feature
+++ b/tests/functional/features/sso/password.feature
@@ -49,6 +49,22 @@ Feature: SSO password management
       Then "Peter Alder" should be on Welcome to your great.gov.uk profile page
 
 
+    @ED-2251
+    @sso
+    @account
+    @manage
+    @password
+    @fake-sso-email-verification
+    Scenario: Suppliers should not be able to change the password to one with only letters
+      Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
+      And "Peter Alder" signed out from SSO/great.gov.uk account
+      And "Peter Alder" received a password reset email
+
+      When "Peter Alder" attempts to change the password to one with only letters and using the password reset link
+
+      Then "Peter Alder" should see "This password contains letters only." message
+
+
     @ED-2146
     @sso
     @account
@@ -70,7 +86,7 @@ Feature: SSO password management
     @manage
     @password
     @fake-sso-email-verification
-    Scenario: Suppliers should not be to use the password reset link more than once
+    Scenario: Suppliers should not be able to use the password reset link more than once
       Given "Peter Alder" has a verified standalone SSO/great.gov.uk account
       And "Peter Alder" signed out from SSO/great.gov.uk account
       And "Peter Alder" received a password reset email

--- a/tests/functional/steps/fab_when_def.py
+++ b/tests/functional/steps/fab_when_def.py
@@ -360,3 +360,10 @@ def when_supplier_select_preferred_countries_of_export(
         context, supplier_alias, preferred, other):
     fab_select_preferred_countries_of_export(
         context, supplier_alias, preferred, other)
+
+
+@when('"{supplier_alias}" attempts to change the password to one with only letters and using the password reset link')
+def when_supplier_tries_to_change_password_to_letters_only(
+        context, supplier_alias):
+    sso_change_password_with_password_reset_link(
+        context, supplier_alias, new=True, letters_only=True)

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -1795,8 +1795,12 @@ def sso_change_password_with_password_reset_link(
 
     if new:
         password_length = 15
-        password = "".join(random.choice(string.ascii_letters + string.digits)
-                           for _ in range(password_length))
+        if letters_only:
+            password = "".join(choice(ascii_letters)
+                               for _ in range(password_length))
+        else:
+            password = "".join(choice(ascii_letters) + choice(digits)
+                               for _ in range(password_length))
         context.update_actor(supplier_alias, password=password)
     if same:
         password = actor.password

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 """FAB Given step implementations."""
 import logging
-import random
 import re
-import string
-from random import choice
+from random import choice, randrange
+from string import ascii_letters, digits
 from urllib.parse import parse_qsl, quote, urljoin, urlsplit
 
 from behave.model import Table
@@ -291,7 +290,7 @@ def bp_provide_company_details(context, supplier_alias):
     # Step 0 - generate random details & update Company matching details
     # Need to get Company details after updating it in the Scenario Data
     title = "{} {}".format(company.title, sentence())
-    size = random.choice(NO_OF_EMPLOYEES)
+    size = choice(NO_OF_EMPLOYEES)
     website = "http://{}.{}".format(rare_word(min_length=15), rare_word())
     keywords = ", ".join(sentence().split())
     context.set_company_details(
@@ -327,8 +326,8 @@ def bp_select_random_sector_and_export_to_country(context, supplier_alias):
     :type supplier_alias: str
     """
     actor = context.get_actor(supplier_alias)
-    sector = random.choice(SECTORS)
-    countries = [COUNTRIES[random.choice(list(COUNTRIES))]]
+    sector = choice(SECTORS)
+    countries = [COUNTRIES[choice(list(COUNTRIES))]]
     other = ""
 
     # Step 1 - Submit the Choose Your Sector form
@@ -1457,8 +1456,8 @@ def fas_browse_suppliers_by_multiple_sectors(
     content = response.content.decode("utf-8")
     filters = Selector(text=content).css(sector_selector).extract()
 
-    sectors = list(set(random.choice(filters)
-                       for _ in range(random.randrange(1, len(filters)))))
+    sectors = list(set(choice(filters)
+                       for _ in range(randrange(1, len(filters)))))
     results = {}
     logging.debug(
         "%s will browse Suppliers by multiple Industry sector filters '%s'",
@@ -1485,8 +1484,8 @@ def fas_browse_suppliers_by_invalid_sectors(
     content = response.content.decode("utf-8")
     filters = Selector(text=content).css(sector_selector).extract()
 
-    sectors = list(set(random.choice(filters)
-                       for _ in range(random.randrange(1, len(filters)))))
+    sectors = list(set(choice(filters)
+                       for _ in range(randrange(1, len(filters)))))
 
     sectors.append("this_is_an_invalid_sector_filter")
     logging.debug(
@@ -1667,7 +1666,7 @@ def get_form_value(key: str) -> str or list or int or None:
         (" predefined countries$", get_n_country_codes(get_number_from_key(key))),
         ("1 predefined country$", get_n_country_codes(1)),
         ("none selected", None),
-        ("sector", random.choice(SECTORS))
+        ("sector", choice(SECTORS))
     ]
 
     found = False
@@ -1777,7 +1776,7 @@ def sso_sign_in(context: Context, supplier_alias: str):
 
 def sso_change_password_with_password_reset_link(
         context: Context, supplier_alias: str, *, new: bool = False,
-        same: bool = False, mismatch: bool = False):
+        same: bool = False, mismatch: bool = False, letters_only: bool = False):
     actor = context.get_actor(supplier_alias)
     session = actor.session
     link = actor.password_reset_link


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2773)

Scenario:
```gherkin
  @ED-2773
  @session
  @<group>
  @<location>
  Scenario Outline: A signed in Exporter's progress should be updated with temporary information (cookie data merged with persistent storage)
    Given "Robert" is a registered and verified user
    And "Robert" is signed in
    And "Robert" went to the "Home" page
    And "Robert" went to randomly selected "<group>" Article category via "<location>"
    And "Robert" read "<a number>" of articles and stays on the last read article page

    When "Robert" signs out
    And "Robert" goes to the "Home" page
    And "Robert" goes back to the same "<group>" Article category via "<location>"
    And "Robert" opens any Article but the last one
    And "Robert" decides to read through all remaining Articles from selected list
    And "Robert" signs in

    Then "Robert" should be on the "Article" page
    And "Robert"'s current reading progress should be merged with the one from before signing out without any overwriting

    Examples:
      | group            | location     | a number  |
      | Export Readiness | header menu  | a sixth   |
      | Export Readiness | home page    | a quarter |
      | Export Readiness | footer links | a third   |
      | Guidance         | header menu  | a fifth   |
      | Guidance         | home page    | a quarter |
      | Guidance         | footer links | a third   |


  @ED-2773
  @session
  @<group>
  @<location>
  Scenario Outline: A signed in Exporter's progress should be updated with temporary information (cookie data merged with persistent storage)
    Given "Robert" is a registered and verified user
    And "Robert" is signed in
    And "Robert" went to the "Home" page
    And "Robert" went to randomly selected "<group>" Article category via "<location>"
    And "Robert" read "<a number>" of articles and stays on the last read article page

    When "Robert" signs out and forgets the article reading history by clearing the cookies
    And "Robert" goes to the "Home" page
    And "Robert" goes back to the same "<group>" Article category via "<location>"
    And "Robert" opens any Article but the last one
    And "Robert" decides to read through all remaining Articles from selected list
    And "Robert" signs in

    Then "Robert" should be on the "Article" page
    And "Robert"'s current reading progress should be merged with the one from before signing out without any overwriting

    Examples:
      | group            | location     | a number  |
      | Export Readiness | header menu  | a sixth   |
      | Export Readiness | home page    | a quarter |
      | Export Readiness | footer links | a third   |
      | Guidance         | header menu  | a fifth   |
      | Guidance         | home page    | a quarter |
      | Guidance         | footer links | a third   |
```
