### PR TITLE
ED-2640 share article on social media and via email

### DIFF
--- a/tests/exred/features/articles.feature
+++ b/tests/exred/features/articles.feature
@@ -546,23 +546,41 @@ Feature: Articles
       | Guidance         | footer links | a third   |
 
 
-  @wip
   @ED-2640
   @sharing
-  Scenario Outline: Any Exporter should be able to share the article via Facebook, Twitter, Linked and email on the article page
+  @<group>
+  @<social_media>
+  Scenario Outline: Any Exporter should be able to share the article via "<social_media>"
     Given "Robert" is on the "<group>" Article List for randomly selected category
     And "Robert" opened any Article
 
     When "Robert" decides to share the article via "<social_media>"
 
-    Then "Robert" should be taken to a new tab with the "<sharing_option>" opened and pre-populated message with the link to the article
+    Then "Robert" should be taken to a new tab with the "<social_media>" share page opened
+    And "Robert" should that "<social_media>" share page has been pre-populated with message and the link to the article
 
     Examples:
-      | group            | sharing_option |
-      | Export Readiness | Facebook       |
-      | Guidance         | Twitter        |
-      | Export Readiness | LinkedIn       |
-      | Guidance         | email          |
+      | group            | social_media |
+      | Export Readiness | Facebook     |
+      | Guidance         | Twitter      |
+      | Export Readiness | LinkedIn     |
+
+
+  @ED-2640
+  @sharing
+  @<group>
+  @<social_media>
+  Scenario Outline: Any Exporter should be able to share the article via "<social_media>"
+    Given "Robert" is on the "<group>" Article List for randomly selected category
+    And "Robert" opened any Article
+
+    When "Robert" decides to share the article via "<social_media>"
+
+    Then "Robert" should see that the share via email link will pre-populate the message subject and body with Article title and URL
+
+    Examples:
+      | group            | social_media |
+      | Guidance         | email        |
 
 
   @wip

--- a/tests/exred/pages/share_on_facebook.py
+++ b/tests/exred/pages/share_on_facebook.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""Share on Facebook Page Object."""
+import logging
+from urllib import parse as urlparse
+from urllib.parse import urljoin
+
+from selenium import webdriver
+
+from utils import (
+    assertion_msg,
+    find_element,
+    take_screenshot,
+    wait_for_visibility
+)
+
+NAME = "Share on Facebook page"
+URL = urljoin("https://www.facebook.com/", "share.php?u=")
+PAGE_TITLE = "Facebook"
+
+EXPECTED_ELEMENTS = {
+    "header": "#homelink",
+}
+
+
+def should_be_here(driver: webdriver):
+    take_screenshot(driver, NAME)
+    with assertion_msg(
+            "Expected page title to be: '%s' but got '%s'", PAGE_TITLE,
+            driver.title):
+        assert driver.title.lower() == PAGE_TITLE.lower()
+    for element_name, element_selector in EXPECTED_ELEMENTS.items():
+        element = find_element(driver, by_css=element_selector)
+        wait_for_visibility(driver, by_css=element_selector)
+        with assertion_msg(
+                "It looks like '%s' element is not visible on %s",
+                element_name, NAME):
+            assert element.is_displayed()
+    logging.debug("All expected elements are visible on '%s' page", NAME)
+
+
+def extract_shared_url(url: str) -> str:
+    parsed_initial_url = urlparse.urlparse(url)
+    initial_url_query_parameters = urlparse.parse_qs(parsed_initial_url.query)
+    next_parameter = initial_url_query_parameters['next'][0]
+    parsed_next_url = urlparse.urlparse(next_parameter)
+    next_url_query_parameters = urlparse.parse_qs(parsed_next_url.query)
+    shared_url = next_url_query_parameters['u'][0]
+    return shared_url
+
+
+def check_if_populated(driver: webdriver, shared_url: str):
+    found_shared_url = extract_shared_url(driver.current_url)
+    with assertion_msg(
+            "Expected to find link to Article '%s' in the Facebook share page "
+            "URL, but got '%s' instead", shared_url, found_shared_url):
+        assert shared_url == found_shared_url
+
+
+def close_all_windows_except_first(driver: webdriver):
+    """This action works only locally, and doesn't work on BrowserStack :("""
+    while len(driver.window_handles) > 1:
+        driver.switch_to.window(driver.window_handles[-1])
+        logging.debug(
+            "Closing window: %s opened with URL %s", driver.window_handles[1],
+            driver.current_url)
+        driver.close()
+        # driver.find_element_by_tag_name('body').send_keys(Keys.CONTROL + 'w')
+    driver.switch_to.window(driver.window_handles[0])

--- a/tests/exred/pages/share_on_linkedin.py
+++ b/tests/exred/pages/share_on_linkedin.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""Share on LinkedIn Page Object."""
+import logging
+from urllib import parse as urlparse
+from urllib.parse import urljoin
+
+from selenium import webdriver
+
+from utils import (
+    assertion_msg,
+    find_element,
+    take_screenshot,
+    wait_for_visibility
+)
+
+NAME = "Share on LinkedIn page"
+URL = urljoin("https://www.linkedin.com/", "shareArticle")
+PAGE_TITLE = "Sign Up | LinkedIn"
+
+EXPECTED_ELEMENTS = {
+    "logo": "#uno-reg-join > div > div > div > div.header-container > header",
+}
+
+
+def should_be_here(driver: webdriver):
+    take_screenshot(driver, NAME)
+    with assertion_msg(
+            "Expected page title to be: '%s' but got '%s'", PAGE_TITLE,
+            driver.title):
+        assert driver.title.lower() == PAGE_TITLE.lower()
+    for element_name, element_selector in EXPECTED_ELEMENTS.items():
+        element = find_element(driver, by_css=element_selector)
+        wait_for_visibility(driver, by_css=element_selector)
+        with assertion_msg(
+                "It looks like '%s' element is not visible on %s",
+                element_name, NAME):
+            assert element.is_displayed()
+    logging.debug("All expected elements are visible on '%s' page", NAME)
+
+
+def extract_shared_url(url: str) -> str:
+    parsed_initial_url = urlparse.urlparse(url)
+    initial_url_query_parameters = urlparse.parse_qs(parsed_initial_url.query)
+    session_redirect = initial_url_query_parameters['session_redirect'][0]
+    parsed_next_url = urlparse.urlparse(session_redirect)
+    next_url_query_parameters = urlparse.parse_qs(parsed_next_url.query)
+    shared_url = next_url_query_parameters['url'][0]
+    return shared_url
+
+
+def check_if_populated(driver: webdriver, shared_url: str):
+    found_shared_url = extract_shared_url(driver.current_url)
+    with assertion_msg(
+            "Expected to find link to Article '%s' in the LinkedIn share page "
+            "URL, but got '%s' instead", shared_url, found_shared_url):
+        assert shared_url == found_shared_url
+
+
+def close_all_windows_except_first(driver: webdriver):
+    """This action works only locally, and doesn't work on BrowserStack :("""
+    while len(driver.window_handles) > 1:
+        driver.switch_to.window(driver.window_handles[-1])
+        logging.debug(
+            "Closing window: %s opened with URL %s", driver.window_handles[1],
+            driver.current_url)
+        driver.close()
+        # driver.find_element_by_tag_name('body').send_keys(Keys.CONTROL + 'w')
+    driver.switch_to.window(driver.window_handles[0])

--- a/tests/exred/pages/share_on_twitter.py
+++ b/tests/exred/pages/share_on_twitter.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""Share on Twitter Page Object."""
+import logging
+from urllib.parse import urljoin
+
+from selenium import webdriver
+
+from utils import (
+    assertion_msg,
+    find_element,
+    take_screenshot,
+    wait_for_visibility
+)
+
+NAME = "Share on Twitter page"
+URL = urljoin("https://twitter.com/", "intent/tweet?text=")
+PAGE_TITLE = "Post a Tweet on Twitter"
+
+MESSAGE_BOX = "#status"
+EXPECTED_ELEMENTS = {
+    "logo": "#header > div > h1 > a",
+    "message_box": MESSAGE_BOX
+}
+
+
+def should_be_here(driver: webdriver):
+    take_screenshot(driver, NAME)
+    with assertion_msg(
+            "Expected page title to be: '%s' but got '%s'", PAGE_TITLE,
+            driver.title):
+        assert driver.title.lower() == PAGE_TITLE.lower()
+    for element_name, element_selector in EXPECTED_ELEMENTS.items():
+        element = find_element(driver, by_css=element_selector)
+        wait_for_visibility(driver, by_css=element_selector)
+        with assertion_msg(
+                "It looks like '%s' element is not visible on %s",
+                element_name, NAME):
+            assert element.is_displayed()
+    logging.debug("All expected elements are visible on '%s' page", NAME)
+
+
+def check_if_populated(driver: webdriver, shared_url: str):
+    status_update_message = find_element(driver, by_css=MESSAGE_BOX)
+    with assertion_msg(
+            "Expected to see article URL '%s' in LinkedIn's status update "
+            "textbox, but couldn't find it in : %s", shared_url,
+            status_update_message.text):
+        assert shared_url in status_update_message.text
+
+
+def close_all_windows_except_first(driver: webdriver):
+    """This action works only locally, and doesn't work on BrowserStack :("""
+    while len(driver.window_handles) > 1:
+        driver.switch_to.window(driver.window_handles[-1])
+        logging.debug(
+            "Closing window: %s opened with URL %s", driver.window_handles[1],
+            driver.current_url)
+        # driver.find_element_by_tag_name('body').send_keys(Keys.CONTROL + 'w')
+        driver.close()
+    driver.switch_to.window(driver.window_handles[0])

--- a/tests/exred/registry/pages.py
+++ b/tests/exred/registry/pages.py
@@ -14,6 +14,9 @@ from pages import (
     interim_exporting_opportunities,
     personalised_journey,
     selling_online_overseas,
+    share_on_facebook,
+    share_on_linkedin,
+    share_on_twitter,
     sso_registration,
     sso_registration_confirmation,
     sso_sign_in,
@@ -123,6 +126,18 @@ EXRED_PAGE_REGISTRY = {
     "article list": {
         "url": None,
         "po": article_list
+    },
+    "share on facebook": {
+        "url": share_on_facebook.URL,
+        "po": share_on_facebook
+    },
+    "share on linkedin": {
+        "url": share_on_linkedin.URL,
+        "po": share_on_linkedin
+    },
+    "share on twitter": {
+        "url": share_on_twitter.URL,
+        "po": share_on_twitter
     },
 }
 

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -5,6 +5,7 @@ from behave import then
 from steps.then_impl import (
     articles_read_counter_same_as_before_registration,
     articles_read_counter_should_be_merged,
+    articles_should_be_on_share_page,
     articles_should_be_thanked_for_feedback,
     articles_should_not_see_feedback_widget,
     articles_should_not_see_link_to_next_article,
@@ -33,6 +34,8 @@ from steps.then_impl import (
     personalised_journey_should_see_banner_and_top_10_table,
     personalised_journey_should_see_read_counter,
     personalised_should_see_layout_for,
+    share_page_should_be_prepopulated,
+    share_page_via_email_should_have_article_details,
     should_be_on_page,
     should_see_links_to_services,
     should_see_sections,
@@ -255,3 +258,18 @@ def then_actor_should_not_see_register_link(context, actor_alias, page_name):
 @then('"{actor_alias}"\'s current reading progress should be merged with the one from before signing out without any overwriting')
 def then_actror_should_see_reading_progress_merged(context, actor_alias):
     articles_read_counter_should_be_merged(context, actor_alias)
+
+
+@then('"{actor_alias}" should be taken to a new tab with the "{social_media}" share page opened')
+def then_actor_should_be_on_share_page(context, actor_alias, social_media):
+    articles_should_be_on_share_page(context, actor_alias, social_media)
+
+
+@then('"{actor_alias}" should that "{social_media}" share page has been pre-populated with message and the link to the article')
+def then_share_page_should_be_prepopulated(context, actor_alias, social_media):
+    share_page_should_be_prepopulated(context, actor_alias, social_media)
+
+
+@then('"{actor_alias}" should see that the share via email link will pre-populate the message subject and body with Article title and URL')
+def then_check_share_via_email_link(context, actor_alias):
+    share_page_via_email_should_have_article_details(context, actor_alias)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -20,7 +20,7 @@ from steps.when_impl import (
     triage_should_be_classified_as_occasional,
     triage_should_be_classified_as_regular
 )
-from utils import assertion_msg, get_actor
+from utils import assertion_msg, clear_driver_cookies, get_actor
 
 
 def should_see_sections_on_home_page(
@@ -383,3 +383,32 @@ def articles_read_counter_should_be_merged(context: Context, actor_alias: str):
             "got %d", actor_alias, number_of_visited_articles,
             current_read_counter):
         assert current_read_counter == number_of_visited_articles
+
+
+def articles_should_be_on_share_page(
+        context: Context, actor_alias: str, social_media: str):
+    page_name = "share on {}".format(social_media.lower())
+    social_media_page = get_page_object(page_name)
+    social_media_page.should_be_here(context.driver)
+    logging.debug("%s is on the '%s' share page", actor_alias, social_media)
+
+
+def share_page_should_be_prepopulated(context: Context, actor_alias: str, social_media: str):
+    page_name = "share on {}".format(social_media.lower())
+    social_media_page = get_page_object(page_name)
+    shared_url = context.article_url
+    social_media_page.check_if_populated(context.driver, shared_url)
+    clear_driver_cookies(driver=context.driver)
+    logging.debug(
+        "%s saw '%s' share page populated with appropriate data", actor_alias)
+
+
+def share_page_via_email_should_have_article_details(
+        context: Context, actor_alias: str):
+    driver = context.driver
+    body = driver.current_url
+    subject = article_common.get_article_name(driver)
+    article_common.check_share_via_email_link_details(driver, subject, body)
+    logging.debug(
+        "%s checked that the 'share via email' link contain correct subject: "
+        "'%s' and message body: '%s'", actor_alias, subject, body)

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -11,6 +11,7 @@ from steps.when_impl import (
     articles_open_any,
     articles_open_any_but_the_last,
     articles_open_group,
+    articles_share_on_social_media,
     case_studies_go_to,
     clear_the_cookies,
     continue_export_journey,
@@ -247,3 +248,8 @@ def when_actor_signs_out(context, actor_alias):
 @when('"{actor_alias}" goes to randomly selected "{group}" Article category via "{location}"')
 def when_actor_is_on_article_list(context, actor_alias, group, location):
     articles_open_group(context, actor_alias, group, location=location)
+
+
+@when('"{actor_alias}" decides to share the article via "{social_media}"')
+def when_actor_shares_article(context, actor_alias, social_media):
+    articles_share_on_social_media(context, actor_alias, social_media)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -1044,3 +1044,17 @@ def get_geo_ip(context: Context, actor_alias: str):
     driver.get("https://www.geoiptool.com/")
     take_screenshot(driver, "geoip")
     logging.debug("%s checked the geoip", actor_alias)
+
+
+@retry(wait_fixed=30000, stop_max_attempt_number=3)
+def articles_share_on_social_media(
+        context: Context, actor_alias: str, social_media: str):
+    context.article_url = context.driver.current_url
+    if social_media.lower() == "email":
+        article_common.check_if_link_opens_email_client(context.driver)
+    else:
+        article_common.check_if_link_opens_new_tab(context.driver, social_media)
+        article_common.share_via(context.driver, social_media)
+    logging.debug(
+        "%s successfully got to the share article on '%s'", actor_alias,
+        social_media)


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-2640)

Scenario:
```gherkin
  @ED-2640
  @sharing
  @<group>
  @<social_media>
  Scenario Outline: Any Exporter should be able to share the article via "<social_media>"
    Given "Robert" is on the "<group>" Article List for randomly selected category
    And "Robert" opened any Article

    When "Robert" decides to share the article via "<social_media>"

    Then "Robert" should be taken to a new tab with the "<social_media>" share page opened
    And "Robert" should that "<social_media>" share page has been pre-populated with message and the link to the article

    Examples:
      | group            | social_media |
      | Export Readiness | Facebook     |
      | Guidance         | Twitter      |
      | Export Readiness | LinkedIn     |


  @ED-2640
  @sharing
  @<group>
  @<social_media>
  Scenario Outline: Any Exporter should be able to share the article via "<social_media>"
    Given "Robert" is on the "<group>" Article List for randomly selected category
    And "Robert" opened any Article

    When "Robert" decides to share the article via "<social_media>"

    Then "Robert" should see that the share via email link will pre-populate the message subject and body with Article title and URL

    Examples:
      | group            | social_media |
      | Guidance         | email        |
```
