### PR TITLE
ED-2656, ED-2593, ED-2591 share case study and related scenarios

### DIFF
--- a/tests/exred/features/case-studies.feature
+++ b/tests/exred/features/case-studies.feature
@@ -10,7 +10,7 @@ Feature: Case Studies
     When "Robert" goes to the "<relevant>" Case Study via carousel
 
     Then "Robert" should see "<relevant>" case study
-    Then "Robert" should see the Share Widget
+    And "Robert" should see the Share Widget
 
     Examples:
       | relevant |

--- a/tests/exred/features/case-studies.feature
+++ b/tests/exred/features/case-studies.feature
@@ -19,31 +19,28 @@ Feature: Case Studies
       | Third    |
 
 
-  @wip
   @ED-2656
   @<social-media>
   Scenario Outline: Any Exporter should be able to share the Case Study Article via "<social-media>"
-    Given "Robert" is on the Case Study page
+    Given "Robert" is on the Case Study page accessed via "Home" page
 
     When "Robert" decides to share the article via "<social-media>"
 
-    Then "Robert" should be taken to "<social-media>" page with a message containing the link to the article
+    Then "Robert" should be taken to a new tab with the "<social-media>" share page opened
+    And "Robert" should that "<social-media>" share page has been pre-populated with message and the link to the article
 
     Examples:
       | social-media |
       | Facebook     |
       | Twitter      |
-      | Linked       |
+      | LinkedIn     |
 
 
-  @wip
   @ED-2656
   @email
   Scenario: Any Exporter should be able to share the Case Study Article via Email
-    Given "Robert" is on the Case Study page
+    Given "Robert" is on the Case Study page accessed via "Home" page
 
     When "Robert" decides to share the article via "email"
 
-    Then "Robert" should see new email window with
-    And Article name should appear in the email Subject
-    And link to the Article should appear in the email body
+    Then "Robert" should see that the share via email link will pre-populate the message subject and body with Article title and URL

--- a/tests/exred/features/home-page.feature
+++ b/tests/exred/features/home-page.feature
@@ -4,9 +4,9 @@ Feature: Home Page
 
   @ED-2366
   @sections
-  Scenario: Any Exporter should see the "Video, Exporting Journey, Export Readiness, Guidance, Services, Case Studies" sections on the home page.
+  Scenario: Any Exporter should see the "Hero, Exporting Journey, Export Readiness, Guidance, Services, Case Studies, Business is Great, Error Reporting" sections on the home page.
       Given "Robert" visits the "Home" page
-      Then "Robert" should see the "Video, Exporting Journey, Export Readiness, Guidance, Services, Case Studies" sections on Home page
+      Then "Robert" should see the "Hero, Exporting Journey, Export Readiness, Guidance, Services, Case Studies, Business is Great, Error Reporting" sections on Home page
 
 
   @ED-2366

--- a/tests/exred/features/home-page.feature
+++ b/tests/exred/features/home-page.feature
@@ -4,9 +4,9 @@ Feature: Home Page
 
   @ED-2366
   @sections
-  Scenario: Any Exporter should see the "Hero, Exporting Journey, Export Readiness, Guidance, Services, Case Studies, Business is Great, Error Reporting" sections on the home page.
+  Scenario: Any Exporter should see the "Beta, Hero, Exporting Journey, Export Readiness, Guidance, Services, Case Studies, Business is Great, Error Reporting" sections on the home page.
       Given "Robert" visits the "Home" page
-      Then "Robert" should see the "Hero, Exporting Journey, Export Readiness, Guidance, Services, Case Studies, Business is Great, Error Reporting" sections on Home page
+      Then "Robert" should see the "Beta, Hero, Exporting Journey, Export Readiness, Guidance, Services, Case Studies, Business is Great, Error Reporting" sections on Home page
 
 
   @ED-2366

--- a/tests/exred/features/personalised-page.feature
+++ b/tests/exred/features/personalised-page.feature
@@ -82,27 +82,36 @@ Feature: Customised page
       | Occasional |
       | Regular    |
 
-  @wip
-  @ED-2592
-  @personalised-page
-  Scenario: Any Exporter should see the Banner & Top 10 table specific to the sector they selected in triage
-    Given "Robert" has created the personalised journey page
 
-    Then "Robert" should see the Banner & Top 10 table specific to the sector they selected in triage
-
-
-  @wip
   @ED-2593
   @personalised-page
-  Scenario Outline: Any Exporter should get to a relevant case study from Case Studies carousel on the personalised page
-    Given "Robert" is interested in "<case_study_name>" case study
+  @case-studies
+  Scenario Outline: "<relevant>" Exporter should get to a "<selected>" case study from Case Studies carousel on the personalised journey page
+    Given "Robert" was classified as "<relevant>" exporter in the triage process
+    And "Robert" decided to create his personalised journey page
 
-    When "Robert" goes to the relevant "<case_study_name>" link in the Case Studies carousel on the personalised page
+    When "Robert" goes to the "<selected>" Case Study via carousel
 
-    Then "Robert" should see "<case_study_name>" page with a Share widget
+    Then "Robert" should see "<selected>" case study
+    And "Robert" should see the Share Widget
 
     Examples:
-      | case_study_name   |
-      | First case study  |
-      | Second case study |
-      | Third case study  |
+      | relevant   | selected |
+      | New        | First    |
+      | Occasional | Second   |
+
+
+  @ED-2593
+  @personalised-page
+  @case-studies
+  Scenario Outline: "<relevant>" Exporter should not see Case Studies carousel on the personalised journey page
+    Given "Robert" was classified as "<relevant>" exporter in the triage process
+
+    When "Robert" decides to create her personalised journey page
+
+    Then "Robert" should be on the Personalised Journey page for "<relevant>" exporters
+    And "Robert" should not see "case studies" sections on "personalised journey" page
+
+    Examples:
+      | relevant |
+      | Regular  |

--- a/tests/exred/features/personalised-page.feature
+++ b/tests/exred/features/personalised-page.feature
@@ -63,16 +63,24 @@ Feature: Customised page
       | services          | has not        | Article list, Case studies                      |
 
 
-  @wip
   @ED-2591
+  @triage
+  @change-answers
   @personalised-page
-  Scenario: Any Exporter should be able to update preferences from personalised page
-    Given "Robert" is on personalised page
+  Scenario Outline: "<relevant>" Exporter should be able to update preferences from personalised journey page
+    Given "Robert" was classified as "<relevant>" exporter in the triage process
+    And "Robert" decided to create her personalised journey page
 
     When "Robert" decides to update his triage preferences
 
-    Then "Robert" should be redirected to the triage summary where he can change his answers
+    Then "Robert" should be on the "Triage - Summary" page
+    And "Robert" should see an option to change his triage answers
 
+    Examples:
+      | relevant   |
+      | New        |
+      | Occasional |
+      | Regular    |
 
   @wip
   @ED-2592

--- a/tests/exred/features/top-importers.feature
+++ b/tests/exred/features/top-importers.feature
@@ -92,7 +92,7 @@ Feature: Top importers
       | Meat, fish or crustaceans, molluscs or other aquatic invertebrates; preparations thereof                                                                                                                                                  |
       | Sugars and sugar confectionery                                                                                                                                                                                                            |
       | Cocoa and cocoa preparations                                                                                                                                                                                                              |
-      | Preparations of cereals, flour, starch or milk; pastrycooks' products                                                                                                                                                                    |
+      | Preparations of cereals, flour, starch or milk; pastrycooks' products                                                                                                                                                                     |
       | Preparations of vegetables, fruit, nuts or other parts of plants                                                                                                                                                                          |
       | Miscellaneous edible preparations                                                                                                                                                                                                         |
       | Beverages, spirits and vinegar                                                                                                                                                                                                            |
@@ -168,7 +168,7 @@ Feature: Top importers
       | Furniture; bedding, mattresses, mattress supports, cushions and similar stuffed furnishings; lamps and lighting fittings, n.e.c.; illuminated signs, illuminated name-plates and the like; prefabricated buildings                        |
       | Toys, games and sports requisites; parts and accessories thereof                                                                                                                                                                          |
       | Miscellaneous manufactured articles                                                                                                                                                                                                       |
-      | Works of art; collectors' pieces and antiques                                                                                                                                                                                            |
+      | Works of art; collectors' pieces and antiques                                                                                                                                                                                             |
       | Commodities not specified according to kind                                                                                                                                                                                               |
 
 

--- a/tests/exred/pages/article_common.py
+++ b/tests/exred/pages/article_common.py
@@ -28,15 +28,15 @@ BREADCRUMBS = "p.breadcrumbs"
 FEEDBACK_QUESTION = "#js-feedback > p"
 FEEDBACK_RESULT = "#js-feedback-success"
 GO_BACK_LINK = "#category-link"
-INDICATORS_TEXT = "#top div.scope-indicator"
+INDICATORS_TEXT = "div.scope-indicator"
 IS_THERE_ANYTHING_WRONG_WITH_THIS_PAGE_LINK = "section.error-reporting a"
 NEXT_ARTICLE_LINK = "#next-article-link"
 NOT_USEFUL_BUTTON = "#js-feedback-negative"
-REGISTRATION_LINK = "#top > div > p > a:nth-child(1)"
+REGISTRATION_LINK = "#content div.article-container p.register > a:nth-child(1)"
 READ_ARTICLES = "a.article-read"
 SHARE_MENU = "ul.sharing-links"
 SHOW_MORE_BUTTON = "#js-paginate-list-more"
-SIGN_IN_LINK = "#top > div > p > a:nth-child(2)"
+SIGN_IN_LINK = "#content div.article-container p.register > a:nth-child(2)"
 TIME_TO_COMPLETE = "dd.time span.value"
 TOTAL_NUMBER_OF_ARTICLES = "dd.position > span.to"
 USEFUL_BUTTON = "#js-feedback-positive"
@@ -283,9 +283,7 @@ def count_average_word_number_in_lines_list(lines_list, word_length=5):
 def time_to_read_in_seconds(driver: webdriver):
     """Return time to read in minutes give an Article object."""
     article_text = driver.find_element_by_css_selector(ARTICLE_TEXT).text
-    indicators_text = driver.find_element_by_css_selector(INDICATORS_TEXT).text
-    only_article = article_text.replace(indicators_text, '')
-    filtered_lines = filter_lines(only_article)
+    filtered_lines = filter_lines(article_text)
     total_words_count = count_average_word_number_in_lines_list(filtered_lines)
     return round(total_words_count / WORDS_PER_SECOND)
 

--- a/tests/exred/pages/footer.py
+++ b/tests/exred/pages/footer.py
@@ -10,6 +10,10 @@ NAME = "ExRed Footer"
 URL = None
 
 SECTIONS = {
+    "logos": {
+        "dit logo": "#footer-dit-logo",
+        "eig logo": "#footer-eig-logo"
+    },
     "export readiness": {
         "label": "#footer-export-readiness-links",
         "new": "#footer ul[aria-labelledby='footer-export-readiness-links'] > li:nth-child(1) > a",
@@ -41,7 +45,8 @@ SECTIONS = {
         "contact us": "#footer > .site-links > ul > li:nth-child(2) > a",
         "privacy and cookies": "#footer > .site-links > ul > li:nth-child(3) > a",
         "terms and conditions": "#footer > .site-links > ul > li:nth-child(4) > a",
-        "department for international trade": "#footer > .site-links > ul > li:nth-child(5) > a"
+        "department for international trade": "#footer > .site-links > ul > li:nth-child(5) > a",
+        "copyright": "#footer > div.global-footer > p > span"
     }
 }
 

--- a/tests/exred/pages/home.py
+++ b/tests/exred/pages/home.py
@@ -19,14 +19,14 @@ from utils import (
 NAME = "ExRed Home"
 URL = urljoin(EXRED_UI_URL, "?lang=en-gb")
 
-GET_STARTED_BUTTON = ".triage a.button-cta"
-CONTINUE_EXPORT_JOURNEY = ".triage a.button-cta"
-NEW_TO_EXPORTING_LINK = "#personas div:nth-child(1) > div > a"
-OCCASIONAL_EXPORTER_LINK = "#personas div:nth-child(2) > div > a"
-REGULAR_EXPORTED_LINK = "#personas div:nth-child(3) > div > a"
-FIND_A_BUYER_SERVICE_LINK = "#services div:nth-child(1) > article > a"
-ONLINE_MARKETPLACES_SERVICE_LINK = "#services div:nth-child(2) > article > a"
-EXPORT_OPPORTUNITIES_SERVICE_LINK = "#services div:nth-child(3) > article > a"
+GET_STARTED_BUTTON = "#triage-section-get-started"
+CONTINUE_EXPORT_JOURNEY = "#triage-section-continue-your-journey"
+NEW_TO_EXPORTING_LINK = "#personas-section-new"
+OCCASIONAL_EXPORTER_LINK = "#personas-section-occasional"
+REGULAR_EXPORTED_LINK = "#personas-section-regular"
+FIND_A_BUYER_SERVICE_LINK = "#services-section-find-a-buyer-link"
+SELLING_ONLINE_OVERSEAS_SERVICE_LINK = "#services-section-selling-online-overseas-link"
+EXPORT_OPPORTUNITIES_SERVICE_LINK = "#services-section-export-opportunities-link"
 CAROUSEL_INDICATORS_SECTION = "#carousel  div.ed-carousel__indicators"
 CAROUSEL_INDICATORS = ".ed-carousel__indicator"
 CAROUSEL_PREV_BUTTON = "#carousel label.ed-carousel__control--backward"
@@ -36,31 +36,47 @@ CAROUSEL_SECOND_INDICATOR = ".ed-carousel__indicator[for='2']"
 CAROUSEL_THIRD_INDICATOR = ".ed-carousel__indicator[for='3']"
 CASE_STUDIES_LINK = "#carousel h3 > a"
 CASE_STUDY_LINK = "#carousel div.ed-carousel__slide:nth-child({}) h3 > a"
-MARKET_RESEARCH_LINK = "#resource-guidance div:nth-child(1) > div > a"
-CUSTOMER_INSIGHT_LINK = "#resource-guidance div:nth-child(2) > div > a"
-FINANCE_LINK = "#resource-guidance div:nth-child(3) > div > a"
-BUSINESS_LINK = "#resource-guidance div:nth-child(4) > div > a"
-GETTING_PAID_LINK = "#resource-guidance div:nth-child(5) > div > a"
-OPERATIONS_AND_COMPLIANCE_LINK = "#resource-guidance div:nth-child(6) > div > a"
+MARKET_RESEARCH_LINK = "#guidance-market-research-link"
+CUSTOMER_INSIGHT_LINK = "#guidance-section-customer-insight-link"
+FINANCE_LINK = "#guidance-section-finance-link"
+BUSINESS_LINK = "#guidance-section-business-planning-link"
+GETTING_PAID_LINK = "#guidance-section-getting-paid-link"
+OPERATIONS_AND_COMPLIANCE_LINK = "#guidance-section-operations-and-compliance-link"
+CAROUSEL = {
+    "itself": "#carousel",
+    "title": "#case-studies-section-title",
+    "description": "#case-studies-section-description",
+    "carousel_previous_button": CAROUSEL_PREV_BUTTON,
+    "carousel_next_button": CAROUSEL_NEXT_BUTTON,
+    "carousel - indicator 1": "#case-studies-section-indicator-1",
+    "carousel - indicator 2": "#case-studies-section-indicator-2",
+    "carousel - indicator 3": "#case-studies-section-indicator-3",
+    "carousel - case study 1 - link": "#case-studies-section-case-study-1-link",
+    "carousel - case study 2 - link": "#case-studies-section-case-study-2-link",
+    "carousel - case study 3 - link": "#case-studies-section-case-study-3-link",
+    "carousel - case study 1 - image": "#case-studies-section-case-study-1-image",
+    "carousel - case study 2 - image": "#case-studies-section-case-study-2-image",
+    "carousel - case study 3 - image": "#case-studies-section-case-study-3-image",
+}
 
 SECTIONS = {
-    "video": {
-        "itself": "section.hero-campaign-section > div > div",
-        "teaser_title": "section.hero-campaign-section > div > div > h1",
-        "teaser description": "section.hero-campaign-section > div > div > p:nth-child(2)",
-        "teaser_logo": "section.hero-campaign-section picture > img",
+    "hero": {
+        "itself": "#content > section.hero-campaign-section",
+        "title": "#hero-campaign-section-title",
+        "description": "#hero-campaign-section-description",
+        "logo": "#hero-campaign-section-eig-logo",
     },
     "exporting journey": {
         "itself": "#content > section.triage.triage-section",
-        "heading": "#content > section.triage.triage-section .heading",
-        "introduction": "#content > section.triage.triage-section .intro",
+        "heading": "#triage-section-title",
+        "introduction": "#triage-section-description",
         "get_started_button": GET_STARTED_BUTTON,
-        "image": "section.triage.triage-section  picture > img"
+        "image": "#triage-section-image"
     },
     "export readiness": {
         "itself": "#personas",
-        "header": "#personas > .container > .header",
-        "intro": "#personas > .container > .intro",
+        "title": "#personas-section-title",
+        "description": "#personas-section-description",
         "groups": "#personas > .container > .group",
         "new": NEW_TO_EXPORTING_LINK,
         "occasional": OCCASIONAL_EXPORTER_LINK,
@@ -68,12 +84,50 @@ SECTIONS = {
         "i'm new to exporting": NEW_TO_EXPORTING_LINK,
         "i export occasionally": OCCASIONAL_EXPORTER_LINK,
         "i'm a regular exporter": REGULAR_EXPORTED_LINK,
+        "new exporter - image": "#personas-section-new-image",
+        "occasional exporter - image": "#personas-section-occasional-image",
+        "regular exporter - image": "#personas-section-regular-image",
     },
     "guidance": {
         "itself": "#resource-guidance",
-        "header": "#resource-guidance .section-header",
-        "intro": "#resource-guidance .intro",
+        "title": "#guidance-section-title",
+        "description": "#guidance-section-description",
         "groups": "#resource-guidance .group",
+        "market research - group": "#guidance-section-market-research",
+        "customer insight - group": "#guidance-section-customer-insight",
+        "finance - group": "#guidance-section-finance",
+        "business planning - group": "#guidance-section-business-planning",
+        "getting paid - group": "#guidance-section-getting-paid",
+        "operations and compliance - group": "#guidance-section-operations-and-compliance",
+
+        "market research - icon": "#guidance-section-market-research-icon",
+        "customer insight - icon": "#guidance-section-customer-insight-icon",
+        "finance - icon": "#guidance-section-finance-icon",
+        "business planning - icon": "#guidance-section-business-planning-icon",
+        "getting paid - icon": "#guidance-section-getting-paid-icon",
+        "operations and compliance - icon": "#guidance-section-operations-and-compliance-icon",
+
+        "market research - read counter": "#guidance-section-market-research-read-counter",
+        "customer insight - read counter": "#guidance-section-customer-insight-read-counter",
+        "finance - read counter": "#guidance-section-finance-article-read-counter",
+        "business planning - read counter": "#guidance-section-business-planning-article-read-counter",
+        "getting paid - read counter": "#guidance-section-getting-paid-article-read-counter",
+        "operations and compliance - read counter": "#guidance-section-operations-and-compliance-article-read-counter",
+
+        "market research - total number of articles": "#guidance-section-market-research-total-number-of-articles",
+        "customer insight - total number of articles": "#guidance-section-customer-insight-total-number-of-articles",
+        "finance - total number of articles": "#guidance-section-finance-total-number-of-articles",
+        "business planning - total number of articles": "#guidance-section-business-planning-total-number-of-articles",
+        "getting paid - total number of articles": "#guidance-section-getting-paid-total-number-of-articles",
+        "operations and compliance - total number of articles": "#guidance-section-operations-and-compliance-total-number-of-articles",
+
+        "market research - description": "#guidance-section-market-research-description",
+        "customer insight - description": "#guidance-section-customer-insight-description",
+        "finance - description": "#guidance-section-finance-description",
+        "business planning - description": "#guidance-section-business-planning-description",
+        "getting paid - description": "#guidance-section-getting-paid-description",
+        "operations and compliance - description": "#guidance-section-operations-and-compliance-description",
+
         "market research": MARKET_RESEARCH_LINK,
         "customer insight": CUSTOMER_INSIGHT_LINK,
         "finance": FINANCE_LINK,
@@ -83,21 +137,48 @@ SECTIONS = {
     },
     "services": {
         "itself": "#services",
-        "intro": "#services .intro",
+        "title": "#services-section-title",
+        "description": "#services-section-description",
         "groups": "#services .group",
-        "find_a_buyer_service": "#services div:nth-child(1) > article",
-        "online_marketplaces_service": "#services div:nth-child(2) > article",
-        "export_opportunities_service": "#services div:nth-child(3) > article",
+
+        "find a buyer - article": "#services div:nth-child(1) > article",
+        "online marketplaces - article": "#services div:nth-child(2) > article",
+        "export opportunities - article": "#services div:nth-child(3) > article",
+
+        "find a buyer - image": "#services-section-find-a-buyer-image",
+        "online marketplaces - image": "#services-section-selling-online-overseas-image",
+        "export opportunities - image": "#services-section-export-opportunities-image",
+
+        "find a buyer - description": "#services-section-find-a-buyer-description",
+        "online marketplaces - description": "#services-section-selling-online-overseas-description",
+        "export opportunities - description": "#services-section-export-opportunities-description",
+
         "find a buyer": FIND_A_BUYER_SERVICE_LINK,
-        "selling online overseas": ONLINE_MARKETPLACES_SERVICE_LINK,
+        "selling online overseas": SELLING_ONLINE_OVERSEAS_SERVICE_LINK,
         "export opportunities": EXPORT_OPPORTUNITIES_SERVICE_LINK,
     },
     "case studies": {
         "itself": "#carousel",
-        "heading": "#carousel .heading",
-        "intro": "#carousel .intro",
+        "title": "#case-studies-section-title",
+        "description": "#case-studies-section-description",
         "carousel_previous_button": CAROUSEL_PREV_BUTTON,
-        "carousel_next_button": CAROUSEL_NEXT_BUTTON
+        "carousel_next_button": CAROUSEL_NEXT_BUTTON,
+        "carousel - indicator 1": "#case-studies-section-indicator-1",
+        "carousel - indicator 2": "#case-studies-section-indicator-2",
+        "carousel - indicator 3": "#case-studies-section-indicator-3",
+        "carousel - case study 1 - link": "#case-studies-section-case-study-1-link",
+        "carousel - case study 1 - image": "#case-studies-section-case-study-1-image",
+    },
+    "business is great": {
+        "itself": "#beis",
+        "title": "#business-is-great-title",
+        # "image": "#business-is-great-image",
+        "description": "#business-is-great-description",
+        "link": "#business-is-great-link",
+    },
+    "error reporting": {
+        "itself": "section.error-reporting",
+        "link": "#error-reporting-section-contact-us"
     }
 }
 

--- a/tests/exred/pages/home.py
+++ b/tests/exred/pages/home.py
@@ -60,6 +60,12 @@ CAROUSEL = {
 }
 
 SECTIONS = {
+    "beta": {
+        "itself": "#content > div.beta",
+        "sticker": "#content > div.beta > div > div.sticker",
+        "message": "#content > div.beta > div > p.beta-message",
+        "link": "#content > div.beta > div > p.beta-message > a"
+    },
     "hero": {
         "itself": "#content > section.hero-campaign-section",
         "title": "#hero-campaign-section-title",

--- a/tests/exred/pages/triage_summary.py
+++ b/tests/exred/pages/triage_summary.py
@@ -6,7 +6,7 @@ from urllib.parse import urljoin
 from selenium import webdriver
 
 from settings import EXRED_UI_URL
-from utils import assertion_msg, take_screenshot
+from utils import assertion_msg, find_element, take_screenshot
 
 NAME = "ExRed Triage - summary"
 URL = urljoin(EXRED_UI_URL, "triage/summary")
@@ -84,3 +84,10 @@ def change_answers(driver: webdriver):
     link = driver.find_element_by_css_selector(CHANGE_ANSWERS_LINK)
     link.click()
     take_screenshot(driver, NAME + " after deciding to change the answers")
+
+
+def should_see_change_your_answers_link(driver: webdriver):
+    take_screenshot(driver, NAME + " change your answers")
+    change_answers_link = find_element(driver, by_css=CHANGE_ANSWERS_LINK)
+    with assertion_msg("Expected to see 'Change your answers' link"):
+        assert change_answers_link.is_displayed()

--- a/tests/exred/steps/given_def.py
+++ b/tests/exred/steps/given_def.py
@@ -14,6 +14,7 @@ from steps.when_impl import (
     articles_open_first,
     articles_open_group,
     articles_read_a_number_of_them,
+    case_studies_go_to_random,
     export_readiness_open_category,
     get_geo_ip,
     guidance_open_category,
@@ -184,3 +185,8 @@ def given_actor_checks_the_goeip(context, actor_alias):
 @given('"{actor_alias}" is signed in')
 def given_actor_is_signed_in(context, actor_alias, *, location="top bar"):
     sign_in(context, actor_alias, location)
+
+
+@given('"{actor_alias}" is on the Case Study page accessed via "{page_name}" page')
+def given_actor_is_on_random_case_study_page(context, actor_alias, page_name):
+    case_studies_go_to_random(context, actor_alias, page_name)

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -37,6 +37,7 @@ from steps.then_impl import (
     share_page_should_be_prepopulated,
     share_page_via_email_should_have_article_details,
     should_be_on_page,
+    should_not_see_sections,
     should_see_links_to_services,
     should_see_sections,
     should_see_sections_on_home_page,
@@ -144,6 +145,12 @@ def then_expected_export_readiness_page_elements_should_be_visible(
 @then('"{actor_alias}" should see "{sections}" sections on "{page_name}" page')
 def then_should_see_sections(context, actor_alias, sections, page_name):
     should_see_sections(context, actor_alias, sections.split(", "), page_name)
+
+
+@then('"{actor_alias}" should not see "{sections}" section on "{page_name}" page')
+@then('"{actor_alias}" should not see "{sections}" sections on "{page_name}" page')
+def then_should_not_see_sections(context, actor_alias, sections, page_name):
+    should_not_see_sections(context, actor_alias, sections.split(", "), page_name)
 
 
 @then('"{actor_alias}" should be able to navigate to the next article from the List following the Article Order')

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -42,7 +42,8 @@ from steps.then_impl import (
     should_see_sections,
     should_see_sections_on_home_page,
     should_see_share_widget,
-    triage_should_be_classified_as
+    triage_should_be_classified_as,
+    triage_should_see_change_your_answers_link
 )
 from steps.when_impl import (
     triage_answer_questions_again,
@@ -280,3 +281,8 @@ def then_share_page_should_be_prepopulated(context, actor_alias, social_media):
 @then('"{actor_alias}" should see that the share via email link will pre-populate the message subject and body with Article title and URL')
 def then_check_share_via_email_link(context, actor_alias):
     share_page_via_email_should_have_article_details(context, actor_alias)
+
+
+@then('"{actor_alias}" should see an option to change his triage answers')
+def then_actor_should_see_option_to_change_triage_answers(context, actor_alias):
+    triage_should_see_change_your_answers_link(context, actor_alias)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -173,6 +173,16 @@ def should_see_sections(
             page_name)
 
 
+def should_not_see_sections(
+        context: Context, actor_alias: str, sections: list, page_name: str):
+    page = get_page_object(page_name)
+    for section in sections:
+        page.should_not_see_section(context.driver, section)
+        logging.debug(
+            "As expected %s cannot see '%s' section on %s page", actor_alias,
+            section, page_name)
+
+
 def articles_should_see_in_correct_order(context: Context, actor_alias: str):
     actor = get_actor(context, actor_alias)
     group = actor.article_group

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -128,14 +128,14 @@ def personalised_should_see_layout_for(
     incorporated = actor.are_you_incorporated
     online_marketplaces = actor.do_you_use_online_marketplaces
     code, _ = actor.what_do_you_want_to_export
-    if classification == "new":
+    if classification.lower() == "new":
         personalised_journey.layout_for_new_exporter(
             context.driver, incorporated=incorporated, sector_code=code)
-    elif classification == "occasional":
+    elif classification.lower() == "occasional":
         personalised_journey.layout_for_occasional_exporter(
             context.driver, incorporated=incorporated,
             use_online_marketplaces=online_marketplaces, sector_code=code)
-    elif classification == "regular":
+    elif classification.lower() == "regular":
         personalised_journey.layout_for_regular_exporter(
             context.driver, incorporated=incorporated, sector_code=code)
     else:

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -11,7 +11,8 @@ from pages import (
     get_finance,
     guidance_common,
     home,
-    personalised_journey
+    personalised_journey,
+    triage_summary
 )
 from registry.articles import get_article, get_articles
 from registry.pages import get_page_object
@@ -422,3 +423,9 @@ def share_page_via_email_should_have_article_details(
     logging.debug(
         "%s checked that the 'share via email' link contain correct subject: "
         "'%s' and message body: '%s'", actor_alias, subject, body)
+
+
+def triage_should_see_change_your_answers_link(
+        context: Context, actor_alias: str):
+    triage_summary.should_see_change_your_answers_link(context.driver)
+    logging.debug("%s can see 'change your answers' link", actor_alias)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -849,6 +849,13 @@ def case_studies_go_to(context: Context, actor_alias: str, case_number: str):
         case_study_title)
 
 
+def case_studies_go_to_random(context, actor_alias, page_name):
+    assert page_name.lower() in ["home"]
+    visit_page(context, actor_alias, page_name)
+    case_number = random.choice(["first", "second", "third"])
+    case_studies_go_to(context, actor_alias, case_number)
+
+
 def open_link(
         context: Context, actor_alias: str, group: str, category: str,
         location: str):


### PR DESCRIPTION
These tickets:
* [ED-2656](https://uktrade.atlassian.net/browse/ED-2656)
* [ED-2593](https://uktrade.atlassian.net/browse/ED-2593)
* [ED-2591](https://uktrade.atlassian.net/browse/ED-2591)


Scenario:
```gherkin
  @ED-2656
  @<social-media>
  Scenario Outline: Any Exporter should be able to share the Case Study Article via "<social-media>"
    Given "Robert" is on the Case Study page accessed via "Home" page

    When "Robert" decides to share the article via "<social-media>"

    Then "Robert" should be taken to a new tab with the "<social-media>" share page opened
    And "Robert" should that "<social-media>" share page has been pre-populated with message and the link to the article

    Examples:
      | social-media |
      | Facebook     |
      | Twitter      |
      | LinkedIn     |


  @ED-2656
  @email
  Scenario: Any Exporter should be able to share the Case Study Article via Email
    Given "Robert" is on the Case Study page accessed via "Home" page

    When "Robert" decides to share the article via "email"

    Then "Robert" should see that the share via email link will pre-populate the message subject and body with Article title and URL

  @ED-2593
  @personalised-page
  @case-studies
  Scenario Outline: "<relevant>" Exporter should get to a "<selected>" case study from Case Studies carousel on the personalised journey page
    Given "Robert" was classified as "<relevant>" exporter in the triage process
    And "Robert" decided to create his personalised journey page

    When "Robert" goes to the "<selected>" Case Study via carousel

    Then "Robert" should see "<selected>" case study
    And "Robert" should see the Share Widget

    Examples:
      | relevant   | selected |
      | New        | First    |
      | Occasional | Second   |


  @ED-2593
  @personalised-page
  @case-studies
  Scenario Outline: "<relevant>" Exporter should not see Case Studies carousel on the personalised journey page
    Given "Robert" was classified as "<relevant>" exporter in the triage process

    When "Robert" decides to create her personalised journey page

    Then "Robert" should be on the Personalised Journey page for "<relevant>" exporters
    And "Robert" should not see "case studies" sections on "personalised journey" page

    Examples:
      | relevant |
      | Regular  |


  @ED-2591
  @triage
  @change-answers
  @personalised-page
  Scenario Outline: "<relevant>" Exporter should be able to update preferences from personalised journey page
    Given "Robert" was classified as "<relevant>" exporter in the triage process
    And "Robert" decided to create her personalised journey page

    When "Robert" decides to update his triage preferences

    Then "Robert" should be on the "Triage - Summary" page
    And "Robert" should see an option to change his triage answers

    Examples:
      | relevant   |
      | New        |
      | Occasional |
      | Regular    |
```
