### PR TITLE
ED-3112 Improve stability of FAB & ExRed tests & Update scenario tags

### DIFF
--- a/tests/exred/environment.py
+++ b/tests/exred/environment.py
@@ -100,7 +100,8 @@ def after_feature(context: Context, feature: Feature):
             message = ("Feature '%s' failed. Reason: '%s': '%s'" %
                        (feature.name, feature.exception, feature.error_message))
             logging.error(message)
-            logging.debug(context.scenario_data)
+            if hasattr(context, "scenario_data"):
+                logging.debug(context.scenario_data)
             if "browserstack" in CONFIG_NAME:
                 if hasattr(context, "driver"):
                     session_id = context.driver.session_id

--- a/tests/exred/features/accessing-services.feature
+++ b/tests/exred/features/accessing-services.feature
@@ -40,6 +40,7 @@ Feature: Accessing Services
   @wip
   @out-of-scope
   @ED-2660
+  @ED-3089
   @home-page
   @accessing-services
   @interim-pages

--- a/tests/exred/pages/header.py
+++ b/tests/exred/pages/header.py
@@ -113,7 +113,8 @@ def open(driver: webdriver, group: str, element: str):
 
 
 def go_to_registration(driver: webdriver):
-    registration_link = find_element(driver, by_css=REGISTRATION_LINK)
+    registration_link = find_element(
+        driver, by_css=REGISTRATION_LINK, wait_for_it=False)
     registration_link.click()
 
 

--- a/tests/exred/pages/header.py
+++ b/tests/exred/pages/header.py
@@ -8,8 +8,7 @@ from selenium.webdriver.common.keys import Keys
 from utils import (
     assertion_msg,
     find_element,
-    take_screenshot,
-    wait_for_visibility
+    take_screenshot
 )
 
 NAME = "ExRed Header"
@@ -65,7 +64,6 @@ def should_see_all_links(driver: webdriver):
                 "Looking for '%s' element in '%s' section with '%s' selector",
                 element_name, section, element_selector)
             element = find_element(driver, by_css=element_selector)
-            wait_for_visibility(driver, by_css=element_selector)
             with assertion_msg(
                     "It looks like '%s' in '%s' section is not visible",
                     element_name, section):
@@ -83,7 +81,6 @@ def should_see_link_to(driver: webdriver, section: str, item_name: str):
         menu = find_element(driver, by_css=menu_selector)
         menu.send_keys(Keys.ENTER)
     menu_item = find_element(driver, by_css=item_selector)
-    wait_for_visibility(driver, by_css=item_selector)
     with assertion_msg(
             "It looks like '%s' in '%s' section is not visible", item_name,
             section):
@@ -108,7 +105,6 @@ def open(driver: webdriver, group: str, element: str):
         menu.send_keys(Keys.ENTER)
     menu_item_selector = SECTIONS[group.lower()][element.lower()]
     menu_item = find_element(driver, by_css=menu_item_selector)
-    wait_for_visibility(driver, by_css=menu_item_selector)
     with assertion_msg("%s menu item: '%s' is not visible", group, element):
         assert menu_item.is_displayed()
     menu_item.click()

--- a/tests/exred/pages/home.py
+++ b/tests/exred/pages/home.py
@@ -14,8 +14,7 @@ from utils import (
     find_element,
     find_elements,
     selenium_action,
-    take_screenshot,
-    wait_for_visibility
+    take_screenshot
 )
 
 NAME = "ExRed Home"
@@ -340,7 +339,6 @@ def open_case_study(driver: webdriver, case_number: str):
             find_case_study_by_going_right(driver, case_study_number)
 
     link_selector = CASE_STUDY_LINK.format(case_study_number)
-    wait_for_visibility(driver, by_css=link_selector)
     case_study_link = find_element(driver, by_css=link_selector)
     case_study_link.click()
 

--- a/tests/exred/pages/home.py
+++ b/tests/exred/pages/home.py
@@ -347,7 +347,8 @@ def get_case_study_title(driver: webdriver, case_number: str) -> str:
     case_study_numbers = {"first": 1, "second": 2, "third": 3}
     case_number = case_study_numbers[case_number.lower()]
     link_selector = CASE_STUDY_LINK.format(case_number)
-    case_study_link = find_element(driver, by_css=link_selector)
+    case_study_link = find_element(
+        driver, by_css=link_selector, wait_for_it=False)
     return case_study_link.text.strip()
 
 

--- a/tests/exred/pages/selling_online_overseas.py
+++ b/tests/exred/pages/selling_online_overseas.py
@@ -9,8 +9,7 @@ from settings import SELLING_ONLINE_OVERSEAS_UI_URL
 from utils import (
     assertion_msg,
     find_element,
-    take_screenshot,
-    wait_for_visibility
+    take_screenshot
 )
 
 NAME = "Selling Online Overseas Home page"
@@ -31,7 +30,6 @@ def should_be_here(driver: webdriver):
         assert driver.title.lower() == PAGE_TITLE.lower()
     for element_name, element_selector in EXPECTED_ELEMENTS.items():
         element = find_element(driver, by_css=element_selector)
-        wait_for_visibility(driver, by_css=element_selector)
         with assertion_msg(
                 "It looks like '%s' element is not visible on %s",
                 element_name, NAME):

--- a/tests/exred/pages/share_on_facebook.py
+++ b/tests/exred/pages/share_on_facebook.py
@@ -9,8 +9,7 @@ from selenium import webdriver
 from utils import (
     assertion_msg,
     find_element,
-    take_screenshot,
-    wait_for_visibility
+    take_screenshot
 )
 
 NAME = "Share on Facebook page"
@@ -30,7 +29,6 @@ def should_be_here(driver: webdriver):
         assert driver.title.lower() == PAGE_TITLE.lower()
     for element_name, element_selector in EXPECTED_ELEMENTS.items():
         element = find_element(driver, by_css=element_selector)
-        wait_for_visibility(driver, by_css=element_selector)
         with assertion_msg(
                 "It looks like '%s' element is not visible on %s",
                 element_name, NAME):

--- a/tests/exred/pages/share_on_linkedin.py
+++ b/tests/exred/pages/share_on_linkedin.py
@@ -9,8 +9,7 @@ from selenium import webdriver
 from utils import (
     assertion_msg,
     find_element,
-    take_screenshot,
-    wait_for_visibility
+    take_screenshot
 )
 
 NAME = "Share on LinkedIn page"
@@ -30,7 +29,6 @@ def should_be_here(driver: webdriver):
         assert driver.title.lower() == PAGE_TITLE.lower()
     for element_name, element_selector in EXPECTED_ELEMENTS.items():
         element = find_element(driver, by_css=element_selector)
-        wait_for_visibility(driver, by_css=element_selector)
         with assertion_msg(
                 "It looks like '%s' element is not visible on %s",
                 element_name, NAME):

--- a/tests/exred/pages/share_on_twitter.py
+++ b/tests/exred/pages/share_on_twitter.py
@@ -8,8 +8,7 @@ from selenium import webdriver
 from utils import (
     assertion_msg,
     find_element,
-    take_screenshot,
-    wait_for_visibility
+    take_screenshot
 )
 
 NAME = "Share on Twitter page"
@@ -31,7 +30,6 @@ def should_be_here(driver: webdriver):
         assert driver.title.lower() == PAGE_TITLE.lower()
     for element_name, element_selector in EXPECTED_ELEMENTS.items():
         element = find_element(driver, by_css=element_selector)
-        wait_for_visibility(driver, by_css=element_selector)
         with assertion_msg(
                 "It looks like '%s' element is not visible on %s",
                 element_name, NAME):

--- a/tests/exred/pages/sso_registration.py
+++ b/tests/exred/pages/sso_registration.py
@@ -45,7 +45,7 @@ def fill_out(driver: webdriver, email: str, password: str):
     password_input = find_element(driver, by_css=PASSWORD_INPUT)
     password_confirmation_input = find_element(
         driver, by_css=PASSWORD_CONFIRMATION_INPUT)
-    t_and_c = find_element(driver, by_css=T_AND_C_BUTTON)
+    t_and_c = find_element(driver, by_css=T_AND_C_BUTTON, wait_for_it=False)
     email_input.clear()
     email_input.send_keys(email)
     email_confirmation_input.clear()

--- a/tests/exred/utils/__init__.py
+++ b/tests/exred/utils/__init__.py
@@ -302,6 +302,7 @@ def check_if_element_is_not_present(
     :param driver: Selenium driver
     :param by_css: CSS selector to locate the element to wait for
     :param by_id: ID of the element to wait for
+    :param element_name: human friendly name of the element used in log msg
     :return: found WebElement
     """
     assert by_id or by_css, "Provide ID or CSS selector"
@@ -321,13 +322,16 @@ def check_if_element_is_not_present(
 
 def find_element(
         driver: webdriver, *, by_css: str = None,
-        by_id: str = None, element_name: str = "") -> WebElement:
+        by_id: str = None, element_name: str = "",
+        wait_for_it: bool = True) -> WebElement:
     """Find element by CSS selector or it's ID.
 
     :param driver: Selenium driver
     :param by_css: CSS selector to locate the element to wait for
     :param by_id: ID of the element to wait for
     :param element_name: (optional) human friend element name
+    :param wait_for_it: (optional) flag to decide whether you want to wait for
+                        the visibility of the element
     :return: found WebElement
     """
     assert by_id or by_css, "Provide ID or CSS selector"
@@ -338,6 +342,8 @@ def find_element(
             element = driver.find_element_by_css_selector(by_css)
         else:
             element = driver.find_element_by_id(by_id)
+    if wait_for_it:
+        wait_for_visibility(driver, by_css=by_css, by_id=by_id)
     return element
 
 

--- a/tests/functional/features/fab/profile.feature
+++ b/tests/functional/features/fab/profile.feature
@@ -437,7 +437,7 @@ Feature: Trade Profile
   @fake-sso-email-verification
   @bug
   @ED-3040
-  @fixme
+  @fixed
   @found-with-automated-tests
   Scenario: Supplier should be able to update a case study for an unverified company
     Given "Peter Alder" created an unverified profile for randomly selected company "Y"
@@ -455,7 +455,7 @@ Feature: Trade Profile
   @fake-sso-email-verification
   @bug
   @ED-3040
-  @fixme
+  @fixed
   @found-with-automated-tests
   Scenario: Supplier should be able to update a case study for a verified company
     Given "Peter Alder" has created and verified profile for randomly selected company "Y"
@@ -474,7 +474,7 @@ Feature: Trade Profile
   @fake-sso-email-verification
   @bug
   @ED-3040
-  @fixme
+  @fixed
   @found-with-automated-tests
   Scenario: Supplier should be able to update multiple case studies for an unverified company
     Given "Peter Alder" created an unverified profile for randomly selected company "Y"
@@ -496,7 +496,7 @@ Feature: Trade Profile
   @fake-sso-email-verification
   @bug
   @ED-3040
-  @fixme
+  @fixed
   @found-with-automated-tests
   Scenario: Supplier should be able to update multiple case studies for a verified company
     Given "Peter Alder" has created and verified profile for randomly selected company "Y"

--- a/tests/functional/features/fab/profile.feature
+++ b/tests/functional/features/fab/profile.feature
@@ -338,7 +338,7 @@ Feature: Trade Profile
     @profile
     @bug
     @ED-1833
-    @fixme
+    @fixed
     @fake-sso-email-verification
     Scenario: Supplier should NOT be able to use invalid links to Online Profiles (social media URLs)
       Given "Peter Alder" has created and verified profile for randomly selected company "Y"

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -99,6 +99,8 @@ def select_random_company(
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
+    max_attempts = 15
+    counter = 0
 
     while True:
         # Step 1 - find an active company without a FAS profile
@@ -108,6 +110,12 @@ def select_random_company(
         response = fab_ui_confirm_company.go_to(session, company)
         registered = is_already_registered(response)
         inactive = is_inactive(response)
+        counter += 1
+        if counter >= max_attempts:
+            with assertion_msg(
+                    "Failed to find an active company which is not registered "
+                    "with FAB after %d attempts", max_attempts):
+                assert False
         if registered or inactive:
             logging.warning(
                 "Company '%s' is already registered or inactive, will use "

--- a/tests/functional/utils/db_utils.py
+++ b/tests/functional/utils/db_utils.py
@@ -53,7 +53,7 @@ companyID INTEGER;
 BEGIN
     -- STEP 0 - get company ID (need to explicitly cast it to Integer)
     actor_email := %s;
-    companyID := (SELECT company_id::INTEGER FROM user_user WHERE company_email = actor_email);
+    companyID := (SELECT company_id::INTEGER FROM supplier_supplier WHERE company_email = actor_email);
     -- STEP 1 - delete all possible notifications
     DELETE FROM notifications_supplieremailnotification WHERE supplier_id = companyID;
     DELETE FROM notifications_anonymousunsubscribe WHERE email = actor_email;


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-3112)

- fix db clean-up scripts
- improve ExRed UI test reliability by adding an implicit "wait for visibility" action executed of every attempt of finding a web element
- other minor tweaks