### PR TITLE
ED-3149 change language on international & domestic page

### DIFF
--- a/makefile
+++ b/makefile
@@ -100,15 +100,15 @@ smoke_tests:
 	pytest tests/smoke $(pytest_args)
 
 SET_PYLINK_CHECKER_ENV_VARS_PROD := \
-	export IGNORED_PREFIXES="https://www.linkedin.com/shareArticle,https://twitter.com/intent/tweet,http://www.yellow.com,https://www.contactus.trade.gov.uk,https://trade.great.gov.uk/search/,https://trade.great.gov.uk/suppliers/" && \
+	export IGNORED_PREFIXES="http://www.kwintessential.co.uk/resources/guides/,https://www.ukbaa.org.uk/,http://gb.kompass.com/,https://ico.org.uk/concerns/getting/,http://www.iata.org/whatwedo/cargo/e/efreight/Pages/index.aspx,https://developer.google.com/,http://www.yellow.com,https://www.contactus.trade.gov.uk,https://trade.great.gov.uk/search/,https://trade.great.gov.uk/suppliers/" && \
 	export TEST_URLS="https://www.great.gov.uk/ https://www.export.great.gov.uk/ https://find-a-buyer.export.great.gov.uk/ https://sso.trade.great.gov.uk/accounts/login/ https://trade.great.gov.uk/ https://profile.great.gov.uk/about/"
 
 SET_PYLINK_CHECKER_ENV_VARS_STAGE := \
-	export IGNORED_PREFIXES="https://www.linkedin.com/shareArticle,https://twitter.com/intent/tweet,http://www.yellow.com,https://www.contactus.trade.gov.uk,https://stage.supplier.directory.uktrade.io/search/,https://stage.supplier.directory.uktrade.io/suppliers/" && \
+	export IGNORED_PREFIXES="http://www.kwintessential.co.uk/resources/guides/,https://www.ukbaa.org.uk/,http://gb.kompass.com/,https://ico.org.uk/concerns/getting/,http://www.iata.org/whatwedo/cargo/e/efreight/Pages/index.aspx,https://developer.google.com/,http://www.yellow.com,https://www.contactus.trade.gov.uk,https://stage.supplier.directory.uktrade.io/search/,https://stage.supplier.directory.uktrade.io/suppliers/" && \
 	export TEST_URLS="https://export.great.uat.uktrade.io/ https://stage.buyer.directory.uktrade.io/ https://stage.sso.uktrade.io/accounts/login/  https://stage.profile.uktrade.io/about/"
 
 SET_PYLINK_CHECKER_ENV_VARS_DEV := \
-	export IGNORED_PREFIXES="http://www.yellow.com,https://www.contactus.trade.gov.uk,https://dev.supplier.directory.uktrade.io/search/,https://dev.supplier.directory.uktrade.io/suppliers/" && \
+	export IGNORED_PREFIXES="http://www.kwintessential.co.uk/resources/guides/,https://www.ukbaa.org.uk/,http://gb.kompass.com/,https://ico.org.uk/concerns/getting/,http://www.iata.org/whatwedo/cargo/e/efreight/Pages/index.aspx,https://developer.google.com/,http://www.yellow.com,https://www.contactus.trade.gov.uk,https://dev.supplier.directory.uktrade.io/search/,https://dev.supplier.directory.uktrade.io/suppliers/" && \
 	export TEST_URLS="https://dev.exportreadiness.directory.uktrade.io/ https://dev.buyer.directory.uktrade.io/ https://www.dev.sso.uktrade.io/accounts/login/  https://dev.profile.uktrade.io/about/"
 
 # default to DEV environment if TEST_ENV is not set

--- a/makefile
+++ b/makefile
@@ -108,7 +108,7 @@ SET_PYLINK_CHECKER_ENV_VARS_STAGE := \
 	export TEST_URLS="https://export.great.uat.uktrade.io/ https://stage.buyer.directory.uktrade.io/ https://stage.sso.uktrade.io/accounts/login/  https://stage.profile.uktrade.io/about/"
 
 SET_PYLINK_CHECKER_ENV_VARS_DEV := \
-	export IGNORED_PREFIXES="https://www.linkedin.com/shareArticle,https://twitter.com/intent/tweet,http://www.yellow.com,https://www.contactus.trade.gov.uk,https://dev.supplier.directory.uktrade.io/search/,https://dev.supplier.directory.uktrade.io/suppliers/" && \
+	export IGNORED_PREFIXES="http://www.yellow.com,https://www.contactus.trade.gov.uk,https://dev.supplier.directory.uktrade.io/search/,https://dev.supplier.directory.uktrade.io/suppliers/" && \
 	export TEST_URLS="https://dev.exportreadiness.directory.uktrade.io/ https://dev.buyer.directory.uktrade.io/ https://www.dev.sso.uktrade.io/accounts/login/  https://dev.profile.uktrade.io/about/"
 
 # default to DEV environment if TEST_ENV is not set
@@ -119,13 +119,13 @@ smoke_tests_links_checker:
 	echo "Running pylinkchecker agaisnt: $${TEST_URLS} environment" && \
 	pylinkvalidate.py \
 	    --progress \
-	    --timeout=35 \
+	    --timeout=55 \
 	    --depth=2 \
 	    --workers=10 \
 	    --types=a \
 	    --test-outside \
 	    --parser=lxml \
-	    --header="User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.97 Safari/537.36 Vivaldi/1.94.1008.36" \
+	    --header="User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; FSL 7.0.6.01001)" \
 	    --ignore="$${IGNORED_PREFIXES}" \
 	    $${TEST_URLS}
 

--- a/tests/exred/features/home-page.feature
+++ b/tests/exred/features/home-page.feature
@@ -72,7 +72,7 @@ Feature: Home Page
     Then "Robert" should not see the window with promotional video
 
 
-  @wip
+  @ED-3083
   @language-selector
   Scenario: Visitor should be able to open and close the language selector
     Given "Robert" visits the "Home" page
@@ -84,7 +84,7 @@ Feature: Home Page
     Then "Robert" should not see the language selector
 
 
-  @wip
+  @ED-3083
   @language-selector
   @accessibility
   Scenario: Keyboard users should be able to open and close the language selector using just the keyboard
@@ -97,7 +97,7 @@ Feature: Home Page
     Then "Robert" should not see the language selector
 
 
-  @wip
+  @ED-3083
   @language-selector
   @accessibility
   Scenario: Language selector should trap the keyboard in order to help Keyboard users to navigate
@@ -109,21 +109,22 @@ Feature: Home Page
     Then "Robert"'s keyboard should be trapped to the language selector
 
 
-  @wip
+  @ED-3083
   @language-selector
-  Scenario Outline: Visitors should be able to view International page in "<preferred_language>"
-    Given "Robert" visits the "International" page
+  Scenario Outline: Visitors should be able to view go to International page after changing language to "<preferred_language>" on the Domestic Home Page
+    Given "Robert" visits the "Home" page
 
-    When "Robert" decides to view the "International" page in "<preferred_language>"
+    When "Robert" decides to view the page in "<preferred_language>"
 
-    Then "Robert" should see the "International" page in "<preferred_language>"
+    Then "Robert" should be on the "International" page
+    And "Robert" should see the page in "<preferred_language>"
 
     Examples: available languages
-      | language     |
-      | English      |
-      | 简体中文     |
-      | Deutsch      |
-      | 日本語       |
-      | Español      |
-      | Português    |
-      | العربيّة     |
+      | preferred_language |
+      | English            |
+      | 简体中文            |
+      | Deutsch            |
+      | 日本語              |
+      | Español            |
+      | Português          |
+      | العربيّة            |

--- a/tests/exred/features/international-page.feature
+++ b/tests/exred/features/international-page.feature
@@ -64,34 +64,35 @@ Feature: International Page
     Then "Robert"'s keyboard should be trapped to the language selector
 
 
-  @wip
+  @ED-3149
   @language-selector
   Scenario Outline: Visitors should be able to view International page in "<preferred_language>"
     Given "Robert" visits the "International" page
 
-    When "Robert" decides to view the "International" page in "<preferred_language>"
+    When "Robert" decides to view the page in "<preferred_language>"
 
-    Then "Robert" should see the "International" page in "<preferred_language>"
+    Then "Robert" should be on the "International" page
+    And "Robert" should see the page in "<preferred_language>"
 
     Examples: available languages
-      | language     |
-      | English      |
-      | 简体中文     |
-      | Deutsch      |
-      | 日本語       |
-      | Español      |
-      | Português    |
-      | العربيّة     |
+      | preferred_language |
+      | English            |
+      | 简体中文            |
+      | Deutsch            |
+      | 日本語              |
+      | Español            |
+      | Português          |
+      | العربيّة            |
 
 
-  @wip
+  @ED-3149
   @language-selector
   Scenario: Visitors should be able to "get guidance and services to help them export" (visit ExRed) from International page
     Given "Robert" visits the "International" page
 
-    When "Robert" decides to view the International page in "English (UK)"
+    When "Robert" decides to view the page in "English (UK)"
 
-    Then "Robert" should be on the "ExRed Home" page
+    Then "Robert" should be on the "Home" page
 
 
   @wip

--- a/tests/exred/pages/language_selector.py
+++ b/tests/exred/pages/language_selector.py
@@ -16,6 +16,7 @@ from utils import (
 
 NAME = "Language selector"
 
+LANGUAGE_INDICATOR = "#header-bar span.lang"
 LANGUAGE_SELECTOR_OPEN = "#header-bar a.LanguageSelectorDialog-Tracker"
 LANGUAGE_SELECTOR_CLOSE = "#header-language-selector-close"
 DOMESTIC_PAGE = "section.language-selector-dialog div.domestic-redirect > p > a"
@@ -75,6 +76,16 @@ KEYBOARD_NAVIGABLE_ELEMENTS = {
         ("domestic page", DOMESTIC_PAGE),
         ("close", LANGUAGE_SELECTOR_CLOSE),
     ]
+}
+LANGUAGE_INDICATOR_VALUES = {
+    "English": "en-gb",
+    "English (UK)": "en-gb",
+    "简体中文": "zh-hans",
+    "Deutsch": "de",
+    "日本語": "ja",
+    "Español": "es",
+    "Português": "pt",
+    "العربيّة": "ar",
 }
 
 
@@ -148,3 +159,13 @@ def change_to(
         language_button.send_keys(Keys.ENTER)
     else:
         language_button.click()
+
+
+def check_page_language_is(driver: webdriver, expected_language: str):
+    expected_language_code = LANGUAGE_INDICATOR_VALUES[expected_language]
+    language_indicator = find_element(driver, by_css=LANGUAGE_INDICATOR)
+    language_indicator_code = language_indicator.text.lower()
+    with assertion_msg(
+            "Expected to see page in '%s' but got '%s'",
+            expected_language_code, language_indicator_code):
+        assert language_indicator_code == expected_language_code

--- a/tests/exred/pages/language_selector.py
+++ b/tests/exred/pages/language_selector.py
@@ -42,7 +42,7 @@ ELEMENTS_ON = {
     "international": {
         "itself": "section.language-selector-dialog",
         "title": "#great-languages-selector",
-        "domestic page": DOMESTIC_PAGE,
+        "English (UK)": DOMESTIC_PAGE,
         "English": ENGLISH,
         "简体中文": CHINESE,
         "Deutsch": GERMAN,
@@ -137,3 +137,14 @@ def keyboard_should_be_trapped(driver: webdriver, page_name: str):
     number_of_navigation_iterations = 2
     for _ in range(number_of_navigation_iterations):
         navigate_through_links_with_keyboard(driver, page_name)
+
+
+def change_to(
+        driver: webdriver, page_name: str, language: str, *,
+        with_keyboard: bool = False):
+    language_selector = ELEMENTS_ON[page_name.lower()][language]
+    language_button = find_element(driver, by_css=language_selector)
+    if with_keyboard:
+        language_button.send_keys(Keys.ENTER)
+    else:
+        language_button.click()

--- a/tests/exred/registry/articles.py
+++ b/tests/exred/registry/articles.py
@@ -154,7 +154,7 @@ USE_FREIGHT_FORWARDER = Article(
     time_to_read=0
 )
 USE_INCOTERMS_IN_CONTRACTS = Article(
-    title='User incoterms in contracts',
+    title='Use incoterms in contracts',
     time_to_read=0
 )
 GET_YOUR_EXPORT_DOCUMENTS_RIGHT = Article(

--- a/tests/exred/steps/then_def.py
+++ b/tests/exred/steps/then_def.py
@@ -45,6 +45,7 @@ from steps.then_impl import (
     should_be_on_page,
     should_not_see_sections,
     should_see_links_to_services,
+    should_see_page_in_preferred_language,
     should_see_sections,
     should_see_share_widget,
     triage_should_be_classified_as,
@@ -317,3 +318,9 @@ def then_actor_should_not_see_language_selector(context, actor_alias):
 @then('"{actor_alias}"\'s keyboard should be trapped to the language selector')
 def then_keyboard_should_be_trapped_to_language_selector(context, actor_alias):
     language_selector_keyboard_should_be_trapped(context, actor_alias)
+
+
+@then('"{actor_alias}" should see the page in "{preferred_language}"')
+def then_page_language_should_be(context, actor_alias, preferred_language):
+    should_see_page_in_preferred_language(
+        context, actor_alias, preferred_language)

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -475,3 +475,8 @@ def language_selector_keyboard_should_be_trapped(
     visited_page = actor.visited_page
     language_selector.keyboard_should_be_trapped(
         context.driver, page_name=visited_page)
+
+
+def should_see_page_in_preferred_language(
+        context: Context, actor_alias: str, preferred_language: str):
+    language_selector.check_page_language_is(context.driver, preferred_language)

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -18,6 +18,7 @@ from steps.when_impl import (
     export_readiness_open_category,
     guidance_open_category,
     guidance_read_through_all_articles,
+    language_selector_change_to,
     language_selector_close,
     language_selector_navigate_through_links_with_keyboard,
     language_selector_open,
@@ -299,3 +300,9 @@ def when_actor_closes_language_selector_with_keyboard(context, actor_alias):
 def when_actor_navigates_through_language_selector_links_with_keyboard(
         context, actor_alias):
     language_selector_navigate_through_links_with_keyboard(context, actor_alias)
+
+
+@when('"{actor_alias}" decides to view the page in "{preferred_language}"')
+def when_actor_views_page_in_selected_language(
+        context, actor_alias, preferred_language):
+    language_selector_change_to(context, actor_alias, preferred_language)

--- a/tests/exred/steps/when_impl.py
+++ b/tests/exred/steps/when_impl.py
@@ -1111,3 +1111,15 @@ def language_selector_navigate_through_links_with_keyboard(
     visited_page = actor.visited_page
     language_selector.navigate_through_links_with_keyboard(
         context.driver, page_name=visited_page)
+
+
+def language_selector_change_to(
+        context: Context, actor_alias: str, preferred_language: str):
+    actor = get_actor(context, actor_alias)
+    visited_page = actor.visited_page
+    logging.debug(
+        "%s decided to change language on %s to %s", actor_alias, visited_page,
+        preferred_language)
+    language_selector_open(context, actor_alias)
+    language_selector.change_to(
+        context.driver, visited_page, preferred_language)


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-3149)

Scenarios:
```gherkin
  @ED-3149
  @language-selector
  Scenario Outline: Visitors should be able to view International page in "<preferred_language>"
    Given "Robert" visits the "International" page

    When "Robert" decides to view the page in "<preferred_language>"

    Then "Robert" should be on the "International" page
    And "Robert" should see the page in "<preferred_language>"

    Examples: available languages
      | preferred_language |
      | English            |
      | 简体中文            |
      | Deutsch            |
      | 日本語              |
      | Español            |
      | Português          |
      | العربيّة            |


  @ED-3149
  @language-selector
  Scenario: Visitors should be able to "get guidance and services to help them export" (visit ExRed) from International page
    Given "Robert" visits the "International" page

    When "Robert" decides to view the page in "English (UK)"

    Then "Robert" should be on the "Home" page
```

Apart from that with a minimal effort, four scenarios for this ticket [@ED-3083](https://uktrade.atlassian.net/browse/ED-3083) were also added:
```gherkin
  @ED-3083
  @language-selector
  Scenario: Visitor should be able to open and close the language selector
    Given "Robert" visits the "Home" page

    When "Robert" opens up the language selector
    Then "Robert" should see the language selector

    When "Robert" closes the language selector
    Then "Robert" should not see the language selector


  @ED-3083
  @language-selector
  @accessibility
  Scenario: Keyboard users should be able to open and close the language selector using just the keyboard
    Given "Robert" visits the "Home" page

    When "Robert" opens up the language selector using his keyboard
    Then "Robert" should see the language selector

    When "Robert" closes the language selector using his keyboard
    Then "Robert" should not see the language selector


  @ED-3083
  @language-selector
  @accessibility
  Scenario: Language selector should trap the keyboard in order to help Keyboard users to navigate
    Given "Robert" visits the "Home" page

    When "Robert" opens up the language selector using his keyboard
    And "Robert" uses his keyboard to navigate through all links visible on language selector

    Then "Robert"'s keyboard should be trapped to the language selector


  @ED-3083
  @language-selector
  Scenario Outline: Visitors should be able to view go to International page after changing language to "<preferred_language>" on the Domestic Home Page
    Given "Robert" visits the "Home" page

    When "Robert" decides to view the page in "<preferred_language>"

    Then "Robert" should be on the "International" page
    And "Robert" should see the page in "<preferred_language>"

    Examples: available languages
      | preferred_language |
      | English            |
      | 简体中文            |
      | Deutsch            |
      | 日本語              |
      | Español            |
      | Português          |
      | العربيّة            
```