### PR TITLE
ED-3222 remaining scenarios for your export journey link

### DIFF
--- a/tests/exred/features/header-footer.feature
+++ b/tests/exred/features/header-footer.feature
@@ -237,4 +237,18 @@ Feature: Header-Footer
 
     Then "Robert" should be on the "Personalised Journey" page
     And "Robert" should not see "Save Progress" section on "Personalised Journey" page
+
+
+  @ED-3287
+  @<group>
+  @articles
   @your-export-journey-link
+  Scenario Outline: Any user who has not signed-in should be asked to register or sign-in whilst being on the Article List page
+    Given "Robert" is on the "<group>" Article List for randomly selected category
+
+    Then "Robert" should see "Save Progress" section on "Article List" page
+
+    Examples: article groups
+      | group            |
+      | Export Readiness |
+      | Guidance         |

--- a/tests/exred/features/header-footer.feature
+++ b/tests/exred/features/header-footer.feature
@@ -147,17 +147,38 @@ Feature: Header-Footer
     Then "Robert" should not see "Save Progress" section on "Create your export journey" page
 
 
-  @wip
-  @ED-2737
+  @ED-3283
   @your-export-journey-link
-  Scenario: Any user who has completed triage should be able to get to the custom page from the header
-    Given "Robert" has completed the triage questions
-    When "Robert" goes to his export journey via appropriate header link
-    Then "Robert" should be on the "Custom" page
+  @<specific>
+  Scenario Outline: Any user who has created his/her "Personalised Journey page" should be able to return to it using "Your export journey" link
+    Given "Robert" answered triage questions
+    And "Robert" decided to create his personalised journey page
+    And "Robert" is on the "Personalised Journey" page
+    And "Robert" goes to the "<specific>" page
 
+    When "Robert" decides to use "Your export journey" link in "header menu"
 
-  @wip
-  @ED-2737
+    Then "Robert" should be on the "Personalised Journey" page
+
+    Examples:
+      | specific                     |
+      | Home                         |
+      | Interim Export Opportunities |
+      | Export Opportunities         |
+
+    @bug
+    @ED-3282
+    @fixme
+    Examples: header needs to be updated
+      | specific                     |
+      | Selling Online Overseas      |
+
+    @bug
+    @ED-3242
+    @fixme
+    Examples: header needs to be updated
+      | specific                     |
+      | Find a Buyer                 |
   @your-export-journey-link
   Scenario: Any user who hasn’t signed in should be asked to register or sign in, in the Guidance section of the custom page.
     Given "Robert" is not a registered user

--- a/tests/exred/features/header-footer.feature
+++ b/tests/exred/features/header-footer.feature
@@ -212,9 +212,17 @@ Feature: Header-Footer
     Examples: header needs to be updated
       | specific                     |
       | Find a Buyer                 |
+
+
+  @ED-3285
   @your-export-journey-link
+  Scenario: Any user who has created his/her "Personalised Journey page" and hasn't signed-in should be asked to register or sign-in, in the Guidance section on the Personalised Journey page.
+    Given "Robert" answered triage questions
 
+    When "Robert" decides to create his personalised journey page
 
+    Then "Robert" should be on the "Personalised Journey" page
+    And "Robert" should see "Save Progress" section on "Personalised Journey" page
   @your-export-journey-link
 
 

--- a/tests/exred/features/header-footer.feature
+++ b/tests/exred/features/header-footer.feature
@@ -223,7 +223,18 @@ Feature: Header-Footer
 
     Then "Robert" should be on the "Personalised Journey" page
     And "Robert" should see "Save Progress" section on "Personalised Journey" page
+
+
+  @ED-3286
   @your-export-journey-link
+  @fake-sso-email-verification
+  Scenario: Any signed-in user who has created his/her "Personalised Journey page" should not be asked to register or sign-in, in the Guidance section on the Personalised Journey page.
+    Given "Robert" is a registered and verified user
+    And "Robert" is signed in
+    And "Robert" answered triage questions
 
+    When "Robert" decides to create his personalised journey page
 
+    Then "Robert" should be on the "Personalised Journey" page
+    And "Robert" should not see "Save Progress" section on "Personalised Journey" page
   @your-export-journey-link

--- a/tests/exred/features/header-footer.feature
+++ b/tests/exred/features/header-footer.feature
@@ -179,15 +179,39 @@ Feature: Header-Footer
     Examples: header needs to be updated
       | specific                     |
       | Find a Buyer                 |
+
+
+  @ED-3284
   @your-export-journey-link
-  Scenario: Any user who hasn’t signed in should be asked to register or sign in, in the Guidance section of the custom page.
-    Given "Robert" is not a registered user
-    When "Robert" visits the "Custom" page
-    Then "Robert" should see registration text in the "Guidance" section
+  @<specific>
+  Scenario Outline: Any user who has completed triage (without creating Personalised Journey page) should be redirected to "Create your export journey" page when using related header link
+    Given "Robert" answered triage questions
+    And "Robert" is on the "Triage - summary" page
+    And "Robert" goes to the "<specific>" page
 
+    When "Robert" decides to use "Your export journey" link in "header menu"
 
-  @wip
-  @ED-2737
+    Then "Robert" should be on the "Create your export journey" page
+
+    Examples:
+      | specific                     |
+      | Home                         |
+      | Interim Export Opportunities |
+      | Export Opportunities         |
+
+    @bug
+    @ED-3282
+    @fixme
+    Examples: header needs to be updated
+      | specific                     |
+      | Selling Online Overseas      |
+
+    @bug
+    @ED-3242
+    @fixme
+    Examples: header needs to be updated
+      | specific                     |
+      | Find a Buyer                 |
   @your-export-journey-link
   Scenario: Any user who signed in should not be asked to register or sign in in the Guidance section of the custom page.
     Given "Robert" is not a registered user

--- a/tests/exred/features/header-footer.feature
+++ b/tests/exred/features/header-footer.feature
@@ -252,3 +252,21 @@ Feature: Header-Footer
       | group            |
       | Export Readiness |
       | Guidance         |
+
+
+  @ED-3288
+  @<group>
+  @articles
+  @your-export-journey-link
+  Scenario Outline: Any user who has not signed-in should be asked to register or sign-in whilst being on the the Article page
+    Given "Robert" is on the "<group>" Article List for randomly selected category
+    And "Robert" shows all of the articles on the page whenever possible
+
+    When "Robert" opens any article on the list
+
+    Then "Robert" should see "Save Progress" section on "Article" page
+
+    Examples: article groups
+      | group            |
+      | Export Readiness |
+      | Guidance         |

--- a/tests/exred/features/header-footer.feature
+++ b/tests/exred/features/header-footer.feature
@@ -213,25 +213,9 @@ Feature: Header-Footer
       | specific                     |
       | Find a Buyer                 |
   @your-export-journey-link
-  Scenario: Any user who signed in should not be asked to register or sign in in the Guidance section of the custom page.
-    Given "Robert" is not a registered user
-    When "Robert" visits the "Custom" page
-    Then "Robert" should not see registration text in the "Guidance" section
 
 
-  @wip
-  @ED-2737
   @your-export-journey-link
-  Scenario: Any user who hasn’t signed in should be asked to register in the article pages
-    Given "Robert" is not a registered user
-    When "Robert" visits any "Article" page
-    Then "Robert" should see registration text
 
 
-  @wip
-  @ED-2737
   @your-export-journey-link
-  Scenario: Any user who signed in should not be told to register in article pages
-    Given "Robert" is a registered user
-    When "Robert" visits any "Article" page
-    Then "Robert" should not see registration text

--- a/tests/exred/features/header-footer.feature
+++ b/tests/exred/features/header-footer.feature
@@ -270,3 +270,22 @@ Feature: Header-Footer
       | group            |
       | Export Readiness |
       | Guidance         |
+
+
+  @ED-3289
+  @<group>
+  @articles
+  @your-export-journey-link
+  @fake-sso-email-verification
+  Scenario Outline: Any user who signed in should not be told to Register or Sign-in whilst being on the Article List page
+    Given "Robert" is a registered and verified user
+    And "Robert" is signed in
+
+    When "Robert" goes to randomly selected "<group>" Article category
+
+    Then "Robert" should not see "Save Progress" section on "Article List" page
+
+    Examples: article groups
+      | group            |
+      | Export Readiness |
+      | Guidance         |

--- a/tests/exred/features/header-footer.feature
+++ b/tests/exred/features/header-footer.feature
@@ -289,3 +289,23 @@ Feature: Header-Footer
       | group            |
       | Export Readiness |
       | Guidance         |
+
+
+  @ED-3290
+  @<group>
+  @articles
+  @your-export-journey-link
+  @fake-sso-email-verification
+  Scenario Outline: Any user who signed in should not be told to Register or Sign-in whilst being on the Article page
+    Given "Robert" is a registered and verified user
+    And "Robert" is signed in
+
+    When "Robert" goes to randomly selected "<group>" Article category
+    And "Robert" opens any article on the list
+
+    Then "Robert" should not see "Save Progress" section on "Article" page
+
+    Examples: article groups
+      | group            |
+      | Export Readiness |
+      | Guidance         |

--- a/tests/exred/pages/article_common.py
+++ b/tests/exred/pages/article_common.py
@@ -132,20 +132,6 @@ def check_if_link_to_next_article_is_displayed(
             assert link.text.lower() == next_article.lower()
 
 
-def check_elements_are_visible(driver: webdriver, elements: list):
-    take_screenshot(driver, NAME)
-    for element in elements:
-        selector = SCOPE_ELEMENTS[element.lower()]
-        page_element = find_element(
-            driver, by_css=selector, element_name=element)
-        if "firefox" not in driver.capabilities["browserName"].lower():
-            logging.debug("Moving focus to '%s' element", element)
-            action_chains = ActionChains(driver)
-            action_chains.move_to_element(page_element)
-            action_chains.perform()
-        check_if_element_is_visible(page_element, element_name=element)
-
-
 def go_to_article(driver: webdriver, title: str):
     with selenium_action(driver, "Could not find article: %s", title):
         article = driver.find_element_by_link_text(title)
@@ -187,11 +173,6 @@ def should_not_see_link_to_next_article(driver: webdriver):
     check_if_element_is_not_visible(
         driver, by_css=NEXT_ARTICLE_LINK,
         element_name="Link to the next article")
-
-
-def should_not_see_personas_end_page(driver: webdriver):
-    """Check if Actor is stil on an Article page."""
-    check_elements_are_visible(driver, ["article name"])
 
 
 def go_back_to_article_list(driver: webdriver):

--- a/tests/exred/pages/personalised_journey.py
+++ b/tests/exred/pages/personalised_journey.py
@@ -37,6 +37,8 @@ TOP_IMPORTER = "#top_importer_name"
 TOP_IMPORTERS = "#content > section.top-markets > div > ol > li > dl"
 TRADE_VALUE = "#top_importer_global_trade_value"
 TOP_10_TRADE_VALUE = ".cell-global_trade_value"
+REGISTER = "#articles > div > div.scope-indicator > p > a:nth-child(1)"
+SIGN_IN = "#articles > div > div.scope-indicator > p > a:nth-child(2)"
 SECTIONS = {
     "hero": {
         "title": "section.hero-section h1",
@@ -112,6 +114,10 @@ SECTIONS = {
         "business planning": BUSINESS_LINK,
         "getting paid": GETTING_PAID_LINK,
         "operations and compliance": OPERATIONS_AND_COMPLIANCE_LINK,
+    },
+    "save progress": {
+        "register link": REGISTER,
+        "sign-in link": SIGN_IN
     },
     "case studies": {
         "heading": "#carousel h2",

--- a/tests/exred/pages/triage_create_your_export_journey.py
+++ b/tests/exred/pages/triage_create_your_export_journey.py
@@ -16,7 +16,7 @@ from settings import EXRED_UI_URL
 from utils import check_if_element_is_not_visible, take_screenshot
 
 NAME = "Create your export journey"
-URL = urljoin(EXRED_UI_URL, "custom/")
+URL = urljoin(EXRED_UI_URL, "triage/")
 PAGE_TITLE = "Your export journey - great.gov.uk"
 
 START_NOW = "#start-now-container > a"

--- a/tests/exred/steps/then_impl.py
+++ b/tests/exred/steps/then_impl.py
@@ -211,7 +211,7 @@ def articles_should_not_see_link_to_next_article(
 
 def articles_should_not_see_personas_end_page(
         context: Context, actor_alias: str):
-    article_common.should_not_see_personas_end_page(context.driver)
+    article_common.should_be_here(context.driver)
 
 
 def articles_should_see_link_to_first_article_from_next_category(

--- a/tests/exred/steps/when_def.py
+++ b/tests/exred/steps/when_def.py
@@ -261,6 +261,11 @@ def when_actor_is_on_article_list(context, actor_alias, group, location):
     articles_open_group(context, actor_alias, group, location=location)
 
 
+@when('"{actor_alias}" goes to randomly selected "{group}" Article category')
+def when_actor_goes_to_random_article_group(context, actor_alias, group):
+    articles_open_group(context, actor_alias, group)
+
+
 @when('"{actor_alias}" decides to share the article via "{social_media}"')
 def when_actor_shares_article(context, actor_alias, social_media):
     articles_share_on_social_media(context, actor_alias, social_media)


### PR DESCRIPTION
This PR includes 8 scenarios from this [ticket](https://uktrade.atlassian.net/browse/ED-3222)

* [ED-3283](https://uktrade.atlassian.net/browse/ED-3283)
* [ED-3284](https://uktrade.atlassian.net/browse/ED-3284)
* [ED-3285](https://uktrade.atlassian.net/browse/ED-3285)
* [ED-3286](https://uktrade.atlassian.net/browse/ED-3286)
* [ED-3287](https://uktrade.atlassian.net/browse/ED-3287)
* [ED-3288](https://uktrade.atlassian.net/browse/ED-3288)
* [ED-3289](https://uktrade.atlassian.net/browse/ED-3289)
* [ED-3290](https://uktrade.atlassian.net/browse/ED-3290)

Scenarios:
```gherkin
  @ED-3283
  @your-export-journey-link
  @<specific>
  Scenario Outline: Any user who has created his/her "Personalised Journey page" should be able to return to it using "Your export journey" link
    Given "Robert" answered triage questions
    And "Robert" decided to create his personalised journey page
    And "Robert" is on the "Personalised Journey" page
    And "Robert" goes to the "<specific>" page

    When "Robert" decides to use "Your export journey" link in "header menu"

    Then "Robert" should be on the "Personalised Journey" page

    Examples:
      | specific                     |
      | Home                         |
      | Interim Export Opportunities |
      | Export Opportunities         |

    @bug
    @ED-3282
    @fixme
    Examples: header needs to be updated
      | specific                     |
      | Selling Online Overseas      |

    @bug
    @ED-3242
    @fixme
    Examples: header needs to be updated
      | specific                     |
      | Find a Buyer                 |
```
```gherkin
  @ED-3284
  @your-export-journey-link
  @<specific>
  Scenario Outline: Any user who has completed triage (without creating Personalised Journey page) should be redirected to "Create your export journey" page when using related header link
    Given "Robert" answered triage questions
    And "Robert" is on the "Triage - summary" page
    And "Robert" goes to the "<specific>" page

    When "Robert" decides to use "Your export journey" link in "header menu"

    Then "Robert" should be on the "Create your export journey" page

    Examples:
      | specific                     |
      | Home                         |
      | Interim Export Opportunities |
      | Export Opportunities         |

    @bug
    @ED-3282
    @fixme
    Examples: header needs to be updated
      | specific                     |
      | Selling Online Overseas      |

    @bug
    @ED-3242
    @fixme
    Examples: header needs to be updated
      | specific                     |
      | Find a Buyer                 |
```
```gherkin
  @ED-3285
  @your-export-journey-link
  Scenario: Any user who has created his/her "Personalised Journey page" and hasn't signed-in should be asked to register or sign-in, in the Guidance section on the Personalised Journey page.
    Given "Robert" answered triage questions

    When "Robert" decides to create his personalised journey page

    Then "Robert" should be on the "Personalised Journey" page
    And "Robert" should see "Save Progress" section on "Personalised Journey" page
```
```gherkin
  @ED-3286
  @your-export-journey-link
  @fake-sso-email-verification
  Scenario: Any signed-in user who has created his/her "Personalised Journey page" should not be asked to register or sign-in, in the Guidance section on the Personalised Journey page.
    Given "Robert" is a registered and verified user
    And "Robert" is signed in
    And "Robert" answered triage questions

    When "Robert" decides to create his personalised journey page

    Then "Robert" should be on the "Personalised Journey" page
    And "Robert" should not see "Save Progress" section on "Personalised Journey" page
```
```gherkin
  @ED-3287
  @<group>
  @articles
  @your-export-journey-link
  Scenario Outline: Any user who has not signed-in should be asked to register or sign-in whilst being on the Article List page
    Given "Robert" is on the "<group>" Article List for randomly selected category

    Then "Robert" should see "Save Progress" section on "Article List" page

    Examples: article groups
      | group            |
      | Export Readiness |
      | Guidance         |
```
```gherkin
  @ED-3288
  @<group>
  @articles
  @your-export-journey-link
  Scenario Outline: Any user who has not signed-in should be asked to register or sign-in whilst being on the the Article page
    Given "Robert" is on the "<group>" Article List for randomly selected category
    And "Robert" shows all of the articles on the page whenever possible

    When "Robert" opens any article on the list

    Then "Robert" should see "Save Progress" section on "Article" page

    Examples: article groups
      | group            |
      | Export Readiness |
      | Guidance         |
```
```gherkin
  @ED-3289
  @<group>
  @articles
  @your-export-journey-link
  @fake-sso-email-verification
  Scenario Outline: Any user who signed in should not be told to Register or Sign-in whilst being on the Article List page
    Given "Robert" is a registered and verified user
    And "Robert" is signed in

    When "Robert" goes to randomly selected "<group>" Article category

    Then "Robert" should not see "Save Progress" section on "Article List" page

    Examples: article groups
      | group            |
      | Export Readiness |
      | Guidance         |
```
```gherkin
  @ED-3290
  @<group>
  @articles
  @your-export-journey-link
  @fake-sso-email-verification
  Scenario Outline: Any user who signed in should not be told to Register or Sign-in whilst being on the Article page
    Given "Robert" is a registered and verified user
    And "Robert" is signed in

    When "Robert" goes to randomly selected "<group>" Article category
    And "Robert" opens any article on the list

    Then "Robert" should not see "Save Progress" section on "Article" page

    Examples: article groups
      | group            |
      | Export Readiness |
      | Guidance         |
```