### PR TITLE
[DNM] ED-3556 add collaborator without a SSO/great.gov.uk account

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -51,6 +51,7 @@ urls = {
     'ui-buyer:company-edit-sectors': 'company-profile/edit/sectors/',
     'ui-buyer:company-edit-contact': 'company-profile/edit/contact/',
     'ui-buyer:company-edit-social-media': 'company-profile/edit/social-media/',
+    'ui-buyer:account-add-collaborator': 'account/add-collaborator/',
 
     # UI-SUPPLIER
     'ui-supplier:landing': '',

--- a/tests/functional/features/fab/multiuser-accounts.feature
+++ b/tests/functional/features/fab/multiuser-accounts.feature
@@ -1,4 +1,3 @@
-@wip
 @multi-user
 Feature: Multi-user accounts
 
@@ -12,16 +11,17 @@ Feature: Multi-user accounts
 
     When "Peter Alder" decides to add "Annette Geissinger" as a collaborator
 
-    Then "Annette" should receive an email with a request for becoming a collaborator to company "Y" profile
+    Then "Annette Geissinger" should receive an email with a request for becoming a collaborator to company "Y" profile
 
     Examples:
-      | has or does not have | a             |
-      | has                  | a verified    |
-      | has                  | an unverified |
-      | does not have        | a verified    |
-      | does not have        | an unverified |
+      | a             | has or does not have |
+      | a verified    | has                  |
+      | a verified    | does not have        |
+      | an unverified | has                  |
+      | an unverified | does not have        |
 
 
+  @wip
   @ED-3555
   @multi-user
   @add-collaborator
@@ -37,6 +37,7 @@ Feature: Multi-user accounts
     Then "Annette Geissinger" should be on "Edit Company profile" page
 
 
+  @wip
   @ED-3556
   @multi-user
   @add-collaborator
@@ -51,6 +52,7 @@ Feature: Multi-user accounts
     Then "Annette Geissinger" should be on "SSO registration" page
 
 
+  @wip
   @ED-3557
   @multi-user
   @add-collaborator
@@ -68,6 +70,7 @@ Feature: Multi-user accounts
     Then "Annette Geissinger" should be on "Edit Company profile" page
 
 
+  @wip
   @ED-3558
   @multi-user
   @add-collaborator
@@ -80,6 +83,7 @@ Feature: Multi-user accounts
     Then "Annette Geissinger, Betty Jones, James Weir" should receive an email with a request for becoming a collaborator to company "Y" profile
 
 
+  @wip
   @ED-3559
   @multi-user
   @add-collaborator
@@ -99,7 +103,7 @@ Feature: Multi-user accounts
     And "James Weir" should be on "Edit Company profile" page
 
 
-
+  @wip
   @ED-3560
   @multi-user
   @add-collaborator
@@ -113,6 +117,7 @@ Feature: Multi-user accounts
     Then "Annette Geissinger" should not see options to manage account users on "SSO - Find a buyer" page
 
 
+  @wip
   @ED-3561
   @multi-user
   @transfer-ownership
@@ -133,6 +138,7 @@ Feature: Multi-user accounts
       | does not have        | an unverified |
 
 
+  @wip
   @ED-3562
   @multi-user
   @transfer-ownership
@@ -154,6 +160,7 @@ Feature: Multi-user accounts
       | does not have        | an unverified |
 
 
+  @wip
   @ED-3564
   @multi-user
   @remove-collaborator
@@ -169,6 +176,7 @@ Feature: Multi-user accounts
     And "Annette Geissinger" should not be able to access "Edit profile" page
 
 
+  @wip
   @ED-3565
   @multi-user
   @remove-collaborator
@@ -186,6 +194,7 @@ Feature: Multi-user accounts
     And "James Weir" should not be able to access "Edit profile" page
 
 
+  @wip
   @ED-3566
   @multi-user
   @transfer-ownership
@@ -203,6 +212,7 @@ Feature: Multi-user accounts
     And "Annette Geissinger" should be told that her company is published
 
 
+  @wip
   @ED-3567
   @multi-user
   @add-content
@@ -237,6 +247,7 @@ Feature: Multi-user accounts
       | sector of interest          |
 
 
+  @wip
   @ED-3568
   @multi-user
   @add-content
@@ -256,6 +267,7 @@ Feature: Multi-user accounts
       | Anfiteatro_El_Jem.jpeg |
 
 
+  @wip
   @ED-3569
   @multi-user
   @add-content
@@ -271,6 +283,7 @@ Feature: Multi-user accounts
     And "Annette Geissinger" should see all case studies on the FAS Company's Directory Profile page
 
 
+  @wip
   @ED-3570
   @multi-user
   @edge-case
@@ -287,6 +300,7 @@ Feature: Multi-user accounts
     And "Annette Geissinger" should not see options to manage account users on "SSO - Find a buyer" page
 
 
+  @wip
   @ED-3571
   @multi-user
   @edge-case
@@ -302,6 +316,7 @@ Feature: Multi-user accounts
     Then "Peter Alder" should be on "Edit Company profile" page
 
 
+  @wip
   @ED-3572
   @multi-user
   @edge-case
@@ -315,6 +330,7 @@ Feature: Multi-user accounts
     Then "Annette" should receive an email with a request for becoming a collaborator to company "Y" profile
 
 
+  @wip
   @ED-3573
   @multi-user
   @edge-case

--- a/tests/functional/features/fab/multiuser-accounts.feature
+++ b/tests/functional/features/fab/multiuser-accounts.feature
@@ -31,7 +31,7 @@ Feature: Multi-user accounts
     And "Peter Alder" added "Annette Geissinger" as a collaborator
     And "Annette Geissinger" has received an email with a request to confirm that she's been added to company "Y" Find a Buyer profile
 
-    When "Annette Geissinger" confirms that she wants to collaborate with company "Y" profile
+    When "Annette Geissinger" confirms that she wants to be added to the company "Y" Find a Buyer profile
 
     Then "Annette Geissinger" should see "FAB Company profile" page
 

--- a/tests/functional/features/fab/multiuser-accounts.feature
+++ b/tests/functional/features/fab/multiuser-accounts.feature
@@ -1,0 +1,330 @@
+@wip
+@multi-user
+Feature: Multi-user accounts
+
+
+  @ED-3554
+  @multi-user
+  @add-collaborator
+  Scenario Outline: Invited collaborator should receive an email with an invitation to collaborate to "<a>" company profile
+    Given "Peter Alder" has created "<a>" profile for randomly selected company "Y"
+    And "Annette Geissinger" "<has or does not have>" an SSO/great.gov.uk account
+
+    When "Peter Alder" decides to add "Annette Geissinger" as a collaborator
+
+    Then "Annette" should receive an email with a request for becoming a collaborator to company "Y" profile
+
+    Examples:
+      | has or does not have | a             |
+      | has                  | a verified    |
+      | has                  | an unverified |
+      | does not have        | a verified    |
+      | does not have        | an unverified |
+
+
+  @ED-3555
+  @multi-user
+  @add-collaborator
+  Scenario: Add "1" collaborator with an SSO/great.gov.uk account to a verified company
+    Given "Peter Alder" has created and verified profile for randomly selected company "Y"
+    And "Annette Geissinger" has a verified standalone SSO/great.gov.uk account
+    And "Annette Geissinger" is signed in to SSO/great.gov.uk account
+    And "Peter Alder" added "Annette Geissinger" as a collaborator
+    And "Annette Geissinger" has received an email with a request for becoming a collaborator to company "Y" profile
+
+    When "Annette Geissinger" confirms that she wants to become a collaborator to company "Y" profile
+
+    Then "Annette Geissinger" should be on "Edit Company profile" page
+
+
+  @ED-3556
+  @multi-user
+  @add-collaborator
+  Scenario: Add "1" collaborator without an SSO/great.gov.uk account to a verified company
+    Given "Peter Alder" has created and verified profile for randomly selected company "Y"
+    And "Annette Geissinger" "does not have" an SSO/great.gov.uk account
+    And "Peter Alder" added "Annette Geissinger" as a collaborator
+    And "Annette Geissinger" has received an email with a request for becoming a collaborator to company "Y" profile
+
+    When "Annette Geissinger" decides to confirm that she wants to become a collaborator to company "Y" profile
+
+    Then "Annette Geissinger" should be on "SSO registration" page
+
+
+  @ED-3557
+  @multi-user
+  @add-collaborator
+  Scenario: Add "1" collaborator without an SSO/great.gov.uk account to a verified company
+    Given "Peter Alder" has created and verified profile for randomly selected company "Y"
+    And "Annette Geissinger" "does not have" an SSO/great.gov.uk account
+    And "Peter Alder" added "Annette Geissinger" as a collaborator to company "Y" profile
+    And "Annette Geissinger" has received an email with a request for becoming a collaborator to company "Y" profile
+    And "Annette Geissinger" decides to confirm that she wants to be added to the profile
+    And "Annette Geissinger" should be on "SSO registration" page
+
+    When "Annette Geissinger" creates an SSO/great.gov.uk account
+    And "Annette Geissinger" confirms that she wants to be added to the profile
+
+    Then "Annette Geissinger" should be on "Edit Company profile" page
+
+
+  @ED-3558
+  @multi-user
+  @add-collaborator
+  Scenario: Invited collaborators should receive an email with an invitation to collaborate
+    Given "Peter Alder" has created "an unverified" profile for randomly selected company "Y"
+    And "Annette Geissinger, Betty Jones, James Weir" "does not have" a SSO/great.gov.uk account
+
+    When "Peter Alder" decides to add "Annette Geissinger, Betty Jones, James Weir" as a collaborator
+
+    Then "Annette Geissinger, Betty Jones, James Weir" should receive an email with a request for becoming a collaborator to company "Y" profile
+
+
+  @ED-3559
+  @multi-user
+  @add-collaborator
+  Scenario: Add "3" collaborators with an SSO/great.gov.uk account to a verified company
+    Given "Peter Alder" has created an unverified profile for randomly selected company "Y"
+    And "Annette Geissinger" has a verified standalone SSO/great.gov.uk account
+    And "Betty Jones" has a verified standalone SSO/great.gov.uk account
+    And "James Weir" has a verified standalone SSO/great.gov.uk account
+    And "Peter Alder" added "Annette Geissinger, Betty Jones, James Weir" as collaborators to company "Y"
+
+    When "Annette Geissinger" confirms that she wants to be added as a collaborator
+    And "Betty Jones" confirms that she wants to be added as a collaborator
+    And "James Weir" confirms that he wants to be added as a collaborator
+
+    Then "Annette Geissinger" should be on "Edit Company profile" page
+    And "Betty Jones" should be on "Edit Company profile" page
+    And "James Weir" should be on "Edit Company profile" page
+
+
+
+  @ED-3560
+  @multi-user
+  @add-collaborator
+  Scenario: Collaborators should not be able to add/remove other collaborators or transfer account ownership
+    Given "Peter Alder" has created an unverified profile for randomly selected company "Y"
+    And "Peter Alder" added "Annette Geissinger" as a collaborator to company "Y"
+    And "Annette Geissinger" is signed in to SSO/great.gov.uk account
+
+    When "Annette Geissinger" goes to the SSO "Find a buyer" tab
+
+    Then "Annette Geissinger" should not see options to manage account users on "SSO - Find a buyer" page
+
+
+  @ED-3561
+  @multi-user
+  @transfer-ownership
+  Scenario Outline: New Account Owner should receive an email with a request to confirm account ownership
+    Given "Peter Alder" has created "<a>" profile for randomly selected company "Y"
+    And "Annette Geissinger" "<has or does not have>" a SSO/great.gov.uk account
+
+    When "Peter Alder" decides to transfer the company "Y" account ownership to "Annette Geissinger"
+    And "Peter Alder" confirms his password before transferring the ownership
+
+    Then "Annette" should receive an email with a request for becoming the owner of the company "Y" profile
+
+    Examples:
+      | has or does not have | a             |
+      | has                  | a verified    |
+      | has                  | an unverified |
+      | does not have        | a verified    |
+      | does not have        | an unverified |
+
+
+  @ED-3562
+  @multi-user
+  @transfer-ownership
+  Scenario Outline: Company account owner should be able to transfer the account ownership to a user who "has or does not have" an SSO/great.gov.uk account
+    Given "Peter Alder" has created "<a>" profile for randomly selected company "Y"
+    And "Annette Geissinger" "<has or does not have>" a SSO/great.gov.uk account
+
+    When "Peter Alder" transfers the company "Y" account ownership to "Annette Geissinger"
+    And "Annette Geissinger" accepts the request for becoming the owner of company "Y" profile
+
+    Then "Annette Geissinger" should see options to manage account users on "SSO - Find a buyer" page
+    And "Peter Alder" should not see options to manage account users on "SSO - Find a buyer" page
+
+    Examples:
+      | has or does not have | a             |
+      | has                  | a verified    |
+      | has                  | an unverified |
+      | does not have        | a verified    |
+      | does not have        | an unverified |
+
+
+  @ED-3564
+  @multi-user
+  @remove-collaborator
+  @fake-sso-email-verification
+  Scenario: Account owner should be able to remove one account collaborator
+    Given "Peter Alder" has created an unverified profile for randomly selected company "Y"
+    And "Peter Alder" added "Annette Geissinger" as a collaborator to company "Y"
+    And "Annette Geissinger" accepted request for becoming a collaborator to company "Y"
+
+    When "Peter Alder" removes "Annette Geissinger" from the list of collaborators to the company "Y"
+
+    Then "Peter Alder" should not see "Annette Geissinger" on the list of collaborators to the company "Y"
+    And "Annette Geissinger" should not be able to access "Edit profile" page
+
+
+  @ED-3565
+  @multi-user
+  @remove-collaborator
+  @fake-sso-email-verification
+  Scenario: Account owner should be able to remove multiple account collaborators
+    Given "Peter Alder" has created a unverified profile for randomly selected company "Y"
+    And "Peter Alder" added "Annette Geissinger, Betty Jones, James Weir" as collaborators to company "Y"
+    And "Annette Geissinger, Betty Jones, James Weir" accepted request for becoming a collaborator to company "Y"
+
+    When "Peter Alder" removes "Annette Geissinger, Betty Jones, James Weir" from the list of collaborators to the company "Y"
+
+    Then "Peter Alder" should not see "Annette Geissinger, Betty Jones, James Weir" on the list of collaborators to the company "Y"
+    And "Annette Geissinger" should not be able to access "Edit profile" page
+    And "Betty Jones" should not be able to access "Edit profile" page
+    And "James Weir" should not be able to access "Edit profile" page
+
+
+  @ED-3566
+  @multi-user
+  @transfer-ownership
+  @verification
+  @letter
+  @fake-sso-email-verification
+  Scenario: Collaborators should be able to verify company profile with verification code
+    Given "Peter Alder" has created an unverified profile for randomly selected company "Y"
+    And "Peter Alder" added "Annette Geissinger" as a collaborator to company "Y"
+    And "Annette Geissinger" accepted request for becoming a collaborator to company "Y"
+
+    When "Annette Geissinger" verifies the company with the verification code from the letter sent after Directory Profile was created
+
+    Then "Annette Geissinger" should be on edit Company's Directory Profile page
+    And "Annette Geissinger" should be told that her company is published
+
+
+  @ED-3567
+  @multi-user
+  @add-content
+  @fake-sso-email-verification
+  Scenario: Account collaborators should be able to update company's details
+    Given "Peter Alder" has created a verified profile for randomly selected company "Y"
+    And "Peter Alder" added "Annette Geissinger" as a collaborator to company "Y"
+    And "Annette Geissinger" accepted request for becoming a collaborator to company "Y"
+
+    When "Annette Geissinger" updates company's details
+      | detail                      |
+      | business name               |
+      | website                     |
+      | keywords                    |
+      | number of employees         |
+      | sector of interest          |
+      | countries to export to      |
+
+    Then "Annette Geissinger" should see new details on FAB Company's Directory Profile page
+      | detail                      |
+      | business name               |
+      | website                     |
+      | keywords                    |
+      | number of employees         |
+      | sector of interest          |
+    And "Annette Geissinger" should see new details on FAS Company's Directory Profile page
+      | detail                      |
+      | business name               |
+      | website                     |
+      | keywords                    |
+      | number of employees         |
+      | sector of interest          |
+
+
+  @ED-3568
+  @multi-user
+  @add-content
+  @fake-sso-email-verification
+  Scenario Outline: Account collaborators should be able to upload company's logo
+    Given "Peter Alder" has created a verified profile for randomly selected company "Y"
+    And "Peter Alder" added "Annette Geissinger" as a collaborator to company "Y"
+    And "Annette Geissinger" accepted request for becoming a collaborator to company "Y"
+
+    When "Annette Geissinger" uploads "<valid_image>" as company's logo
+
+    Then "Annette Geissinger" should see that logo on FAB Company's Directory Profile page
+    And "Annette Geissinger" should see a PNG logo thumbnail on FAS Company's Directory Profile page
+
+    Examples:
+      | valid_image            |
+      | Anfiteatro_El_Jem.jpeg |
+
+
+  @ED-3569
+  @multi-user
+  @add-content
+  @fake-sso-email-verification
+  Scenario: Account collaborators should be able to add a case study
+    Given "Peter Alder" has created a verified profile for randomly selected company "Y"
+    And "Peter Alder" added "Annette Geissinger" as a collaborator to company "Y"
+    And "Annette Geissinger" accepted request for becoming a collaborator to company "Y"
+
+    When "Annette Geissinger" adds a complete case study called "no 1"
+
+    Then "Annette Geissinger" should see all case studies on the FAB Company's Directory Profile page
+    And "Annette Geissinger" should see all case studies on the FAS Company's Directory Profile page
+
+
+  @ED-3570
+  @multi-user
+  @edge-case
+  @fake-sso-email-verification
+  Scenario: New account owner should be able to transfer it back to the original owner
+    Given "Peter Alder" has created an unverified profile for randomly selected company "Y"
+    And "Peter Alder" transferred the company "Y" account ownership to "Annette Geissinger"
+    And "Annette Geissinger" accepted request for becoming the owner of company "Y" profile
+
+    When "Annette Geissinger" transfers the company "Y" account ownership to "Peter Alder"
+    And "Peter Alder" accepts the request for becoming the owner of company "Y" profile
+
+    Then "Peter Alder" should see options to manage account users on "SSO - Find a buyer" page
+    And "Annette Geissinger" should not see options to manage account users on "SSO - Find a buyer" page
+
+
+  @ED-3571
+  @multi-user
+  @edge-case
+  @fake-sso-email-verification
+  Scenario: New account owner should be able to add the original owner as a collaborator to the company profile
+    Given "Peter Alder" has created an unverified profile for randomly selected company "Y"
+    And "Peter Alder" transferred the company "Y" account ownership to "Annette Geissinger"
+    And "Annette Geissinger" accepted request for becoming the owner of company "Y" profile
+
+    When "Annette Geissinger" adds "Peter Alder" as a collaborator
+    And "Peter Alder" confirms that he wants to become a collaborator to company "Y" profile
+
+    Then "Peter Alder" should be on "Edit Company profile" page
+
+
+  @ED-3572
+  @multi-user
+  @edge-case
+  @fake-sso-email-verification
+  Scenario: Supplier should receive an email with a request for becoming a collaborator despite already having a profile
+    Given "Peter Alder" has created an unverified profile for randomly selected company "Y"
+    And "Annette Geissinger" has created an unverified profile for randomly selected company "Z"
+
+    When "Peter Alder" decides to add "Annette Geissinger" as a collaborator
+
+    Then "Annette" should receive an email with a request for becoming a collaborator to company "Y" profile
+
+
+  @ED-3573
+  @multi-user
+  @edge-case
+  @fake-sso-email-verification
+  Scenario: Adding Collaborator which is already an owner of a different profile shouldn't work
+    Given "Peter Alder" has created an unverified profile for randomly selected company "Y"
+    And "Annette Geissinger" has created an unverified profile for randomly selected company "Z"
+    And "Peter Alder" added "Annette Geissinger" as a collaborator
+    And "Annette Geissinger" has received an email with a request for becoming a collaborator to company "Y" profile
+
+    When "Annette Geissinger" confirms that she wants to become a collaborator to company "Y" profile
+
+    Then "Annette Geissinger" should be on "Edit Company profile" page

--- a/tests/functional/features/fab/multiuser-accounts.feature
+++ b/tests/functional/features/fab/multiuser-accounts.feature
@@ -36,7 +36,6 @@ Feature: Multi-user accounts
     Then "Annette Geissinger" should see "FAB Company profile" page
 
 
-  @wip
   @ED-3556
   @multi-user
   @add-collaborator
@@ -46,9 +45,9 @@ Feature: Multi-user accounts
     And "Peter Alder" added "Annette Geissinger" as a collaborator
     And "Annette Geissinger" has received an email with a request to confirm that she's been added to company "Y" Find a Buyer profile
 
-    When "Annette Geissinger" decides to confirm that she wants to become a collaborator to company "Y" profile
+    When "Annette Geissinger" opens the invitation from company "Y", creates a SSO/great.gov.uk account and confirms that he wants to be added to the FAB profile
 
-    Then "Annette Geissinger" should be on "SSO registration" page
+    Then "Annette Geissinger" should see "FAB Company profile" page
 
 
   @wip

--- a/tests/functional/features/fab/multiuser-accounts.feature
+++ b/tests/functional/features/fab/multiuser-accounts.feature
@@ -21,7 +21,6 @@ Feature: Multi-user accounts
       | an unverified | does not have        |
 
 
-  @wip
   @ED-3555
   @multi-user
   @add-collaborator
@@ -30,11 +29,11 @@ Feature: Multi-user accounts
     And "Annette Geissinger" has a verified standalone SSO/great.gov.uk account
     And "Annette Geissinger" is signed in to SSO/great.gov.uk account
     And "Peter Alder" added "Annette Geissinger" as a collaborator
-    And "Annette Geissinger" has received an email with a request for becoming a collaborator to company "Y" profile
+    And "Annette Geissinger" has received an email with a request for becoming a collaborator with company "Y" profile
 
-    When "Annette Geissinger" confirms that she wants to become a collaborator to company "Y" profile
+    When "Annette Geissinger" confirms that she wants to collaborate with company "Y" profile
 
-    Then "Annette Geissinger" should be on "Edit Company profile" page
+    Then "Annette Geissinger" should see "FAB Company profile" page
 
 
   @wip

--- a/tests/functional/features/fab/multiuser-accounts.feature
+++ b/tests/functional/features/fab/multiuser-accounts.feature
@@ -11,7 +11,7 @@ Feature: Multi-user accounts
 
     When "Peter Alder" decides to add "Annette Geissinger" as a collaborator
 
-    Then "Annette Geissinger" should receive an email with a request for becoming a collaborator to company "Y" profile
+    Then "Annette Geissinger" should receive an email with a request to confirm that she's been added to company "Y" Find a Buyer profile
 
     Examples:
       | a             | has or does not have |
@@ -29,7 +29,7 @@ Feature: Multi-user accounts
     And "Annette Geissinger" has a verified standalone SSO/great.gov.uk account
     And "Annette Geissinger" is signed in to SSO/great.gov.uk account
     And "Peter Alder" added "Annette Geissinger" as a collaborator
-    And "Annette Geissinger" has received an email with a request for becoming a collaborator with company "Y" profile
+    And "Annette Geissinger" has received an email with a request to confirm that she's been added to company "Y" Find a Buyer profile
 
     When "Annette Geissinger" confirms that she wants to collaborate with company "Y" profile
 
@@ -44,7 +44,7 @@ Feature: Multi-user accounts
     Given "Peter Alder" has created and verified profile for randomly selected company "Y"
     And "Annette Geissinger" "does not have" an SSO/great.gov.uk account
     And "Peter Alder" added "Annette Geissinger" as a collaborator
-    And "Annette Geissinger" has received an email with a request for becoming a collaborator to company "Y" profile
+    And "Annette Geissinger" has received an email with a request to confirm that she's been added to company "Y" Find a Buyer profile
 
     When "Annette Geissinger" decides to confirm that she wants to become a collaborator to company "Y" profile
 

--- a/tests/functional/pages/fab_ui_account_add_collaborator.py
+++ b/tests/functional/pages/fab_ui_account_add_collaborator.py
@@ -12,7 +12,7 @@ from tests.functional.utils.request import check_response
 URL = get_absolute_url("ui-buyer:account-add-collaborator")
 EXPECTED_STRINGS = [
     "Add a user to your profile", "Enter the new user’s email address",
-    "Confirm", "Cancel"
+    "Confirm", "Cancel", "Is there anything wrong with this page?"
 ]
 
 
@@ -38,6 +38,8 @@ def go_to(session: Session) -> Response:
 def add_collaborator(session: Session, token: str, email: str) -> Response:
     data = {
         "csrfmiddlewaretoken": token,
-        "email": email
+        "email_address": email
     }
-    return make_request(Method.POST, URL, session=session, data=data)
+    headers = {"Referer": URL}
+    return make_request(
+        Method.POST, URL, session=session, data=data, headers=headers)

--- a/tests/functional/pages/fab_ui_account_add_collaborator.py
+++ b/tests/functional/pages/fab_ui_account_add_collaborator.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""FAB - Add Collaborator page"""
+from requests import Response, Session
+
+from tests import get_absolute_url
+from tests.functional.utils.generic import (
+    Method,
+    make_request,
+)
+from tests.functional.utils.request import check_response
+
+URL = get_absolute_url("ui-buyer:account-add-collaborator")
+EXPECTED_STRINGS = [
+    "Add a user to your profile", "Enter the new user’s email address",
+    "Confirm", "Cancel"
+]
+
+
+def should_be_here(response: Response):
+    """Check if User is on the correct page."""
+    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+
+
+def go_to(session: Session) -> Response:
+    """Go to "Edit Company's Details" page.
+
+    This requires:
+     * Supplier to be logged in
+
+    """
+    headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
+    response = make_request(Method.GET, URL, session=session, headers=headers)
+
+    should_be_here(response)
+    return response
+
+
+def add_collaborator(session: Session, token: str, email: str) -> Response:
+    data = {
+        "csrfmiddlewaretoken": token,
+        "email": email
+    }
+    return make_request(Method.POST, URL, session=session, data=data)

--- a/tests/functional/pages/fab_ui_confim_your_collaboration.py
+++ b/tests/functional/pages/fab_ui_confim_your_collaboration.py
@@ -19,7 +19,7 @@ def should_be_here(response: Response):
     logging.debug("Successfully got to the FAB Confirm your collaboration page")
 
 
-def open_confirmation_link(session: Session, link: str) -> Response:
+def open(session: Session, link: str) -> Response:
     """Open the invitation link sent to the Collaborator."""
     with assertion_msg("Expected a non-empty invitation link"):
         assert link

--- a/tests/functional/pages/fab_ui_confim_your_collaboration.py
+++ b/tests/functional/pages/fab_ui_confim_your_collaboration.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""FAB - Confirm your will to collaborate to company's profile page"""
+import logging
+
+from requests import Response, Session
+
+from tests.functional.utils.generic import assertion_msg
+from tests.functional.utils.request import Method, check_response, make_request
+
+EXPECTED_STRINGS = [
+    "Collaborate", "Do you want to be added as user to the profile for", "Yes",
+    "No", "Is there anything wrong with this page?"
+]
+
+
+def should_be_here(response: Response):
+    """Check if Collaborator is on FAB Confirm your collaboration Page."""
+    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+    logging.debug("Successfully got to the FAB Confirm your collaboration page")
+
+
+def open_confirmation_link(session: Session, link: str) -> Response:
+    """Open the invitation link sent to the Collaborator."""
+    with assertion_msg("Expected a non-empty invitation link"):
+        assert link
+    return make_request(Method.GET, link, session=session)
+
+
+def confirm(
+        session: Session, csrf_middleware_token: str, invitation_link: str) \
+        -> Response:
+    """Confirm the invitation for collaboration.
+
+    Example invitation link:
+    https://dev.buyer.directory.uktrade.io/account/collaborate/accept/?invite_key=d1d04035-fb15-4bad-9903-452345234534
+    """
+    # in order to be redirected to the correct URL we have `unquote`
+    # the form_action_value
+    start = invitation_link.index("=") + 1
+    invite_key = invitation_link[start:]
+    headers = {"Referer": invitation_link}
+    data = {
+        "csrfmiddlewaretoken": csrf_middleware_token,
+        "invite_key": invite_key
+    }
+
+    return make_request(
+        Method.POST, invitation_link, session=session, headers=headers,
+        data=data)

--- a/tests/functional/pages/sso_ui_register.py
+++ b/tests/functional/pages/sso_ui_register.py
@@ -34,15 +34,17 @@ def should_be_here(response: Response):
     logging.debug("Successfully got to the SSO Registration page")
 
 
-def go_to(session: Session) -> Response:
-    """Go to the SSO Registration page.
-
-    :param session: Supplier session object
-    :return: response object
-    """
-    headers = {"Referer": get_absolute_url("ui-buyer:landing")}
+def go_to(
+        session: Session, *, next: str = None, referer: str = None) -> Response:
+    """Go to the SSO Registration page."""
+    referer = referer or get_absolute_url("ui-buyer:landing")
+    if next:
+        url = urljoin(URL, "?next={}".format(next))
+    else:
+        url = URL
+    headers = {"Referer": referer}
     response = make_request(
-        Method.GET, URL, session=session, headers=headers)
+        Method.GET, url, session=session, headers=headers)
     should_be_here(response)
     return response
 
@@ -77,15 +79,14 @@ def submit(actor: Actor, company: Company, exported: bool) -> Response:
     return response
 
 
-def submit_no_company(actor: Actor) -> Response:
+def submit_no_company(
+        actor: Actor, *, next: str = None, referer: str = URL) -> Response:
     """Will submit the SSO Registration form without company's details.
 
     Used when Supplier creates a SSO/great.gov.uk account first.
-
-    :param actor: a namedtuple with Actor details
     """
     session = actor.session
-    headers = {"Referer": URL}
+    headers = {"Referer": referer}
     data = {
         "csrfmiddlewaretoken": actor.csrfmiddlewaretoken,
         "email": actor.email,
@@ -94,6 +95,8 @@ def submit_no_company(actor: Actor) -> Response:
         "password2": actor.password,
         "terms_agreed": "on",
     }
+    if next:
+        data["next"] = next
 
     response = make_request(
         Method.POST, URL, session=session, headers=headers, data=data)

--- a/tests/functional/registry/__init__.py
+++ b/tests/functional/registry/__init__.py
@@ -30,7 +30,8 @@ from tests.functional.pages import (
     sud_ui_selling_online_overseas,
     sud_ui_find_a_buyer,
     sud_ui_export_opportunities,
-    fab_ui_account_add_collaborator
+    fab_ui_account_add_collaborator,
+    fab_ui_confim_your_collaboration
 )
 
 from tests import get_absolute_url
@@ -219,6 +220,10 @@ FAB_PAGE_REGISTRY = {
         "url": "ui-buyer:account-add-collaborator",
         "po": fab_ui_account_add_collaborator
     },
+    "fab confirm you want to be added to the profile": {
+        "url": None,
+        "po": fab_ui_confim_your_collaboration
+    }
 }
 
 SUD_PAGE_REGISTRY = {

--- a/tests/functional/registry/__init__.py
+++ b/tests/functional/registry/__init__.py
@@ -27,8 +27,11 @@ from tests.functional.pages import (
     sso_ui_password_reset,
     sso_ui_register,
     sud_ui_landing,
-    sud_ui_selling_online_overseas, sud_ui_find_a_buyer,
-    sud_ui_export_opportunities)
+    sud_ui_selling_online_overseas,
+    sud_ui_find_a_buyer,
+    sud_ui_export_opportunities,
+    fab_ui_account_add_collaborator
+)
 
 from tests import get_absolute_url
 from tests.functional.pages import fab_ui_case_study_basic
@@ -211,6 +214,10 @@ FAB_PAGE_REGISTRY = {
     "fab edit social media links": {
         "url": "ui-buyer:company-edit-social-media",
         "po": fab_ui_edit_online_profiles
+    },
+    "fab add collaborator": {
+        "url": "ui-buyer:account-add-collaborator",
+        "po": fab_ui_account_add_collaborator
     },
 }
 

--- a/tests/functional/steps/fab_given_def.py
+++ b/tests/functional/steps/fab_given_def.py
@@ -197,3 +197,12 @@ def given_verified_sso_account_associated_with_company(
         context, supplier_alias, company_alias):
     reg_create_verified_sso_account_associated_with_company(
         context, supplier_alias, company_alias)
+
+
+@given('"{actor_alias}" has created "{verified_or_not}" profile for randomly selected company "{company_alias}"')
+def create_verified_or_not_profile(
+        context, actor_alias, verified_or_not, company_alias):
+    if verified_or_not == "a verified":
+        reg_create_verified_profile(context, actor_alias, company_alias)
+    else:
+        reg_create_unverified_profile(context, actor_alias, company_alias)

--- a/tests/functional/steps/fab_given_def.py
+++ b/tests/functional/steps/fab_given_def.py
@@ -18,7 +18,9 @@ from tests.functional.steps.fab_given_impl import (
     sso_create_standalone_verified_sso_account,
     sso_get_password_reset_link,
     unauthenticated_buyer,
-    unauthenticated_supplier
+    unauthenticated_supplier,
+    create_actor_with_or_without_sso_account,
+    create_actor_with_verified_or_unverified_fab_profile
 )
 from tests.functional.steps.fab_then_impl import (
     fab_should_see_all_case_studies,
@@ -203,16 +205,16 @@ def given_verified_sso_account_associated_with_company(
         context, supplier_alias, company_alias)
 
 
-@given('"{actor_alias}" has created "{verified_or_not}" profile for randomly selected company "{company_alias}"')
-def create_verified_or_not_profile(
+@given('"{actor_alias}" has created "{verified_or_not}" profile for randomly '
+       'selected company "{company_alias}"')
+def given_actor_with_verified_or_not_profile(
         context, actor_alias, verified_or_not, company_alias):
-    if verified_or_not == "a verified":
-        reg_create_verified_profile(context, actor_alias, company_alias)
-    else:
-        reg_create_unverified_profile(context, actor_alias, company_alias)
+    create_actor_with_verified_or_unverified_fab_profile(
+        context, actor_alias, verified_or_not, company_alias)
 
 
 @given('"{actor_alias}" "{has_or_does_not_have}" an SSO/great.gov.uk account')
-def step_impl(context, actor_alias, has_or_does_not_have):
-    if has_or_does_not_have == "has":
-        sso_create_standalone_verified_sso_account(context, actor_alias)
+def given_actor_with_or_without_sso_account(
+        context, actor_alias, has_or_does_not_have):
+    create_actor_with_or_without_sso_account(
+        context, actor_alias, has_or_does_not_have)

--- a/tests/functional/steps/fab_given_def.py
+++ b/tests/functional/steps/fab_given_def.py
@@ -28,7 +28,8 @@ from tests.functional.steps.fab_then_impl import (
     prof_should_see_logo_picture,
     reg_should_get_verification_email,
     sso_should_be_signed_in_to_sso_account,
-    sso_should_be_signed_out_from_sso_account
+    sso_should_be_signed_out_from_sso_account,
+    sso_should_get_request_for_collaboration_email
 )
 from tests.functional.steps.fab_when_impl import (
     go_to_page,
@@ -36,7 +37,8 @@ from tests.functional.steps.fab_when_impl import (
     prof_add_online_profiles,
     prof_set_company_description,
     prof_sign_out_from_fab,
-    prof_supplier_uploads_logo
+    prof_supplier_uploads_logo,
+    prof_add_collaborator
 )
 
 
@@ -218,3 +220,17 @@ def given_actor_with_or_without_sso_account(
         context, actor_alias, has_or_does_not_have):
     create_actor_with_or_without_sso_account(
         context, actor_alias, has_or_does_not_have)
+
+
+@given('"{supplier_alias}" added "{collaborator_alias}" as a collaborator')
+def given_supplier_added_a_collaborator(
+        context, supplier_alias, collaborator_alias):
+    prof_add_collaborator(context, supplier_alias, collaborator_alias)
+
+
+@given('"{supplier_alias}" has received an email with a request for becoming a'
+       ' collaborator with company "{company_alias}" profile')
+def given_actor_should_receive_email_with_request_for_collaboration(
+        context, supplier_alias, company_alias):
+    sso_should_get_request_for_collaboration_email(
+        context, supplier_alias, company_alias)

--- a/tests/functional/steps/fab_given_def.py
+++ b/tests/functional/steps/fab_given_def.py
@@ -110,18 +110,20 @@ def given_supplier_is_signed_out_from_sso(context, supplier_alias):
 
 @given('"{supplier_alias}" selected an active company without a Directory '
        'Profile identified by an alias "{company_alias}"')
-def given_supplier_selects_random_company(context, supplier_alias, company_alias):
+def given_supplier_selects_random_company(
+        context, supplier_alias, company_alias):
     reg_select_random_company_and_confirm_export_status(
         context, supplier_alias, company_alias)
 
 
 @given('"{supplier_alias}" has added links to online profiles')
-def given_supplier_adds_valid_links_to_online_profiles(context, supplier_alias):
+def given_supplier_adds_valid_links_to_online_profiles(
+        context, supplier_alias):
     prof_add_online_profiles(context, supplier_alias, context.table)
 
 
-@given('"{supplier_alias}" created an unverified profile for randomly selected '
-       'company "{company_alias}"')
+@given('"{supplier_alias}" created an unverified profile for randomly selected'
+       ' company "{company_alias}"')
 def given_unverified_profile(context, supplier_alias, company_alias):
     reg_create_unverified_profile(context, supplier_alias, company_alias)
 
@@ -133,12 +135,14 @@ def given_supplier_sets_logo_picture(context, supplier_alias, picture):
 
 @given('"{supplier_alias}" can see that logo on FAB Company\'s Directory '
        'Profile page')
-def given_supplier_can_see_correct_logo_on_fab_profile(context, supplier_alias):
+def given_supplier_can_see_correct_logo_on_fab_profile(
+        context, supplier_alias):
     prof_should_see_logo_picture(context, supplier_alias)
 
 
 @given('"{supplier_alias}" added a complete case study called "{case_alias}"')
-def given_supplier_added_complete_case_study(context, supplier_alias, case_alias):
+def given_supplier_added_complete_case_study(
+        context, supplier_alias, case_alias):
     prof_add_case_study(context, supplier_alias, case_alias)
     fab_should_see_all_case_studies(context, supplier_alias)
 

--- a/tests/functional/steps/fab_given_def.py
+++ b/tests/functional/steps/fab_given_def.py
@@ -206,3 +206,9 @@ def create_verified_or_not_profile(
         reg_create_verified_profile(context, actor_alias, company_alias)
     else:
         reg_create_unverified_profile(context, actor_alias, company_alias)
+
+
+@given('"{actor_alias}" "{has_or_does_not_have}" an SSO/great.gov.uk account')
+def step_impl(context, actor_alias, has_or_does_not_have):
+    if has_or_does_not_have == "has":
+        sso_create_standalone_verified_sso_account(context, actor_alias)

--- a/tests/functional/steps/fab_given_def.py
+++ b/tests/functional/steps/fab_given_def.py
@@ -228,8 +228,8 @@ def given_supplier_added_a_collaborator(
     prof_add_collaborator(context, supplier_alias, collaborator_alias)
 
 
-@given('"{supplier_alias}" has received an email with a request for becoming a'
-       ' collaborator with company "{company_alias}" profile')
+@given('"{supplier_alias}" has received an email with a request to confirm that he\'s been added to company "{company_alias}" Find a Buyer profile')
+@given('"{supplier_alias}" has received an email with a request to confirm that she\'s been added to company "{company_alias}" Find a Buyer profile')
 def given_actor_should_receive_email_with_request_for_collaboration(
         context, supplier_alias, company_alias):
     sso_should_get_request_for_collaboration_email(

--- a/tests/functional/steps/fab_given_def.py
+++ b/tests/functional/steps/fab_given_def.py
@@ -188,7 +188,7 @@ def given_actor_gets_company_slug(context, actor_alias, company_alias):
 
 
 @given('"{supplier_alias}" received the letter with verification code')
-def step_impl(context, supplier_alias):
+def given_supplier_received_verification_letter(context, supplier_alias):
     reg_should_get_verification_letter(context, supplier_alias)
 
 

--- a/tests/functional/steps/fab_given_impl.py
+++ b/tests/functional/steps/fab_given_impl.py
@@ -290,3 +290,21 @@ def reg_create_verified_sso_account_associated_with_company(
     flag_sso_account_as_verified(context, supplier.email)
     sso_sign_in(context, supplier_alias)
     finish_registration_after_flagging_as_verified(context, supplier_alias)
+
+
+def create_actor_with_or_without_sso_account(
+        context: Context, actor_alias: str, has_or_does_not_have: str):
+    if has_or_does_not_have == "has":
+        sso_create_standalone_verified_sso_account(context, actor_alias)
+    else:
+        supplier = unauthenticated_supplier(actor_alias)
+        context.add_actor(supplier)
+
+
+def create_actor_with_verified_or_unverified_fab_profile(
+        context: Context, actor_alias: str, verified_or_not: str,
+        company_alias: str):
+    if verified_or_not == "a verified":
+        reg_create_verified_profile(context, actor_alias, company_alias)
+    else:
+        reg_create_unverified_profile(context, actor_alias, company_alias)

--- a/tests/functional/steps/fab_then_def.py
+++ b/tests/functional/steps/fab_then_def.py
@@ -367,8 +367,8 @@ def then_actor_should_see_a_message(context, actor_alias, message):
     should_see_message(context, actor_alias, message)
 
 
-@then('"{actor_alias}" should receive an email with a request for becoming a '
-      'collaborator to company "{company_alias}" profile')
+@then('"{actor_alias}" should receive an email with a request to confirm that he\'s been added to company "{company_alias}" Find a Buyer profile')
+@then('"{actor_alias}" should receive an email with a request to confirm that she\'s been added to company "{company_alias}" Find a Buyer profile')
 def then_actor_should_receive_email_with_request_for_collaboration(
         context, actor_alias, company_alias):
     sso_should_get_request_for_collaboration_email(

--- a/tests/functional/steps/fab_then_def.py
+++ b/tests/functional/steps/fab_then_def.py
@@ -49,7 +49,8 @@ from tests.functional.steps.fab_then_impl import (
     sso_should_be_signed_in_to_sso_account,
     sso_should_be_told_about_password_reset,
     sso_should_get_password_reset_email,
-    sso_should_see_invalid_password_reset_link_error
+    sso_should_see_invalid_password_reset_link_error,
+    sso_should_get_request_for_collaboration_email
 )
 from tests.functional.steps.fab_when_impl import (
     fas_feedback_request_should_be_submitted,
@@ -364,3 +365,11 @@ def then_supplier_should_be_asked_about_verification(context, supplier_alias):
 @then('"{actor_alias}" should see "{message}" message')
 def then_actor_should_see_a_message(context, actor_alias, message):
     should_see_message(context, actor_alias, message)
+
+
+@then('"{actor_alias}" should receive an email with a request for becoming a '
+      'collaborator to company "{company_alias}" profile')
+def then_actor_should_receive_email_with_request_for_collaboration(
+        context, actor_alias, company_alias):
+    sso_should_get_request_for_collaboration_email(
+        context, actor_alias, company_alias)

--- a/tests/functional/steps/fab_then_impl.py
+++ b/tests/functional/steps/fab_then_impl.py
@@ -48,7 +48,8 @@ from tests.functional.utils.gov_notify import (
 from tests.settings import (
     FAS_LOGO_PLACEHOLDER_IMAGE,
     FAS_MESSAGE_FROM_BUYER_SUBJECT,
-    SEARCHABLE_CASE_STUDY_DETAILS
+    SEARCHABLE_CASE_STUDY_DETAILS,
+    FAB_CONFIRM_COLLABORATION_SUBJECT
 )
 
 
@@ -828,3 +829,21 @@ def should_see_message(context: Context, actor_alias: str, message: str):
             "Response content doesn't contain expected message: '%s'", message):
         assert message in content
     logging.debug("%s saw expected message: '%s'", actor_alias, message)
+
+
+def sso_should_get_request_for_collaboration_email(
+        context: Context, actor_alias: str, company_alias: str):
+    actor = context.get_actor(actor_alias)
+    company = context.get_company(company_alias)
+    logging.debug(
+        "Trying to find email with a request for collaboration with company: "
+        "%s", company.title)
+    subject = FAB_CONFIRM_COLLABORATION_SUBJECT.format(company.title)
+    response = find_mail_gun_events(
+        context, service=MailGunService.DIRECTORY, recipient=actor.email,
+        event=MailGunEvent.ACCEPTED, subject=subject)
+    context.response = response
+    with assertion_msg(
+            "Expected to find an email with a request for collaboration with "
+            "company: '%s'", company_alias):
+        assert response.status_code == 200

--- a/tests/functional/steps/fab_when_def.py
+++ b/tests/functional/steps/fab_when_def.py
@@ -53,7 +53,8 @@ from tests.functional.steps.fab_when_impl import (
     sso_open_password_reset_link,
     sso_request_password_reset,
     sso_sign_in,
-    sso_supplier_confirms_email_address
+    sso_supplier_confirms_email_address,
+    prof_add_collaborator
 )
 
 
@@ -367,3 +368,8 @@ def when_supplier_tries_to_change_password_to_letters_only(
         context, supplier_alias):
     sso_change_password_with_password_reset_link(
         context, supplier_alias, new=True, letters_only=True)
+
+
+@when('"{supplier_alias}" decides to add "{collaborator_alias}" as a collaborator')
+def when_owner_adds_a_collaborator(context, supplier_alias, collaborator_alias):
+    prof_add_collaborator(context, supplier_alias, collaborator_alias)

--- a/tests/functional/steps/fab_when_def.py
+++ b/tests/functional/steps/fab_when_def.py
@@ -55,7 +55,8 @@ from tests.functional.steps.fab_when_impl import (
     sso_sign_in,
     sso_supplier_confirms_email_address,
     prof_add_collaborator,
-    fab_confirm_collaboration_request
+    fab_confirm_collaboration_request,
+    fab_collaborator_create_sso_account_and_confirm_email
 )
 
 
@@ -382,4 +383,12 @@ def when_owner_adds_a_collaborator(
 def when_collaborator_confirms_the_collaboration_request(
         context, collaborator_alias, company_alias):
     fab_confirm_collaboration_request(
+        context, collaborator_alias, company_alias)
+
+
+@when('"{collaborator_alias}" opens the invitation from company "{company_alias}", creates a SSO/great.gov.uk account and confirms that he wants to be added to the FAB profile')
+@when('"{collaborator_alias}" opens the invitation from company "{company_alias}", creates a SSO/great.gov.uk account and confirms that she wants to be added to the FAB profile')
+def when_collaborator_creates_sso_account_and_confirms_email(
+        context, collaborator_alias, company_alias):
+    fab_collaborator_create_sso_account_and_confirm_email(
         context, collaborator_alias, company_alias)

--- a/tests/functional/steps/fab_when_def.py
+++ b/tests/functional/steps/fab_when_def.py
@@ -54,7 +54,8 @@ from tests.functional.steps.fab_when_impl import (
     sso_request_password_reset,
     sso_sign_in,
     sso_supplier_confirms_email_address,
-    prof_add_collaborator
+    prof_add_collaborator,
+    fab_confirm_collaboration_request
 )
 
 
@@ -373,3 +374,13 @@ def when_supplier_tries_to_change_password_to_letters_only(
 @when('"{supplier_alias}" decides to add "{collaborator_alias}" as a collaborator')
 def when_owner_adds_a_collaborator(context, supplier_alias, collaborator_alias):
     prof_add_collaborator(context, supplier_alias, collaborator_alias)
+
+
+@when('"{collaborator_alias}" confirms that he wants to collaborate with '
+      'company "{company_alias}" profile')
+@when('"{collaborator_alias}" confirms that she wants to collaborate with '
+      'company "{company_alias}" profile')
+def when_collaborator_confirms_the_collaboration_request(
+        context, collaborator_alias, company_alias):
+    fab_confirm_collaboration_request(
+        context, collaborator_alias, company_alias)

--- a/tests/functional/steps/fab_when_def.py
+++ b/tests/functional/steps/fab_when_def.py
@@ -372,14 +372,13 @@ def when_supplier_tries_to_change_password_to_letters_only(
 
 
 @when('"{supplier_alias}" decides to add "{collaborator_alias}" as a collaborator')
-def when_owner_adds_a_collaborator(context, supplier_alias, collaborator_alias):
+def when_owner_adds_a_collaborator(
+        context, supplier_alias, collaborator_alias):
     prof_add_collaborator(context, supplier_alias, collaborator_alias)
 
 
-@when('"{collaborator_alias}" confirms that he wants to collaborate with '
-      'company "{company_alias}" profile')
-@when('"{collaborator_alias}" confirms that she wants to collaborate with '
-      'company "{company_alias}" profile')
+@when('"{collaborator_alias}" confirms that he wants to be added to the company "{company_alias}" Find a Buyer profile')
+@when('"{collaborator_alias}" confirms that she wants to be added to the company "{company_alias}" Find a Buyer profile')
 def when_collaborator_confirms_the_collaboration_request(
         context, collaborator_alias, company_alias):
     fab_confirm_collaboration_request(

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -48,6 +48,9 @@ from tests.functional.pages import (
     fab_ui_confim_your_collaboration
 )
 from tests.functional.registry import get_fabs_page_object, get_fabs_page_url
+from tests.functional.steps.fab_then_impl import (
+    reg_should_get_verification_email
+)
 from tests.functional.utils.context_utils import Company
 from tests.functional.utils.generic import (
     assertion_msg,
@@ -69,7 +72,8 @@ from tests.functional.utils.generic import (
     random_message_data,
     rare_word,
     sentence,
-    get_verification_code
+    get_verification_code,
+    extract_registration_page_link
 )
 from tests.functional.utils.request import Method, check_response, make_request
 from tests.settings import (
@@ -624,6 +628,26 @@ def reg_create_standalone_unverified_sso_account(
             "It looks like user is still logged in, as the "
             "sso_display_logged_in cookie is not equal to False"):
         assert response.cookies.get("sso_display_logged_in") == "false"
+
+
+def sso_collaborator_confirm_email_address(
+        context: Context, supplier_alias: str):
+    """Given that invited collaborator has clicked on the email confirmation
+     link, he/she has to confirm that the provided email address is the
+      correct one.
+    """
+    actor = context.get_actor(supplier_alias)
+    form_action_value = context.form_action_value
+
+    # STEP 1 - Submit "Confirm your email address" form
+    response = sso_ui_confim_your_email.confirm(actor, form_action_value)
+    context.response = response
+
+    # STEP 2 - Check if Supplier if on SSO Profile Landing page
+    fab_ui_confim_your_collaboration.should_be_here(response)
+
+    # STEP 3 - Update Actor's data
+    context.update_actor(supplier_alias, has_sso_account=True)
 
 
 def sso_supplier_confirms_email_address(context, supplier_alias):
@@ -1902,18 +1926,19 @@ def prof_add_collaborator(
 
 
 def fab_confirm_collaboration_request(
-        context: Context, collaborator_alias: str, company_alias: str):
+        context: Context, collaborator_alias: str, company_alias: str,
+        open_invitation_link: bool = True):
     collaborator = context.get_actor(collaborator_alias)
     session = collaborator.session
     link = collaborator.invitation_for_collaboration_link
 
     # Step 1 - open confirmation link
-    response = fab_ui_confim_your_collaboration.open_confirmation_link(
-        session, link)
-    context.response = response
+    if open_invitation_link:
+        response = fab_ui_confim_your_collaboration.open(session, link)
+        context.response = response
 
     # Step 3 - confirm that Supplier is on SSO Confirm Your Email page
-    fab_ui_confim_your_collaboration.should_be_here(response)
+    fab_ui_confim_your_collaboration.should_be_here(context.response)
     logging.debug(
         "Collaborator %s is on the FAB Confirm your collaboration page",
         collaborator_alias
@@ -1921,9 +1946,9 @@ def fab_confirm_collaboration_request(
 
     # Step 4 - extract & store CSRF token & form action value
     # Form Action Value is required to successfully confirm email
-    token = extract_csrf_middleware_token(response)
+    token = extract_csrf_middleware_token(context.response)
     context.update_actor(collaborator_alias, csrfmiddlewaretoken=token)
-    form_action_value = extract_form_action(response)
+    form_action_value = extract_form_action(context.response)
     context.form_action_value = form_action_value
 
     # Step 5 - submit the form
@@ -1932,3 +1957,75 @@ def fab_confirm_collaboration_request(
     logging.debug(
         "%s confirmed that he/she wants to be added to the profile for %s",
         collaborator_alias, company_alias)
+
+
+def fab_open_collaboration_request_link(
+        context: Context, collaborator_alias: str, company_alias: str):
+    collaborator = context.get_actor(collaborator_alias)
+    session = collaborator.session
+    link = collaborator.invitation_for_collaboration_link
+
+    response = fab_ui_confim_your_collaboration.open(session, link)
+    context.response = response
+    logging.debug(
+        "%s opened the collaboration request link from company %s",
+        collaborator_alias, company_alias)
+
+
+def reg_create_standalone_unverified_sso_account_from_sso_login_page(
+        context: Context, actor_alias: str):
+    """Create a standalone SSO/great.gov.uk account."""
+    actor = context.get_actor(actor_alias)
+    response = context.response
+
+    # Step 1: Check if we are on the SSO/great.gov.uk login page
+    sso_ui_login.should_be_here(response)
+
+    # Step 2 - extract CSRF token
+    token = extract_csrf_middleware_token(response)
+    context.update_actor(actor_alias, csrfmiddlewaretoken=token)
+
+    # Step 3 - extract Registration link
+    referer = response.url
+    registration_page_link = extract_registration_page_link(response)
+
+    # Step 4: Go to the SSO/great.gov.uk registration page
+    response = sso_ui_register.go_to(
+        actor.session, next=registration_page_link, referer=referer)
+    context.response = response
+
+    # Step 5 - extract CSRF token
+    token = extract_csrf_middleware_token(response)
+    context.update_actor(actor_alias, csrfmiddlewaretoken=token)
+
+    # Step 6: Check if User is not logged in
+    with assertion_msg(
+            "It looks like user is still logged in, as the "
+            "sso_display_logged_in cookie is not equal to False"):
+        assert response.cookies.get("sso_display_logged_in") == "false"
+
+    # Step 7: POST SSO accounts/signup/
+    response = sso_ui_register.submit_no_company(
+        actor, next=registration_page_link, referer=response.url)
+    context.response = response
+
+    # Step 8: Check if Supplier is on Verify your email page & is not logged in
+    sso_ui_verify_your_email.should_be_here(response)
+    with assertion_msg(
+            "It looks like user is still logged in, as the "
+            "sso_display_logged_in cookie is not equal to False"):
+        assert response.cookies.get("sso_display_logged_in") == "false"
+
+
+def fab_collaborator_create_sso_account_and_confirm_email(
+        context: Context, collaborator_alias: str, company_alias: str):
+    fab_open_collaboration_request_link(
+        context, collaborator_alias, company_alias)
+    sso_ui_login.should_be_here(context.response)
+    reg_create_standalone_unverified_sso_account_from_sso_login_page(
+        context, collaborator_alias)
+    reg_should_get_verification_email(context, collaborator_alias)
+    reg_open_email_confirmation_link(context, collaborator_alias)
+    sso_collaborator_confirm_email_address(context, collaborator_alias)
+    fab_confirm_collaboration_request(
+        context, collaborator_alias, company_alias, open_invitation_link=False)

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -1885,6 +1885,7 @@ def prof_add_collaborator(
     context.response = response
 
     token = extract_csrf_middleware_token(response)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
     response = fab_ui_account_add_collaborator.add_collaborator(
         supplier.session, token, collaborator.email)

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -43,7 +43,8 @@ from tests.functional.pages import (
     sso_ui_logout,
     sso_ui_password_reset,
     sso_ui_register,
-    sso_ui_verify_your_email
+    sso_ui_verify_your_email,
+    fab_ui_account_add_collaborator
 )
 from tests.functional.registry import get_fabs_page_object, get_fabs_page_url
 from tests.functional.utils.context_utils import Company
@@ -1874,3 +1875,18 @@ def finish_registration_after_flagging_as_verified(
            .format(register_url, company.number))
     response = make_request(Method.GET, url, session=actor.session)
     context.response = response
+
+
+def prof_add_collaborator(
+        context: Context, supplier_alias: str, collaborator_alias: str):
+    supplier = context.get_actor(supplier_alias)
+    collaborator = context.get_actor(collaborator_alias)
+    response = fab_ui_account_add_collaborator.go_to(supplier.session)
+    context.response = response
+
+    token = extract_csrf_middleware_token(response)
+
+    response = fab_ui_account_add_collaborator.add_collaborator(
+        supplier.session, token, collaborator.email)
+
+    profile_ui_find_a_buyer.should_be_here(response)

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -1880,6 +1880,7 @@ def finish_registration_after_flagging_as_verified(
 def prof_add_collaborator(
         context: Context, supplier_alias: str, collaborator_alias: str):
     supplier = context.get_actor(supplier_alias)
+    company = context.get_company(supplier.company_alias)
     collaborator = context.get_actor(collaborator_alias)
     response = fab_ui_account_add_collaborator.go_to(supplier.session)
     context.response = response
@@ -1891,3 +1892,9 @@ def prof_add_collaborator(
         supplier.session, token, collaborator.email)
 
     profile_ui_find_a_buyer.should_be_here(response)
+    collaborators = company.collaborators
+    if collaborators:
+        collaborators.append(collaborator_alias)
+    else:
+        collaborators = [collaborator_alias]
+    context.set_company_details(company.alias, collaborators=collaborators)

--- a/tests/functional/utils/context_utils.py
+++ b/tests/functional/utils/context_utils.py
@@ -18,7 +18,7 @@ Actor = namedtuple(
     [
         'alias', 'email', 'password', 'session', 'csrfmiddlewaretoken',
         'email_confirmation_link', 'company_alias', 'has_sso_account', 'type',
-        'password_reset_link'
+        'password_reset_link', 'invitation_for_collaboration_link'
     ]
 )
 CaseStudy = namedtuple(
@@ -46,7 +46,7 @@ Company = namedtuple(
         'companies_house_details', 'facebook', 'linkedin', 'twitter',
         'case_studies', 'logo_picture', 'logo_url', 'logo_hash',
         'export_to_countries', 'fas_profile_endpoint', 'slug',
-        'verification_code'
+        'verification_code', 'collaborators'
     ]
 )
 Feedback = namedtuple(

--- a/tests/functional/utils/generic.py
+++ b/tests/functional/utils/generic.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Various utils used across the project."""
+from email.mime.text import MIMEText
 from enum import Enum
 
 import hashlib
@@ -38,7 +39,8 @@ from tests.functional.utils.context_utils import (
     CaseStudy,
     Company,
     Feedback,
-    Message
+    Message,
+    Actor
 )
 from tests.functional.utils.request import Method, make_request, check_response
 from tests.settings import (
@@ -54,7 +56,8 @@ from tests.settings import (
     DIRECTORY_API_URL,
     DIRECTORY_API_CLIENT_KEY,
     SSO_PROXY_API_CLIENT_BASE_URL,
-    SSO_PROXY_SIGNATURE_SECRET
+    SSO_PROXY_SIGNATURE_SECRET,
+    FAB_CONFIRM_COLLABORATION_SUBJECT
 )
 
 INDUSTRY_CHOICES = dict(choices.INDUSTRIES)
@@ -1203,3 +1206,68 @@ def filter_out_legacy_industries(company: dict) -> list:
     result = [sector for sector in sectors if sector in INDUSTRY_CHOICES]
     logging.error('Sectors after: %s', result)
     return result
+
+
+@retry(wait_fixed=10000, stop_max_attempt_number=9)
+def mailgun_get_directory_message(context: Context, message_url: str) -> dict:
+    """Get message details from MailGun by its URL."""
+    # this will help us to get the raw MIME
+    headers = {"Accept": "message/rfc2822"}
+    response = make_request(
+        Method.GET, message_url, headers=headers,
+        auth=("api", MAILGUN_DIRECTORY_SECRET_API_KEY))
+    context.response = response
+
+    with assertion_msg(
+            "Expected to get 200 OK from MailGun when getting message details"
+            " but got %s %s instead", response.status_code, response.reason):
+        assert response.status_code == 200
+
+    return response.json()
+
+
+def mailgun_find_email_with_request_for_collaboration(
+        context: Context, actor: Actor, company: Company) -> dict:
+    logging.debug(
+        "Trying to find email with a request for collaboration with company: "
+        "%s", company.title)
+    subject = FAB_CONFIRM_COLLABORATION_SUBJECT.format(company.title)
+    response = find_mail_gun_events(
+        context, service=MailGunService.DIRECTORY, recipient=actor.email,
+        event=MailGunEvent.ACCEPTED, subject=subject)
+    context.response = response
+    with assertion_msg(
+            "Expected to find an email with a request for collaboration with "
+            "company: '%s'", company.alias):
+        assert response.status_code == 200
+    message_url = response.json()["items"][0]["storage"]["url"]
+    return mailgun_get_directory_message(context, message_url)
+
+
+def extract_plain_text_payload(msg: MIMEText) -> str:
+    """Extract plain text payload (7bit) from email message."""
+    res = None
+    if msg.is_multipart():
+        for part in msg.get_payload():
+            if part.get_content_type() == "text/plain":
+                res = part.get_payload()
+    else:
+        seven_bit = "Content-Transfer-Encoding: 7bit"
+        payload = msg.get_payload()
+        with assertion_msg("Could not find plain text msg in email payload"):
+            assert seven_bit in payload
+        start_7bit = payload.find(seven_bit)
+        start = start_7bit + len(seven_bit)
+        end = payload.find("--===============", start)
+        res = payload[start:end]
+    return res
+
+
+def extract_link_with_invitation_for_collaboration(payload: str) -> str:
+    start = payload.find("http")
+    end = payload.find("\n", start) - 1  # `- 1` to skip the newline char
+    invitation_link = payload[start:end]
+    assert invitation_link
+    logging.debug(
+        "Found the link with invitation for collaboration %s", invitation_link)
+    return invitation_link

--- a/tests/functional/utils/generic.py
+++ b/tests/functional/utils/generic.py
@@ -243,7 +243,7 @@ def find_mail_gun_events(
         assert number_of_events > 0
     logging.debug(
         "Found {} event(s) that matched following criteria: {}"
-            .format(number_of_events, params))
+        .format(number_of_events, params))
     return response
 
 

--- a/tests/functional/utils/generic.py
+++ b/tests/functional/utils/generic.py
@@ -439,6 +439,17 @@ def extract_csrf_middleware_token(response: Response):
     return token
 
 
+def extract_registration_page_link(response: Response) -> str:
+    with assertion_msg(
+            "Can't extract link to the Registration page as the response has "
+            "no content"):
+        assert response.content
+    css_selector = "#header-register-link::attr(href)"
+    link = extract_by_css(response, css_selector)
+    logging.debug("Found link to the Registration page token: %s", link)
+    return link
+
+
 def extract_form_action(response: Response) -> str:
     """Extract the form action (endpoint).
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -36,6 +36,8 @@ MAILGUN_DIRECTORY_SECRET_API_KEY = os.environ["MAILGUN_DIRECTORY_SECRET_API_KEY"
 EMAIL_VERIFICATION_MSG_SUBJECT = "Confirm your email address"
 FAS_MESSAGE_FROM_BUYER_SUBJECT = ("Someone is interested in your Find a Buyer "
                                   "profile")
+FAB_CONFIRM_COLLABORATION_SUBJECT = ("Confirm you’ve been added to {}’s Find a"
+                                     " buyer profile")
 SSO_PASSWORD_RESET_MSG_SUBJECT = "Reset your great.gov.uk password"
 NO_OF_EMPLOYEES = ["1-10", "11-50", "51-200", "201-500", "501-1000",
                    "1001-10000", "10001+"]


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-3556)

Scenario:
```gherkin
  @ED-3556
  @multi-user
  @add-collaborator
  Scenario: Add "1" collaborator without an SSO/great.gov.uk account to a verified company
    Given "Peter Alder" has created and verified profile for randomly selected company "Y"
    And "Annette Geissinger" "does not have" an SSO/great.gov.uk account
    And "Peter Alder" added "Annette Geissinger" as a collaborator
    And "Annette Geissinger" has received an email with a request to confirm that she's been added to company "Y" Find a Buyer profile

    When "Annette Geissinger" opens the invitation from company "Y", creates a SSO/great.gov.uk account and confirms that he wants to be added to the FAB profile

    Then "Annette Geissinger" should see "FAB Company profile" page
```
