### PR TITLE
ED-3561 transfer profile ownership

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -52,6 +52,7 @@ urls = {
     'ui-buyer:company-edit-contact': 'company-profile/edit/contact/',
     'ui-buyer:company-edit-social-media': 'company-profile/edit/social-media/',
     'ui-buyer:account-add-collaborator': 'account/add-collaborator/',
+    'ui-buyer:account-remove-collaborator': 'account/remove-collaborator/',
     'ui-buyer:account-transfer-ownership': 'account/transfer/',
     'ui-buyer:account-confirm-password': 'account/transfer/',
     'ui-buyer:account-confirm-ownership-transfer': 'account/transfer/accept/?invite_key=',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -54,6 +54,7 @@ urls = {
     'ui-buyer:account-add-collaborator': 'account/add-collaborator/',
     'ui-buyer:account-transfer-ownership': 'account/transfer/',
     'ui-buyer:account-confirm-password': 'account/transfer/',
+    'ui-buyer:account-confirm-ownership-transfer': 'account/transfer/accept/?invite_key=',
 
     # UI-SUPPLIER
     'ui-supplier:landing': '',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -52,6 +52,8 @@ urls = {
     'ui-buyer:company-edit-contact': 'company-profile/edit/contact/',
     'ui-buyer:company-edit-social-media': 'company-profile/edit/social-media/',
     'ui-buyer:account-add-collaborator': 'account/add-collaborator/',
+    'ui-buyer:account-transfer-ownership': 'account/transfer/',
+    'ui-buyer:account-confirm-password': 'account/transfer/',
 
     # UI-SUPPLIER
     'ui-supplier:landing': '',

--- a/tests/functional/environment.py
+++ b/tests/functional/environment.py
@@ -64,7 +64,7 @@ def after_step(context, step):
                 red("Found form related error(s)")
                 print(form_errors)
             green("Last recorded request & response")
-            print_response(res, trim=True)
+            print_response(res, trim=False)
         else:
             blue("There's no response content to log")
 

--- a/tests/functional/environment.py
+++ b/tests/functional/environment.py
@@ -64,7 +64,7 @@ def after_step(context, step):
                 red("Found form related error(s)")
                 print(form_errors)
             green("Last recorded request & response")
-            print_response(res, trim=False)
+            print_response(res, trim=True)
         else:
             blue("There's no response content to log")
 

--- a/tests/functional/features/fab/multiuser-accounts.feature
+++ b/tests/functional/features/fab/multiuser-accounts.feature
@@ -123,7 +123,6 @@ Feature: Multi-user accounts
     Then "Annette Geissinger" should not see options to manage Find a Buyer profile users on SSO Profile
 
 
-  @wip
   @ED-3561
   @multi-user
   @transfer-ownership
@@ -132,7 +131,6 @@ Feature: Multi-user accounts
     And "Annette Geissinger" "<has or does not have>" an SSO/great.gov.uk account
 
     When "Peter Alder" decides to transfer the ownership of company's "Y" Find a Buyer profile to "Annette Geissinger"
-    And "Peter Alder" confirms his password before transferring the ownership
 
     Then "Annette Geissinger" should receive an email with a request for becoming the owner of the company "Y" profile
 

--- a/tests/functional/features/fab/multiuser-accounts.feature
+++ b/tests/functional/features/fab/multiuser-accounts.feature
@@ -164,7 +164,6 @@ Feature: Multi-user accounts
       | does not have        | an unverified |
 
 
-  @wip
   @ED-3564
   @multi-user
   @remove-collaborator
@@ -180,7 +179,6 @@ Feature: Multi-user accounts
     And "Annette Geissinger" should not be able to access "FAB company profile" page
 
 
-  @wip
   @ED-3565
   @multi-user
   @remove-collaborator

--- a/tests/functional/features/fab/multiuser-accounts.feature
+++ b/tests/functional/features/fab/multiuser-accounts.feature
@@ -170,7 +170,9 @@ Feature: Multi-user accounts
   @fake-sso-email-verification
   Scenario: Account owner should be able to remove one account collaborator
     Given "Peter Alder" has created "an unverified" profile for randomly selected company "Y"
+    And "Annette Geissinger" "has" an SSO/great.gov.uk account
     And "Peter Alder" added "Annette Geissinger" as a collaborator
+    And "Annette Geissinger" has received an email with a request to confirm that she's been added to company "Y" Find a Buyer profile
     And "Annette Geissinger" confirmed that she wants to be added to the company "Y" Find a Buyer profile
 
     When "Peter Alder" removes "Annette Geissinger" from the list of collaborators to the company "Y"
@@ -185,7 +187,11 @@ Feature: Multi-user accounts
   @fake-sso-email-verification
   Scenario: Account owner should be able to remove multiple account collaborators
     Given "Peter Alder" has created "an unverified" profile for randomly selected company "Y"
+    And "Annette Geissinger, Betty Jones, James Weir" "have" an SSO/great.gov.uk account
     And "Peter Alder" added "Annette Geissinger, Betty Jones, James Weir" as a collaborator
+    And "Annette Geissinger" has received an email with a request to confirm that she's been added to company "Y" Find a Buyer profile
+    And "Betty Jones" has received an email with a request to confirm that she's been added to company "Y" Find a Buyer profile
+    And "James Weir" has received an email with a request to confirm that she's been added to company "Y" Find a Buyer profile
     And "Annette Geissinger" confirmed that she wants to be added to the company "Y" Find a Buyer profile
     And "Betty Jones" confirmed that she wants to be added to the company "Y" Find a Buyer profile
     And "James Weir" confirmed that he wants to be added to the company "Y" Find a Buyer profile
@@ -204,7 +210,7 @@ Feature: Multi-user accounts
   @verification
   @letter
   @fake-sso-email-verification
-  Scenario: Collaborators should be able to set cthe company description and verify company profile with verification code
+  Scenario: Collaborators should be able to set the company description and verify company profile with verification code
     Given "Peter Alder" has created "an unverified" profile for randomly selected company "Y"
     And "Annette Geissinger" "has" an SSO/great.gov.uk account
     And "Peter Alder" added "Annette Geissinger" as a collaborator

--- a/tests/functional/features/fab/multiuser-accounts.feature
+++ b/tests/functional/features/fab/multiuser-accounts.feature
@@ -298,6 +298,9 @@ Feature: Multi-user accounts
     And "Annette Geissinger" should see all case studies on the FAS Company's Directory Profile page
 
 
+  @bug
+  @ED-3882
+  @fixme
   @ED-3570
   @multi-user
   @edge-case
@@ -315,6 +318,9 @@ Feature: Multi-user accounts
     And "Annette Geissinger" should not see options to manage Find a Buyer profile users on SSO Profile
 
 
+  @bug
+  @ED-3882
+  @fixme
   @ED-3571
   @multi-user
   @edge-case

--- a/tests/functional/features/fab/multiuser-accounts.feature
+++ b/tests/functional/features/fab/multiuser-accounts.feature
@@ -126,7 +126,7 @@ Feature: Multi-user accounts
   @ED-3561
   @multi-user
   @transfer-ownership
-  Scenario Outline: New Account Owner should receive an email with a request to confirm account ownership
+  Scenario Outline: New Account Owner which "<has or does not have>" a SSO/great.gov.uk account should receive an email with a request for becoming the owner of "<a>" company profile
     Given "Peter Alder" has created "<a>" profile for randomly selected company "Y"
     And "Annette Geissinger" "<has or does not have>" an SSO/great.gov.uk account
 

--- a/tests/functional/features/fab/multiuser-accounts.feature
+++ b/tests/functional/features/fab/multiuser-accounts.feature
@@ -142,7 +142,6 @@ Feature: Multi-user accounts
       | does not have        | an unverified |
 
 
-  @wip
   @ED-3562
   @multi-user
   @transfer-ownership
@@ -295,7 +294,6 @@ Feature: Multi-user accounts
     And "Annette Geissinger" should see all case studies on the FAS Company's Directory Profile page
 
 
-  @wip
   @ED-3570
   @multi-user
   @edge-case
@@ -303,17 +301,16 @@ Feature: Multi-user accounts
   Scenario: New account owner should be able to transfer it back to the original owner
     Given "Peter Alder" has created "an unverified" profile for randomly selected company "Y"
     And "Annette Geissinger" "has" an SSO/great.gov.uk account
-    And "Annette Geissinger" accepted request for becoming the owner of company "Y" profile
-    And "Annette Geissinger" has received an email with a request to become owner of the Find a Buyer profile for company "Y"
 
-    When "Annette Geissinger" transfers the company "Y" account ownership to "Peter Alder"
-    And "Peter Alder" accepts the request for becoming the owner of company "Y" profile
+    When "Peter Alder" transfers the ownership of company's "Y" Find a Buyer profile to "Annette Geissinger"
+    Then "Annette Geissinger" should see options to manage Find a Buyer profile users on SSO Profile
+    And "Peter Alder" should not see options to manage Find a Buyer profile users on SSO Profile
 
+    When "Annette Geissinger" transfers the ownership of company's "Y" Find a Buyer profile to "Peter Alder"
     Then "Peter Alder" should see options to manage Find a Buyer profile users on SSO Profile
     And "Annette Geissinger" should not see options to manage Find a Buyer profile users on SSO Profile
 
 
-  @wip
   @ED-3571
   @multi-user
   @edge-case
@@ -321,13 +318,12 @@ Feature: Multi-user accounts
   Scenario: New account owner should be able to add the original owner as a collaborator to the company profile
     Given "Peter Alder" has created "an unverified" profile for randomly selected company "Y"
     And "Annette Geissinger" "has" an SSO/great.gov.uk account
-    And "Peter Alder" transferred the company "Y" account ownership to "Annette Geissinger"
-    And "Annette Geissinger" accepted request for becoming the owner of company "Y" profile
+    And "Peter Alder" transferred the ownership of company's "Y" Find a Buyer profile to "Annette Geissinger"
 
     When "Annette Geissinger" decides to add "Peter Alder" as a collaborator
     When "Peter Alder" confirms that he wants to be added to the company "Y" Find a Buyer profile
 
-    Then "Annette Geissinger" should see "FAB Company profile" page
+    Then "Peter Alder" should see "FAB Company profile" page
 
 
   @bug

--- a/tests/functional/features/fab/multiuser-accounts.feature
+++ b/tests/functional/features/fab/multiuser-accounts.feature
@@ -147,7 +147,7 @@ Feature: Multi-user accounts
   @transfer-ownership
   @bug
   @ED-2268
-  Scenario Outline: Company account owner should be able to transfer the account ownership to a user who "has or does not have" an SSO/great.gov.uk account
+  Scenario Outline: Company account owner should be able to transfer the ownership of "<a>" profile to a user who "<has or does not have>" an SSO/great.gov.uk account
     Given "Peter Alder" has created "<a>" profile for randomly selected company "Y"
     And "Annette Geissinger" "<has or does not have>" an SSO/great.gov.uk account
 
@@ -157,11 +157,11 @@ Feature: Multi-user accounts
     And "Peter Alder" should not see options to manage Find a Buyer profile users on SSO Profile
 
     Examples:
-      | has or does not have | a             |
-      | has                  | a verified    |
-      | has                  | an unverified |
-      | does not have        | a verified    |
-      | does not have        | an unverified |
+      | a             | has or does not have |
+      | a verified    | has                  |
+      | a verified    | does not have        |
+      | an unverified | has                  |
+      | an unverified | does not have        |
 
 
   @ED-3564

--- a/tests/functional/pages/fab_ui_account_add_collaborator.py
+++ b/tests/functional/pages/fab_ui_account_add_collaborator.py
@@ -13,7 +13,6 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if User is on the correct page."""
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
 
 
@@ -22,7 +21,6 @@ def go_to(session: Session) -> Response:
 
     This requires:
      * Supplier to be logged in
-
     """
     headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
     response = make_request(Method.GET, URL, session=session, headers=headers)

--- a/tests/functional/pages/fab_ui_account_confrim_password.py
+++ b/tests/functional/pages/fab_ui_account_confrim_password.py
@@ -14,7 +14,6 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if User is on the correct page."""
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
 
 
@@ -23,7 +22,6 @@ def go_to(session: Session) -> Response:
 
     This requires:
      * Supplier to be logged in
-
     """
     headers = {"Referer": URL}
     response = make_request(Method.GET, URL, session=session, headers=headers)

--- a/tests/functional/pages/fab_ui_account_confrim_password.py
+++ b/tests/functional/pages/fab_ui_account_confrim_password.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""FAB - Change profile owner - confirm password page"""
+from requests import Response, Session
+from tests import get_absolute_url
+from tests.functional.utils.generic import Method, make_request
+from tests.functional.utils.request import check_response
+
+URL = get_absolute_url("ui-buyer:account-confirm-password")
+EXPECTED_STRINGS = [
+    "Transfer account", "Your password",
+    "For your security, please enter your current password",
+    "Back to previous step", "Confirm", "Cancel"
+]
+
+
+def should_be_here(response: Response):
+    """Check if User is on the correct page."""
+    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+
+
+def go_to(session: Session) -> Response:
+    """Go to "Edit Company's Details" page.
+
+    This requires:
+     * Supplier to be logged in
+
+    """
+    headers = {"Referer": URL}
+    response = make_request(Method.GET, URL, session=session, headers=headers)
+
+    should_be_here(response)
+    return response
+
+
+def submit(session: Session, token: str, password: str) -> Response:
+    data = {
+        "csrfmiddlewaretoken": token,
+        "password-password": password,
+        "transfer_account_wizard_view-current_step": "password"
+    }
+    headers = {"Referer": URL}
+    return make_request(
+        Method.POST, URL, session=session, data=data, headers=headers)

--- a/tests/functional/pages/fab_ui_account_remove_collaborator.py
+++ b/tests/functional/pages/fab_ui_account_remove_collaborator.py
@@ -19,8 +19,6 @@ def should_be_here(response: Response):
 def go_to(session: Session) -> Response:
     headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
     response = make_request(Method.GET, URL, session=session, headers=headers)
-
-    should_be_here(response)
     return response
 
 

--- a/tests/functional/pages/fab_ui_account_remove_collaborator.py
+++ b/tests/functional/pages/fab_ui_account_remove_collaborator.py
@@ -11,10 +11,18 @@ EXPECTED_STRINGS = [
     "Confirm", "Cancel"
 ]
 
+EXPECTED_STRINGS_NO_COLLABORATORS = [
+    "Your company has no collaborators", "Click", "here", "to go back"
+]
 
-def should_be_here(response: Response):
+
+def should_be_here(response: Response, *, have_collaborators: bool = True):
     """Check if User is on the correct page."""
-    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+    if have_collaborators:
+        check_response(response, 200, body_contains=EXPECTED_STRINGS)
+    else:
+        check_response(
+            response, 200, body_contains=EXPECTED_STRINGS_NO_COLLABORATORS)
 
 
 def go_to(session: Session) -> Response:

--- a/tests/functional/pages/fab_ui_account_remove_collaborator.py
+++ b/tests/functional/pages/fab_ui_account_remove_collaborator.py
@@ -20,7 +20,6 @@ EXPECTED_STRINGS_NO_COLLABORATORS = [
 
 
 def should_be_here(response: Response, *, have_collaborators: bool = True):
-    """Check if User is on the correct page."""
     if have_collaborators:
         check_response(response, 200, body_contains=EXPECTED_STRINGS)
     else:
@@ -30,8 +29,7 @@ def should_be_here(response: Response, *, have_collaborators: bool = True):
 
 def go_to(session: Session) -> Response:
     headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
-    response = make_request(Method.GET, URL, session=session, headers=headers)
-    return response
+    return make_request(Method.GET, URL, session=session, headers=headers)
 
 
 def extract_email_to_id_mapping(label: str) -> Tuple[str, str]:

--- a/tests/functional/pages/fab_ui_account_remove_collaborator.py
+++ b/tests/functional/pages/fab_ui_account_remove_collaborator.py
@@ -32,3 +32,7 @@ def remove(session: Session, token: str, email: str) -> Response:
     headers = {"Referer": URL}
     return make_request(
         Method.POST, URL, session=session, data=data, headers=headers)
+
+
+def should_not_see_collaborator(response: Response, collaborator_email: str):
+    check_response(response, 200, unexpected_strings=[collaborator_email])

--- a/tests/functional/pages/fab_ui_account_remove_collaborator.py
+++ b/tests/functional/pages/fab_ui_account_remove_collaborator.py
@@ -7,7 +7,8 @@ from tests.functional.utils.request import check_response
 
 URL = get_absolute_url("ui-buyer:account-remove-collaborator")
 EXPECTED_STRINGS = [
-    "Remove user from your profile",
+    "Remove user from account", "Select the emails you would like to remove",
+    "Confirm", "Cancel"
 ]
 
 

--- a/tests/functional/pages/fab_ui_account_remove_collaborator.py
+++ b/tests/functional/pages/fab_ui_account_remove_collaborator.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 """FAB - Remove Collaborator page"""
+from typing import List, Tuple
+
 from requests import Response, Session
+from scrapy import Selector
 from tests import get_absolute_url
 from tests.functional.utils.generic import Method, make_request
 from tests.functional.utils.request import check_response
@@ -31,10 +34,37 @@ def go_to(session: Session) -> Response:
     return response
 
 
-def remove(session: Session, token: str, email: str) -> Response:
+def extract_email_to_id_mapping(label: str) -> Tuple[str, str]:
+    element_id = Selector(text=label).css("label::attr(for)").extract()[0]
+    email = Selector(text=label).css("label::text").extract()[0]
+    return email, element_id
+
+
+def extract_sso_id(html: str, email_to_element_id: Tuple[str, str]):
+    email, element_id = email_to_element_id
+    css_selector = '#{}::attr(value)'.format(element_id)
+    value = Selector(text=html).css(css_selector).extract()
+    return email, value[0] if value else None
+
+
+def extract_email_to_sso_id(html: str, mapping: dict) -> dict:
+    return dict(map(lambda email_to_element_id:
+                    extract_sso_id(html, email_to_element_id),
+                    mapping.items()))
+
+
+def extract_sso_ids(response: Response) -> dict:
+    content = response.content.decode("utf-8")
+    label_css = "label[for]"
+    labels = Selector(text=content).css(label_css).extract()
+    email_to_element_id_map = dict(map(extract_email_to_id_mapping, labels))
+    return extract_email_to_sso_id(content, email_to_element_id_map)
+
+
+def remove(session: Session, token: str, sso_ids: List[str]) -> Response:
     data = {
         "csrfmiddlewaretoken": token,
-        "email_address": email
+        "sso_ids": sso_ids
     }
     headers = {"Referer": URL}
     return make_request(

--- a/tests/functional/pages/fab_ui_account_remove_collaborator.py
+++ b/tests/functional/pages/fab_ui_account_remove_collaborator.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""FAB - Remove Collaborator page"""
+from requests import Response, Session
+from tests import get_absolute_url
+from tests.functional.utils.generic import Method, make_request
+from tests.functional.utils.request import check_response
+
+URL = get_absolute_url("ui-buyer:account-remove-collaborator")
+EXPECTED_STRINGS = [
+    "Remove user from your profile",
+]
+
+
+def should_be_here(response: Response):
+    """Check if User is on the correct page."""
+    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+
+
+def go_to(session: Session) -> Response:
+    headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
+    response = make_request(Method.GET, URL, session=session, headers=headers)
+
+    should_be_here(response)
+    return response
+
+
+def remove(session: Session, token: str, email: str) -> Response:
+    data = {
+        "csrfmiddlewaretoken": token,
+        "email_address": email
+    }
+    headers = {"Referer": URL}
+    return make_request(
+        Method.POST, URL, session=session, data=data, headers=headers)

--- a/tests/functional/pages/fab_ui_account_transfer_ownership.py
+++ b/tests/functional/pages/fab_ui_account_transfer_ownership.py
@@ -13,7 +13,6 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if User is on the correct page."""
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
 
 
@@ -22,7 +21,6 @@ def go_to(session: Session) -> Response:
 
     This requires:
      * Supplier to be logged in
-
     """
     headers = {"Referer": get_absolute_url("profile:fab")}
     response = make_request(Method.GET, URL, session=session, headers=headers)

--- a/tests/functional/pages/fab_ui_account_transfer_ownership.py
+++ b/tests/functional/pages/fab_ui_account_transfer_ownership.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""FAB - Change profile owner page"""
+from requests import Response, Session
+from tests import get_absolute_url
+from tests.functional.utils.generic import Method, make_request
+from tests.functional.utils.request import check_response
+
+URL = get_absolute_url("ui-buyer:account-transfer-ownership")
+EXPECTED_STRINGS = [
+    "Transfer account", "Next", "Cancel",
+    "Enter the email address you want your profile transferred to."
+]
+
+
+def should_be_here(response: Response):
+    """Check if User is on the correct page."""
+    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+
+
+def go_to(session: Session) -> Response:
+    """Go to "Edit Company's Details" page.
+
+    This requires:
+     * Supplier to be logged in
+
+    """
+    headers = {"Referer": get_absolute_url("profile:fab")}
+    response = make_request(Method.GET, URL, session=session, headers=headers)
+
+    should_be_here(response)
+    return response
+
+
+def submit(session: Session, token: str, email: str) -> Response:
+    data = {
+        "csrfmiddlewaretoken": token,
+        "email-email_address": email,
+        "transfer_account_wizard_view-current_step": "email"
+    }
+    headers = {"Referer": URL}
+    return make_request(
+        Method.POST, URL, session=session, data=data, headers=headers)

--- a/tests/functional/pages/fab_ui_build_profile_address.py
+++ b/tests/functional/pages/fab_ui_build_profile_address.py
@@ -11,8 +11,8 @@ URL = get_absolute_url("ui-buyer:company-edit")
 EXPECTED_STRINGS = [
     "Your company address", "About your company", "Industry and exporting",
     "Confirmation",
-    ("Enter your name. We’ll then send a confirmation letter to your company’s "
-     "registered address address within 5 working days."),
+    ("Enter your name. We’ll then send a confirmation letter to your company’s"
+     " registered address address within 5 working days."),
     "Your name:", "Company number", "Tick to confirm address.",
     ("If you can’t collect the letter yourself, you’ll need to make sure "
      "someone can send it on to you."), "Back to previous step", "Send"
@@ -20,21 +20,15 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on FAB Build your profile - Choose Sector page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
-    logging.debug("Successfully got to the FAB Build and improve your profile. "
-                  "Choose Your company sector")
+    logging.debug(
+        "Successfully got to the FAB Build and improve your profile. Choose "
+        "Your company sector")
 
 
 def submit(actor: Actor) -> Response:
     """Build Profile - Provide Supplier's full name, which will be use when
     sending verification letter.
-
-    :param actor: a namedtuple with Actor details
-    :return: response object
     """
     headers = {"Referer": URL}
     data = {
@@ -43,7 +37,5 @@ def submit(actor: Actor) -> Response:
         "address-postal_full_name": actor.alias,
         "address-address_confirmed": "on"
     }
-    response = make_request(
+    return make_request(
         Method.POST, URL, session=actor.session, headers=headers, data=data)
-
-    return response

--- a/tests/functional/pages/fab_ui_build_profile_basic.py
+++ b/tests/functional/pages/fab_ui_build_profile_basic.py
@@ -9,16 +9,17 @@ from tests.functional.utils.request import Method, check_response, make_request
 
 URL = get_absolute_url("ui-buyer:company-edit")
 EXPECTED_STRINGS = [
-    "Build and improve your profile", "About your company", "Industry and exporting",
-    ("To set up your Find a Buyer profile, enter your company’s basic details, "
-     "then choose which sectors you’re interested in."),
-    ("You can add extra information and a company logo to complete your profile"
-     ". You can edit your profile at any time."),
+    "Build and improve your profile", "About your company",
+    "Industry and exporting",
+    ("To set up your Find a Buyer profile, enter your company’s basic details,"
+     " then choose which sectors you’re interested in."),
+    ("You can add extra information and a company logo to complete your "
+     "profile. You can edit your profile at any time."),
     ("From early 2017, your company profile will be published online and "
      "promoted to international buyers."), "Your company details",
     "Company name", "Website (optional)", "Enter your preferred business name",
     "The website address must start with either http:// or https://",
-    "Enter up to 10 keywords that describe your company (separated by commas):",
+    "Enter up to 10 keywords that describe your company (separated by commas)",
     ("These keywords will be used to help potential overseas buyers find your "
      "company."), "How many employees are in your company?", "Next",
     ("Tell international buyers more about your business to ensure the right "
@@ -27,32 +28,16 @@ EXPECTED_STRINGS = [
 
 
 def go_to(session: Session) -> Response:
-    """Go to "Confirm Company" page. This requires Company
-
-    :param session: Supplier session object
-    :return: response object
-    """
-    response = make_request(Method.GET, URL, session=session)
-
-    return response
+    return make_request(Method.GET, URL, session=session)
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on FAB Build and improve your profile page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Successfully got to the FAB Build and improve your profile")
 
 
 def submit(actor: Actor, company: Company) -> Response:
-    """Submit Build your profile - Basic details form.
-
-    :param actor: a namedtuple with Actor details
-    :param company: a namedtuple with Company details
-    :return: response object
-    """
+    """Submit Build your profile - Basic details form."""
     data = {
         "csrfmiddlewaretoken": actor.csrfmiddlewaretoken,
         "company_profile_edit_view-current_step": "basic"
@@ -66,6 +51,5 @@ def submit(actor: Actor, company: Company) -> Response:
     if company.no_employees is not None:
         data.update({"basic-employees": company.no_employees})
     headers = {"Referer": URL}
-    response = make_request(
+    return make_request(
         Method.POST, URL, session=actor.session, headers=headers, data=data)
-    return response

--- a/tests/functional/pages/fab_ui_build_profile_sector.py
+++ b/tests/functional/pages/fab_ui_build_profile_sector.py
@@ -19,24 +19,14 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on FAB Build and improve your profile page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
-    logging.debug("Successfully got to the FAB Build and improve your profile. "
-                  "Choose Your company sector")
+    logging.debug(
+        "Successfully got to the FAB Build and improve your profile. Choose "
+        "Your company sector")
 
 
 def submit(actor: Actor, sector: str, countries: list, other: str) -> Response:
-    """Submit Build your profile - Choose your sector form.
-
-    :param actor: a namedtuple with Actor details
-    :param sector: Industry Sector in which company is interested in
-    :param countries: a list of country codes of preferred countries to export
-    :param other: list of other countries your company is exporting to
-    :return: response object
-    """
+    """Submit Build your profile - Choose your sector form."""
     headers = {"Referer": URL}
     data = {
         "csrfmiddlewaretoken": actor.csrfmiddlewaretoken,

--- a/tests/functional/pages/fab_ui_build_profile_verification_letter.py
+++ b/tests/functional/pages/fab_ui_build_profile_verification_letter.py
@@ -17,20 +17,12 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on FAB Build your profile - Confirm page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on the FAB Build your profile - Confirm page")
 
 
 def go_to_profile(session: Session) -> Response:
-    """Supplier click on the 'View or amend your company profile' link
-
-    :param session: Supplier session object
-    :return: response object
-    """
+    """Supplier clicks on the 'View or amend your company profile' link."""
     url = get_absolute_url("ui-buyer:company-profile")
     headers = {"Referer": URL}
     response = make_request(

--- a/tests/functional/pages/fab_ui_case_study_basic.py
+++ b/tests/functional/pages/fab_ui_case_study_basic.py
@@ -14,14 +14,14 @@ EXPECTED_STRINGS = [
     "Create case study or project", "Basic", "Images",
     ("Describe something significant your company has done that will be "
      "relevant to international buyers. For example, you could add details of "
-     "a significant collaboration on a recent international project or a major "
-     "export deal."), "Title of your case study or project:",
+     "a significant collaboration on a recent international project or a major"
+     " export deal."), "Title of your case study or project:",
     "Give your case study a title of 60 characters or fewer.",
     "Summary of your case study or project:",
     ("Summarise your case study in 200 characters or fewer. This will appear "
-     "on your main trade profile page"), "Describe your case study or project:",
-    ("Describe the project or case study in 1,000 characters or fewer. Use this"
-     " space to demonstrate the value of your company to an international "
+     "on your main trade profile page"), "Describe your case study or project",
+    ("Describe the project or case study in 1,000 characters or fewer. Use "
+     "this space to demonstrate the value of your company to an international "
      "business audience."), "Sector:",
     "Select the sector most relevant to your case study or project.",
     "The web address for your case study (optional):",
@@ -34,10 +34,6 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on 'Create case study or project' - basic page")
 
@@ -47,9 +43,6 @@ def go_to(session: Session, *, case_number: int = None) -> Response:
 
     This requires:
      * Supplier to be logged in
-
-    :param session: Supplier session object
-    :param case_number: (optional) case study number
     """
     if case_number:
         url = urljoin(EDIT_URL, str(case_number), "/")
@@ -62,12 +55,7 @@ def go_to(session: Session, *, case_number: int = None) -> Response:
 
 
 def prepare_form_data(token: str, case_study: CaseStudy) -> dict:
-    """Prepare form data based on the flags and custom values provided.
-
-    :param token: CSRF middleware token required to submit the form
-    :param case_study: a CaseStudy namedtuple with random data
-    :return: form data with all fields filled out
-    """
+    """Prepare form data based on the flags and custom values provided."""
     data = {
         "csrfmiddlewaretoken": token,
         "supplier_case_study_wizard_view-current_step": "basic",
@@ -81,13 +69,9 @@ def prepare_form_data(token: str, case_study: CaseStudy) -> dict:
     return data
 
 
-def submit_form(session: Session, token: str, case_study: CaseStudy) -> Response:
-    """Submit the form with basic case study data.
-
-    :param session: Supplier session object
-    :param token: CSRF token required to submit the form
-    :param case_study: a CaseStudy namedtuple with random data
-    """
+def submit_form(
+        session: Session, token: str, case_study: CaseStudy) -> Response:
+    """Submit the form with basic case study data."""
     data = prepare_form_data(token, case_study)
     headers = {"Referer": URL}
     response = make_request(

--- a/tests/functional/pages/fab_ui_case_study_images.py
+++ b/tests/functional/pages/fab_ui_case_study_images.py
@@ -22,8 +22,8 @@ EXPECTED_STRINGS = [
     "Upload a third image (optional):",
     "Add a caption that tells visitors what this third image represents:",
     "Testimonial or block quote (optional):",
-    ("Add testimonial from a satisfied client or use this space to highlight an"
-     " important part of your case study."),
+    ("Add testimonial from a satisfied client or use this space to highlight "
+     "an important part of your case study."),
     "Full name of the source of the testimonial (optional):",
     ("Add the source to make the quote more credible and to help buyers "
      "understand the importance of the testimonial."),
@@ -33,21 +33,13 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
-    logging.debug("Supplier is on 'Create case study or project' - images page")
+    logging.debug(
+        "Supplier is on 'Create case study or project' - images page")
 
 
 def prepare_form_data(token: str, case_study: CaseStudy) -> (dict, dict):
-    """Prepare form data based on the flags and custom values provided.
-
-    :param token: CSRF middleware token required to submit the form
-    :param case_study: a CaseStudy namedtuple with random data
-    :return: a tuple consisting of form data and files to upload
-    """
+    """Prepare form data based on the flags and custom values provided."""
     data = {
         "csrfmiddlewaretoken": token,
         "supplier_case_study_wizard_view-current_step": "rich-media",
@@ -87,14 +79,9 @@ def prepare_form_data(token: str, case_study: CaseStudy) -> (dict, dict):
     return data, files
 
 
-def submit_form(session: Session, token: str, case_study: CaseStudy) -> Response:
-    """Submit the form with case study images and extra data.
-
-    :param session: Supplier session object
-    :param token: CSRF token required to submit the form
-    :param case_study: a CaseStudy namedtuple with random data
-    :return: response object
-    """
+def submit_form(
+        session: Session, token: str, case_study: CaseStudy) -> Response:
+    """Submit the form with case study images and extra data."""
     data, files = prepare_form_data(token, case_study)
     headers = {"Referer": URL}
 

--- a/tests/functional/pages/fab_ui_case_study_images.py
+++ b/tests/functional/pages/fab_ui_case_study_images.py
@@ -88,6 +88,7 @@ def submit_form(
     response = make_request(
         Method.POST, URL, session=session, headers=headers, data=data,
         files=files, trim=True)
-    logging.debug("Supplier successfully submitted case study images: %s", data)
+    logging.debug(
+        "Supplier successfully submitted case study images: %s", data)
 
     return response

--- a/tests/functional/pages/fab_ui_confim_your_collaboration.py
+++ b/tests/functional/pages/fab_ui_confim_your_collaboration.py
@@ -13,13 +13,12 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if Collaborator is on FAB Confirm your collaboration Page."""
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
-    logging.debug("Successfully got to the FAB Confirm your collaboration page")
+    logging.debug(
+        "Successfully got to the FAB Confirm your collaboration page")
 
 
 def open(session: Session, link: str) -> Response:
-    """Open the invitation link sent to the Collaborator."""
     with assertion_msg("Expected a non-empty invitation link"):
         assert link
     return make_request(Method.GET, link, session=session)

--- a/tests/functional/pages/fab_ui_confim_your_ownership.py
+++ b/tests/functional/pages/fab_ui_confim_your_ownership.py
@@ -15,7 +15,6 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if Collaborator is on FAB Confirm your profile ownership Page."""
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Successfully got to the FAB Confirm your ownership page")
 

--- a/tests/functional/pages/fab_ui_confim_your_ownership.py
+++ b/tests/functional/pages/fab_ui_confim_your_ownership.py
@@ -3,9 +3,11 @@
 import logging
 
 from requests import Response, Session
+from tests import get_absolute_url
 from tests.functional.utils.generic import assertion_msg
 from tests.functional.utils.request import Method, check_response, make_request
 
+URL = get_absolute_url("ui-buyer:account-confirm-ownership-transfer")
 EXPECTED_STRINGS = [
     "Transfer account", "Do you accept transfer of the company profile for",
     "Yes", "No"

--- a/tests/functional/pages/fab_ui_confim_your_ownership.py
+++ b/tests/functional/pages/fab_ui_confim_your_ownership.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""FAB - Confirm your want to become the new owner of company's profile page"""
+import logging
+
+from requests import Response, Session
+from tests.functional.utils.generic import assertion_msg
+from tests.functional.utils.request import Method, check_response, make_request
+
+EXPECTED_STRINGS = [
+    "Transfer account", "Do you accept transfer of the company profile for",
+    "Yes", "No"
+]
+
+
+def should_be_here(response: Response):
+    """Check if Collaborator is on FAB Confirm your profile ownership Page."""
+    check_response(response, 200, body_contains=EXPECTED_STRINGS)
+    logging.debug("Successfully got to the FAB Confirm your ownership page")
+
+
+def open(session: Session, link: str) -> Response:
+    with assertion_msg("Expected a non-empty account transfer request link"):
+        assert link
+    return make_request(Method.GET, link, session=session)
+
+
+def confirm(
+        session: Session, csrf_middleware_token: str, link: str) -> Response:
+    # in order to be redirected to the correct URL we have `unquote`
+    # the form_action_value
+    start = link.index("=") + 1
+    invite_key = link[start:]
+    headers = {"Referer": link}
+    data = {
+        "csrfmiddlewaretoken": csrf_middleware_token,
+        "invite_key": invite_key
+    }
+
+    return make_request(
+        Method.POST, link, session=session, headers=headers,
+        data=data)

--- a/tests/functional/pages/fab_ui_confirm_company.py
+++ b/tests/functional/pages/fab_ui_confirm_company.py
@@ -48,7 +48,8 @@ def confirm_company_selection(
         "enrolment_view-current_step": "company",
         "company-company_name": company.title,
         "company-company_number": company.number,
-        "company-company_address": company.companies_house_details["address_snippet"]
+        "company-company_address":
+            company.companies_house_details["address_snippet"]
     }
 
     return make_request(

--- a/tests/functional/pages/fab_ui_confirm_company.py
+++ b/tests/functional/pages/fab_ui_confirm_company.py
@@ -22,12 +22,6 @@ EXPECTED_STRINGS = [
 
 
 def go_to(session: Session, company: Company) -> Response:
-    """Go to "Confirm Company" page. This requires Company
-
-    :param session: Supplier session object
-    :param company: a namedtuple with Company details
-    :return: response object
-    """
     data = {"company_name": company.title, "company_number": company.number}
     headers = {"Referer": URL}
 
@@ -38,11 +32,6 @@ def go_to(session: Session, company: Company) -> Response:
 
 
 def should_be_here(response: Response, company: Company):
-    """Check if Supplier is on Confirm Export Status page.
-
-    :param response: response with Confirm Export Status page
-    :param company: a namedtuple with Company details
-    """
     escaped_company_title = escape_html(company.title, upper=True)
     expected = EXPECTED_STRINGS + [escaped_company_title, company.number]
     check_response(response, 200, body_contains=expected)
@@ -51,12 +40,6 @@ def should_be_here(response: Response, company: Company):
 
 def confirm_company_selection(
         session: Session, company: Company, token: str) -> Response:
-    """Confirm that the selected company is the right one.
-
-    :param session: Supplier session object
-    :param company: a named tuple with Company details
-    :param token: a CSRF token required to submit the form
-    """
     query = "?company_number={}".format(company.number)
     url = urljoin(get_absolute_url('ui-buyer:register-confirm-company'), query)
     headers = {"Referer": url}

--- a/tests/functional/pages/fab_ui_confirm_export_status.py
+++ b/tests/functional/pages/fab_ui_confirm_export_status.py
@@ -23,22 +23,12 @@ EXPECTED_STRINGS_WO_SSO_ACCOUNT = [
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on Confirm Export Status page.
-
-    :param response: response with Confirm Export Status page
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on Confirm Export Status page")
 
 
 def submit(session: Session, token: str, exported: bool) -> Response:
-    """Submit the Export Status form.
-
-    :param session: Supplier session object
-    :param token: a CSRF token required to submit the form
-    :param exported: True is exported in the past, False if not
-    :return: response object
-    """
+    """Submit the Export Status form."""
     url = get_absolute_url("ui-buyer:register-confirm-export-status")
     headers = {"Referer": url}
     data = {
@@ -60,8 +50,6 @@ def should_see_info_about_sso_account(response: Response):
 
     NOTE:
     This requires Supplier not to have a SSO account.
-
-    :param response: response with Confirm Export Status page
     """
     expected = EXPECTED_STRINGS + EXPECTED_STRINGS_WO_SSO_ACCOUNT
     check_response(response, 200, body_contains=expected)

--- a/tests/functional/pages/fab_ui_confirm_identity.py
+++ b/tests/functional/pages/fab_ui_confirm_identity.py
@@ -57,11 +57,7 @@ def should_be_here(
 
 
 def confirm_with_letter(actor: Actor) -> Response:
-    """Choose to verify your identity with a physical letter.
-
-    :param actor: a namedtuple with Actor details
-    :return: response object
-    """
+    """Choose to verify your identity with a physical letter."""
     headers = {"Referer": URL}
     letter_url = get_absolute_url("ui-buyer:confirm-identity-letter")
     response = make_request(

--- a/tests/functional/pages/fab_ui_confirm_identity_letter.py
+++ b/tests/functional/pages/fab_ui_confirm_identity_letter.py
@@ -20,21 +20,13 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on FAB Confirm your Identity - with letter page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug(
         "Successfully got to the FAB Confirm your Identity - with letter page")
 
 
 def submit(actor: Actor) -> Response:
-    """Verify your identity with a physical letter.
-
-    :param actor: a namedtuple with Actor details
-    :return: response object
-    """
+    """Verify your identity with a physical letter."""
     headers = {"Referer": URL}
     data = {
         "csrfmiddlewaretoken": actor.csrfmiddlewaretoken,

--- a/tests/functional/pages/fab_ui_confirm_identity_letter.py
+++ b/tests/functional/pages/fab_ui_confirm_identity_letter.py
@@ -10,8 +10,8 @@ from tests.functional.utils.request import Method, check_response, make_request
 URL = get_absolute_url("ui-buyer:confirm-identity-letter")
 EXPECTED_STRINGS = [
     "Your company address", "Address",
-    ("Enter your name. We’ll then send a confirmation letter to your company’s "
-     "registered address address within 5 working days."),
+    ("Enter your name. We’ll then send a confirmation letter to your company’s"
+     " registered address address within 5 working days."),
     "Your name:", "Company number",
     "Tick to confirm address.",
     ("If you can’t collect the letter yourself, you’ll"

--- a/tests/functional/pages/fab_ui_edit_description.py
+++ b/tests/functional/pages/fab_ui_edit_description.py
@@ -14,10 +14,6 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on the Select Sector page")
 
@@ -28,7 +24,9 @@ def go_to(session: Session) -> Response:
     return response
 
 
-def submit(session: Session, token: str, summary: str, description: str) -> Response:
+def submit(
+        session: Session, token: str, summary: str, description: str)\
+        -> Response:
     headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
     data = {
         "csrfmiddlewaretoken": token,

--- a/tests/functional/pages/fab_ui_edit_details.py
+++ b/tests/functional/pages/fab_ui_edit_details.py
@@ -19,7 +19,7 @@ EXPECTED_STRINGS = [
     "Build and improve your profile", "Your company details", "Company name:",
     "Enter your preferred business name", "Website (optional):",
     "The website address must start with either http:// or https://",
-    "Enter up to 10 keywords that describe your company (separated by commas):",
+    "Enter up to 10 keywords that describe your company (separated by commas)",
     ("These keywords will be used to help potential overseas buyers find your "
      "company."), "How many employees are in your company?",
     ("Tell international buyers more about your business to ensure the right "
@@ -28,10 +28,6 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
 
 
@@ -40,7 +36,6 @@ def go_to(session: Session) -> Response:
 
     This requires:
      * Supplier to be logged in
-
     """
     headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
     response = make_request(Method.GET, URL, session=session, headers=headers)
@@ -56,19 +51,6 @@ def update_details(
     """Update basic Company's details: business name, website, keywords & size.
 
     Will use random details or specific values if they are provided.
-
-    :param actor: a namedtuple with Actor details
-    :param company: a namedtuple with Company details
-    :param title: change business title if True, or use the current one if False
-    :param website: change website if True, or use the current one if False
-    :param keywords: change keywords if True, or use the current one if False
-    :param size: change number of employees if True, or use the current one
-    :param specific_title: use specific business title (if provided)
-    :param specific_website: use specific website (if provided)
-    :param specific_keywords: use specific keywords (if provided)
-    :param specific_size: use specific number of employees (if provided)
-    :return: a tuple consisting of Response object and Company details that were
-             actually send in the update request.
     """
     session = actor.session
     token = actor.csrfmiddlewaretoken

--- a/tests/functional/pages/fab_ui_edit_online_profiles.py
+++ b/tests/functional/pages/fab_ui_edit_online_profiles.py
@@ -24,10 +24,6 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on the Edit Online Profiles page")
 
@@ -37,9 +33,6 @@ def go_to(session: Session) -> Response:
 
     This requires:
      * Supplier to be logged in
-
-    :param session: Supplier session object
-    :return: response object
     """
     headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
     response = make_request(Method.GET, URL, session=session, headers=headers)
@@ -56,17 +49,6 @@ def update_profiles(
     NOTE:
     If any of `specific_*` arguments is set to an empty string, then this will
     remove existing link.
-
-    :param actor: a namedtuple with Actor details
-    :param company: a namedtuple with Company details
-    :param facebook: change Facebook URL if True, or use the current one if False
-    :param linkedin: change LinkedIn URL if True, or use the current one if False
-    :param twitter: change Twitter URL if True, or use the current one if False
-    :param specific_facebook: use specific Facebook URL
-    :param specific_linkedin: use specific LinkedIn URL
-    :param specific_twitter: use specific Twitter URL
-    :return: a tuple consisting of a Response object & a namedtuple with Company
-             details used in the update request.
     """
     session = actor.session
     token = actor.csrfmiddlewaretoken
@@ -79,17 +61,20 @@ def update_profiles(
     fake_tw = "http://twitter.com/{}".format(profile_suffix)
 
     if facebook:
-        new_fb = specific_facebook if specific_facebook is not None else fake_fb
+        new_fb = specific_facebook \
+            if specific_facebook is not None else fake_fb
     else:
         new_fb = company.facebook
 
     if linkedin:
-        new_li = specific_linkedin if specific_linkedin is not None else fake_li
+        new_li = specific_linkedin \
+            if specific_linkedin is not None else fake_li
     else:
         new_li = company.linkedin
 
     if twitter:
-        new_tw = specific_twitter if specific_twitter is not None else fake_tw
+        new_tw = specific_twitter \
+            if specific_twitter is not None else fake_tw
     else:
         new_tw = company.twitter
 
@@ -112,13 +97,6 @@ def update_profiles(
 
 def should_see_errors(
         response: Response, *, facebook=True, linkedin=True, twitter=True):
-    """Check if all required errors are visible.
-
-    :param response: a Response object
-    :param facebook: check for a Facebook URL error if True, or not if False
-    :param linkedin: check for a LinkedIn URL error if True, or not if False
-    :param twitter: check for a Twitter URL error if True, or not if False
-    """
     content = response.content.decode("utf-8")
     if facebook:
         with assertion_msg("Could't find link to Facebook profile"):
@@ -134,15 +112,7 @@ def should_see_errors(
 def remove_links(
         actor: Actor, company: Company, *, facebook=False, linkedin=False,
         twitter=False) -> Response:
-    """Remove links to all existing Online Profiles.
-
-    :param actor: a namedtuple with Actor details
-    :param company: a namedtuple with Company details
-    :param facebook: remove link to Facebook profile if True, or not if False
-    :param linkedin: remove link to LinkedIn profile if True, or not if False
-    :param twitter: remove link to Twitter profile if True, or not if False
-    :return: a Response object
-    """
+    """Remove links to all existing Online Profiles."""
     response, _ = update_profiles(
         actor, company, facebook=facebook, linkedin=linkedin,
         twitter=twitter, specific_facebook="", specific_linkedin="",

--- a/tests/functional/pages/fab_ui_edit_sector.py
+++ b/tests/functional/pages/fab_ui_edit_sector.py
@@ -22,8 +22,6 @@ def go_to(session: Session) -> Response:
 
     This requires:
      * Supplier to be logged in
-
-    :param session: Supplier session object
     """
     headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
     response = make_request(
@@ -34,10 +32,6 @@ def go_to(session: Session) -> Response:
 
 
 def should_be_here(response):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on the Select Sector page")
 
@@ -67,7 +61,8 @@ def update(
         new_sector = company.sector
 
     if update_countries:
-        new_countries = country_names or COUNTRIES[random.choice(list(COUNTRIES))]
+        random_country = COUNTRIES[random.choice(list(COUNTRIES))]
+        new_countries = country_names or random_country
     else:
         new_countries = company.export_to_countries
 

--- a/tests/functional/pages/fab_ui_landing.py
+++ b/tests/functional/pages/fab_ui_landing.py
@@ -16,29 +16,17 @@ EXPECTED_STRINGS = [
 
 
 def go_to(session: Session) -> Response:
-    """Go to the FAB Landing page.
-
-    :param session: Supplier session object
-    :return: response object
-    """
     response = make_request(Method.GET, URL, session=session)
     return response
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on FAB Landing page
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Successfully got to the FAB Landing page")
 
 
 def should_be_logged_out(response: Response):
-    """Check if Supplier is logged out by checking the cookies.
-
-    :param response: response object
-    """
+    """Check if Supplier is logged out by checking the cookies."""
     with assertion_msg(
             "Found sso_display_logged_in cookie in the response. Maybe user is"
             " still logged in?"):

--- a/tests/functional/pages/fab_ui_profile.py
+++ b/tests/functional/pages/fab_ui_profile.py
@@ -41,22 +41,13 @@ def go_to(session: Session) -> Response:
 
 
 def should_be_here(response: Response):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on FAB Company's Profile page")
 
 
 def should_see_details(
         company: Company, response: Response, table_of_details: Table):
-    """Supplier should see all expected Company details of FAB profile page.
-
-    :param company: a namedtuple with Company details
-    :param response: a response object
-    :param table_of_details: a table of expected company details
-    """
+    """Supplier should see all expected Company details of FAB profile page."""
     visible_details = [row["detail"] for row in table_of_details]
     content = response.content.decode("utf-8")
 

--- a/tests/functional/pages/fab_ui_profile.py
+++ b/tests/functional/pages/fab_ui_profile.py
@@ -3,12 +3,12 @@
 import logging
 
 from behave.model import Table
-from requests import Response
+from requests import Response, Session
 from tests import get_absolute_url
 from tests.functional.common import DETAILS
 from tests.functional.utils.context_utils import Company
 from tests.functional.utils.generic import assertion_msg
-from tests.functional.utils.request import check_response
+from tests.functional.utils.request import Method, check_response, make_request
 from tests.settings import SECTORS_WITH_LABELS
 
 URL = get_absolute_url("ui-buyer:company-profile")
@@ -32,6 +32,12 @@ EXPECTED_STRINGS_NOT_VERIFIED = [
     "Your company has not yet been verified.", "Verify your company",
     "Your profile can't be published until your company is verified"
 ]
+
+
+def go_to(session: Session) -> Response:
+    headers = {"Referer": URL}
+    response = make_request(Method.GET, URL, session=session, headers=headers)
+    return response
 
 
 def should_be_here(response: Response):

--- a/tests/functional/pages/fab_ui_try_other_services.py
+++ b/tests/functional/pages/fab_ui_try_other_services.py
@@ -16,11 +16,5 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on Try our other services page.
-
-    Supplier can get here, when the company has not exporting intent.
-
-    :param response: response with Try our other services page
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on Try our other services page")

--- a/tests/functional/pages/fab_ui_upload_logo.py
+++ b/tests/functional/pages/fab_ui_upload_logo.py
@@ -23,32 +23,16 @@ EXPECTED_STRINGS_INVALID = [
 
 
 def go_to(session: Session) -> Response:
-    """Go to the FAB Upload Logo page.
-
-    :param session: Supplier session object
-    :return: response object
-    """
     response = make_request(Method.GET, URL, session=session)
     return response
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on FAB Upload Logo page
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Successfully got to the FAB Upload Logo page")
 
 
 def upload(session: Session, token: str, file_path: str) -> Response:
-    """Upload logo.
-
-    :param session: Supplier session object
-    :param token: CSRF token required to upload the file
-    :param file_path: absolute path to the uploaded file
-    :return: response object
-    """
     headers = {"Referer": get_absolute_url("ui-buyer:upload-logo")}
     url = get_absolute_url("ui-buyer:upload-logo")
     data = {
@@ -66,11 +50,7 @@ def upload(session: Session, token: str, file_path: str) -> Response:
 
 
 def was_upload_rejected(response: Response) -> bool:
-    """Check if uploaded file was rejected or not.
-
-    :param response: response object
-    :return: True if file was rejected and False if it was accepted
-    """
+    """Check if uploaded file was rejected or not."""
     content = response.content.decode("utf-8")
     has_error = any([phrase in content for phrase in EXPECTED_STRINGS_INVALID])
     is_200 = response.status_code == 200

--- a/tests/functional/pages/fab_ui_verify_company.py
+++ b/tests/functional/pages/fab_ui_verify_company.py
@@ -22,12 +22,6 @@ EXPECTED_STRINGS_VERIFIED = [
 
 
 def go_to(session: Session, *, referer: str = None) -> Response:
-    """Go to "Confirm Company" page. This requires Company
-
-    :param session: Supplier session object
-    :param referer: (optional) custom referer header value
-    :return: response object
-    """
     referer = referer or get_absolute_url("ui-buyer:company-profile")
     headers = {"Referer": referer}
     response = make_request(Method.GET, URL, session=session, headers=headers)
@@ -35,24 +29,13 @@ def go_to(session: Session, *, referer: str = None) -> Response:
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on Verify Company page.
-
-    :param response: response with Verify Company page.
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on the Verify Company page")
 
 
 def submit(session: Session, token: str, verification_code: str, *,
            referer: str = None) -> Response:
-    """Submit the form with verification code.
-
-    :param session: Supplier session object
-    :param token: CSRF token required to submit the form
-    :param verification_code: code required to verify company's profile
-    :param referer: (optional) custom referer header value
-    :return: response object
-    """
+    """Submit the form with verification code."""
     if referer is None:
         referer = get_absolute_url("ui-buyer:company-profile")
     headers = {"Referer": referer}
@@ -73,11 +56,7 @@ def should_see_company_is_verified(response: Response):
 
 
 def view_or_amend_profile(session: Session) -> Response:
-    """Simulate clicking on the 'View or amend your company profile' link.
-
-    :param session: Supplier session object
-    :return: response object
-    """
+    """Simulate clicking on the 'View or amend your company profile' link."""
     headers = {"Referer": URL}
     url = get_absolute_url("ui-buyer:company-profile")
     response = make_request(Method.GET, url, session=session, headers=headers)

--- a/tests/functional/pages/fas_ui_contact.py
+++ b/tests/functional/pages/fas_ui_contact.py
@@ -36,7 +36,8 @@ def go_to(
 
 
 def should_be_here(response, *, name=None):
-    expected = EXPECTED_STRINGS + [escape_html(name)] if name else EXPECTED_STRINGS
+    extra_strings_to_check = [escape_html(name)] if name else EXPECTED_STRINGS
+    expected = EXPECTED_STRINGS + extra_strings_to_check
     check_response(response, 200, body_contains=expected)
     logging.debug("Supplier is on FAS Contact Company page")
 

--- a/tests/functional/pages/fas_ui_contact.py
+++ b/tests/functional/pages/fas_ui_contact.py
@@ -13,9 +13,9 @@ LANDING = get_absolute_url("ui-supplier:landing")
 URL = urljoin(LANDING, 'suppliers/{company_number}/contact/')
 EXPECTED_STRINGS = [
     "Send a message to",
-    ("Fill in your details and a brief message summarising your needs that will"
-     " be sent to the UK company."), "Your full name:", "Your company name:",
-    "Country:", "Your email address:", "Industry:",
+    ("Fill in your details and a brief message summarising your needs that "
+     "will be sent to the UK company."), "Your full name:",
+    "Your company name:", "Country:", "Your email address:", "Industry:",
     "Enter a subject line for your message:", "Maximum 200 characters.",
     "Enter your message to the UK company:", "Maximum 1000 characters.",
     "Captcha:", "I agree to the great.gov.uk terms and conditions", "Send",
@@ -27,14 +27,8 @@ EXPECTED_STRINGS_MESSAGE_SENT = [
 ]
 
 
-def go_to(session: Session, company_number: str, company_name: str) -> Response:
-    """Go to Company's FAS profile page using company's number.
-
-    :param session: Supplier session object
-    :param company_number: company number
-    :param company_name: name of the company
-    :return: response object
-    """
+def go_to(
+        session: Session, company_number: str, company_name: str) -> Response:
     full_url = URL.format(company_number=company_number)
     response = make_request(Method.GET, full_url, session=session)
     should_be_here(response, name=company_name)
@@ -47,7 +41,8 @@ def should_be_here(response, *, name=None):
     logging.debug("Supplier is on FAS Contact Company page")
 
 
-def submit(session: Session, message: Message or Feedback, company_number: str):
+def submit(
+        session: Session, message: Message or Feedback, company_number: str):
     full_url = URL.format(company_number=company_number)
     headers = {"Referer": URL.format(company_number=company_number)}
     data = {
@@ -66,7 +61,8 @@ def submit(session: Session, message: Message or Feedback, company_number: str):
     return response
 
 
-def should_see_that_message_has_been_sent(company: Company, response: Response):
+def should_see_that_message_has_been_sent(
+        company: Company, response: Response):
     expected = EXPECTED_STRINGS_MESSAGE_SENT + [escape_html(company.title)]
     check_response(response, 200, body_contains=expected)
     logging.debug("Buyer was told that the message has been sent")

--- a/tests/functional/pages/fas_ui_contact.py
+++ b/tests/functional/pages/fas_ui_contact.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 
 from requests import Response, Session
 from tests import get_absolute_url
-from tests.functional.utils.context_utils import Company, Message
+from tests.functional.utils.context_utils import Company, Feedback, Message
 from tests.functional.utils.generic import escape_html
 from tests.functional.utils.request import Method, check_response, make_request
 
@@ -47,7 +47,7 @@ def should_be_here(response, *, name=None):
     logging.debug("Supplier is on FAS Contact Company page")
 
 
-def submit(session: Session, message: Message, company_number: str):
+def submit(session: Session, message: Message or Feedback, company_number: str):
     full_url = URL.format(company_number=company_number)
     headers = {"Referer": URL.format(company_number=company_number)}
     data = {

--- a/tests/functional/pages/fas_ui_creative_industry.py
+++ b/tests/functional/pages/fas_ui_creative_industry.py
@@ -17,19 +17,10 @@ EXPECTED_STRINGS = [
 
 
 def go_to(session: Session) -> Response:
-    """Go to Creative Industry Page on FAS
-
-    :param session: Supplier session object
-    :return: response object
-    """
     headers = {"Referer": get_absolute_url("ui-supplier:industries")}
     return make_request(Method.GET, URL, session=session, headers=headers)
 
 
 def should_be_here(response: Response):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on FAS Creative Industry page")

--- a/tests/functional/pages/fas_ui_creative_industry_summary.py
+++ b/tests/functional/pages/fas_ui_creative_industry_summary.py
@@ -16,19 +16,10 @@ EXPECTED_STRINGS = [
 
 
 def go_to(session: Session) -> Response:
-    """Go to Creative Industry Page on FAS
-
-    :param session: Supplier session object
-    :return: response object
-    """
     headers = {"Referer": get_absolute_url("ui-supplier:industries")}
     return make_request(Method.GET, URL, session=session, headers=headers)
 
 
 def should_be_here(response: Response):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on FAS Creative Industry page")

--- a/tests/functional/pages/fas_ui_feedback.py
+++ b/tests/functional/pages/fas_ui_feedback.py
@@ -19,8 +19,8 @@ EXPECTED_STRINGS_FORM = [
 EXPECTED_STRINGS_SUCCESSFUL_SUBMISSION = [
     "Your request has been submitted",
     "Thank you for letting us know about your organisation’s needs.",
-    ("UK government staff based in your region will be in touch to let you know"
-     " how UK businesses can help you.")
+    ("UK government staff based in your region will be in touch to let you "
+     "know how UK businesses can help you.")
 ]
 EXPECTED_STRINGS_ERRORS = [
     "This field is required.",
@@ -29,11 +29,6 @@ EXPECTED_STRINGS_ERRORS = [
 
 
 def go_to(session: Session) -> Response:
-    """Go to FAS send Feedback form page.
-
-    :param session: Buyer session object
-    :return: response object
-    """
     headers = {"Referer": get_absolute_url("ui-supplier:feedback")}
     response = make_request(Method.GET, URL, session=session, headers=headers)
     should_be_here(response)
@@ -41,10 +36,6 @@ def go_to(session: Session) -> Response:
 
 
 def should_be_here(response):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS_FORM)
     logging.debug("Buyer is on FAS send Feedback page")
 
@@ -61,13 +52,12 @@ def should_see_errors(response):
 
 
 def submit(
-        session: Session, feedback: Feedback, *, referer: str = None) -> Response:
+        session: Session, feedback: Feedback, *, referer: str = None)\
+        -> Response:
     """Submit feedback form.
 
-    :param session: Buyer session object
     :param feedback: a namedtuple with Feedback request details
     :param referer: (optional) Originating page. Defaults to "{FAS}/feedback"
-    :return: response object
     """
     if referer:
         headers = {"Referer": referer}
@@ -84,5 +74,6 @@ def submit(
         "g-recaptcha-response": feedback.g_recaptcha_response,
     }
     response = make_request(
-        Method.POST, URL, session=session, headers=headers, data=data, trim=False)
+        Method.POST, URL, session=session, headers=headers, data=data,
+        trim=False)
     return response

--- a/tests/functional/pages/fas_ui_find_supplier.py
+++ b/tests/functional/pages/fas_ui_find_supplier.py
@@ -25,11 +25,9 @@ def go_to(
         sectors: list = None) -> Response:
     """Go to "FAS Find a Supplier" page.
 
-    :param session: Supplier session object
     :param term: (optional) search term
     :param page: (optional) number of search result page
     :param sectors: (optional) a list of Industry sector filters
-    :return: response object
     """
     params = {}
     if term is not None:
@@ -47,11 +45,6 @@ def go_to(
 
 
 def should_be_here(response, *, number=None):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    :param number: (optional) company number
-    """
     expected = EXPECTED_STRINGS + [number] if number else EXPECTED_STRINGS
     check_response(response, 200, body_contains=expected)
     logging.debug("Buyer is on the FAS Find a Supplier page")

--- a/tests/functional/pages/fas_ui_food_and_drink_industry.py
+++ b/tests/functional/pages/fas_ui_food_and_drink_industry.py
@@ -16,19 +16,10 @@ EXPECTED_STRINGS = [
 
 
 def go_to(session: Session) -> Response:
-    """Go to Food and Drink Industry Page on FAS
-
-    :param session: Supplier session object
-    :return: response object
-    """
     headers = {"Referer": get_absolute_url("ui-supplier:industries")}
     return make_request(Method.GET, URL, session=session, headers=headers)
 
 
 def should_be_here(response: Response):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on FAS Food and Drink Industry page")

--- a/tests/functional/pages/fas_ui_food_and_drink_industry_summary.py
+++ b/tests/functional/pages/fas_ui_food_and_drink_industry_summary.py
@@ -16,19 +16,10 @@ EXPECTED_STRINGS = [
 
 
 def go_to(session: Session) -> Response:
-    """Go to Food and Drink Industry Page on FAS
-
-    :param session: Supplier session object
-    :return: response object
-    """
     headers = {"Referer": get_absolute_url("ui-supplier:industries")}
     return make_request(Method.GET, URL, session=session, headers=headers)
 
 
 def should_be_here(response: Response):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on FAS Food and Drink Industry page")

--- a/tests/functional/pages/fas_ui_health_industry.py
+++ b/tests/functional/pages/fas_ui_health_industry.py
@@ -18,19 +18,10 @@ EXPECTED_STRINGS = [
 
 
 def go_to(session: Session) -> Response:
-    """Go to Health Industry Page on FAS
-
-    :param session: Supplier session object
-    :return: response object
-    """
     headers = {"Referer": get_absolute_url("ui-supplier:industries")}
     return make_request(Method.GET, URL, session=session, headers=headers)
 
 
 def should_be_here(response: Response):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on FAS Health Industry page")

--- a/tests/functional/pages/fas_ui_health_industry_summary.py
+++ b/tests/functional/pages/fas_ui_health_industry_summary.py
@@ -20,19 +20,10 @@ EXPECTED_STRINGS = [
 
 
 def go_to(session: Session) -> Response:
-    """Go to Health Industry Page on FAS
-
-    :param session: Supplier session object
-    :return: response object
-    """
     headers = {"Referer": get_absolute_url("ui-supplier:industries")}
     return make_request(Method.GET, URL, session=session, headers=headers)
 
 
 def should_be_here(response: Response):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on FAS Health Industry page")

--- a/tests/functional/pages/fas_ui_industries.py
+++ b/tests/functional/pages/fas_ui_industries.py
@@ -37,20 +37,11 @@ EXPECTED_STRINGS_FOOD_AND_DRINK = [
 
 
 def go_to(session: Session) -> Response:
-    """Go to Industries Page on FAS
-
-    :param session: Supplier session object
-    :return: response object
-    """
     headers = {"Referer": get_absolute_url("ui-supplier:landing")}
     return make_request(Method.GET, URL, session=session, headers=headers)
 
 
 def should_be_here(response: Response):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on FAS Industries page")
 

--- a/tests/functional/pages/fas_ui_profile.py
+++ b/tests/functional/pages/fas_ui_profile.py
@@ -22,12 +22,7 @@ EXPECTED_STRINGS = [
 
 
 def go_to(session: Session, company_number: str) -> Response:
-    """Go to Company's FAS profile page using company's number.
-
-    :param session: Supplier session object
-    :param company_number: (optional) explicit company number
-    :return: response object
-    """
+    """Go to Company's FAS profile page using company's number."""
     full_url = urljoin(URL, company_number)
     headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
     response = make_request(
@@ -42,9 +37,7 @@ def go_to(session: Session, company_number: str) -> Response:
 def go_to_endpoint(session: Session, endpoint: str) -> Response:
     """Go to Company's FAS profile page using explicit FAS endpoint.
 
-    :param session: Supplier session object
     :param endpoint: FAS endpoint that leads directly to Company's profile page
-    :return: response object
     """
     fas_url = get_absolute_url("ui-supplier:landing")
     profile_url = urljoin(fas_url, endpoint)
@@ -52,11 +45,6 @@ def go_to_endpoint(session: Session, endpoint: str) -> Response:
 
 
 def should_be_here(response, *, number=None):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    :param number: (optional) expected company number
-    """
     expected = EXPECTED_STRINGS + [number] if number else EXPECTED_STRINGS
     check_response(response, 200, body_contains=expected)
     logging.debug("Supplier is on FAS Company's Profile page")
@@ -119,11 +107,13 @@ def should_see_details(
     sector = DETAILS["SECTOR"] in visible_details
 
     if title:
-        with assertion_msg("Couldn't find Company's title '%s'", company.title):
+        with assertion_msg(
+                "Couldn't find Company's title '%s'", company.title):
             assert company.title in content
     if keywords:
         for keyword in company.keywords.split(", "):
-            with assertion_msg("Couldn't find Company's keyword '%s'", keyword):
+            with assertion_msg(
+                    "Couldn't find Company's keyword '%s'", keyword):
                 assert keyword.strip() in content
     if website:
         with assertion_msg(
@@ -158,7 +148,7 @@ def get_case_studies_details(response: Response):
         summary = Selector(text=article).css("p::text").extract()[0]
         href = Selector(text=article).css("a::attr(href)").extract()[0]
         slug = href.split("/")[-2]
-        assert slug, "Could not extract case study slug from {}".format(article)
+        assert slug, "Couldn't extract case study slug from {}".format(article)
         logging.debug("Got case study slug: %s", slug)
         result.append((title, summary, href, slug))
     assert result, "No Case Study details extracted from {}".format(articles)

--- a/tests/functional/pages/fas_ui_tech_industry.py
+++ b/tests/functional/pages/fas_ui_tech_industry.py
@@ -17,19 +17,10 @@ EXPECTED_STRINGS = [
 
 
 def go_to(session: Session) -> Response:
-    """Go to Tech Industry Page on FAS
-
-    :param session: Supplier session object
-    :return: response object
-    """
     headers = {"Referer": get_absolute_url("ui-supplier:industries")}
     return make_request(Method.GET, URL, session=session, headers=headers)
 
 
 def should_be_here(response: Response):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on FAS Tech Industry page")

--- a/tests/functional/pages/fas_ui_tech_industry_summary.py
+++ b/tests/functional/pages/fas_ui_tech_industry_summary.py
@@ -16,19 +16,10 @@ EXPECTED_STRINGS = [
 
 
 def go_to(session: Session) -> Response:
-    """Go to Tech Industry Page on FAS
-
-    :param session: Supplier session object
-    :return: response object
-    """
     headers = {"Referer": get_absolute_url("ui-supplier:industries")}
     return make_request(Method.GET, URL, session=session, headers=headers)
 
 
 def should_be_here(response: Response):
-    """Check if User is on the correct page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Supplier is on FAS Tech Industry page")

--- a/tests/functional/pages/profile_ui_find_a_buyer.py
+++ b/tests/functional/pages/profile_ui_find_a_buyer.py
@@ -31,6 +31,10 @@ EXPECTED_STRINGS_OWNER_TRANSFERRED = [
     "We’ve sent a confirmation email to the new profile owner."
 ]
 
+EXPECTED_STRINGS_USER_REMOVED = [
+    "User successfully removed from your profile"
+]
+
 
 def go_to(session: Session) -> Response:
     """Go to the Profile 'Find a buyer' page / tab.
@@ -45,7 +49,9 @@ def go_to(session: Session) -> Response:
     return response
 
 
-def should_be_here(response: Response, *, owner_transferred: bool = False):
+def should_be_here(
+        response: Response, *, owner_transferred: bool = False,
+        user_removed: bool = False):
     """Check if Supplier is on Profile 'Find a Buyer' page.
 
     NOTE:
@@ -60,6 +66,15 @@ def should_be_here(response: Response, *, owner_transferred: bool = False):
             assert expected_query in response.url
         check_response(
             response, 200, body_contains=EXPECTED_STRINGS_OWNER_TRANSFERRED)
+    if user_removed:
+        expected_query = "?user-removed"
+        with assertion_msg(
+                "Expected to see '{}' in the URL but got: '{}' instead"
+                .format(expected_query, response.url)):
+            assert expected_query in response.url
+        check_response(
+            response, 200, body_contains=EXPECTED_STRINGS_USER_REMOVED)
+
     logging.debug("Successfully got to the Profile 'Find a Buyer' page")
 
 

--- a/tests/functional/pages/profile_ui_find_a_buyer.py
+++ b/tests/functional/pages/profile_ui_find_a_buyer.py
@@ -4,6 +4,7 @@ import logging
 
 from requests import Response, Session
 from tests import get_absolute_url
+from tests.functional.utils.generic import assertion_msg
 from tests.functional.utils.request import Method, check_response, make_request
 
 URL = get_absolute_url("profile:fab")
@@ -26,6 +27,10 @@ EXPECTED_STRINGS_NO_PROFILE = [
     "have buyers contact your sales team directly to get deals moving"
 ]
 
+EXPECTED_STRINGS_OWNER_TRANSFERRED = [
+    "We’ve sent a confirmation email to the new profile owner."
+]
+
 
 def go_to(session: Session) -> Response:
     """Go to the Profile 'Find a buyer' page / tab.
@@ -40,15 +45,21 @@ def go_to(session: Session) -> Response:
     return response
 
 
-def should_be_here(response: Response):
+def should_be_here(response: Response, *, owner_transferred: bool = False):
     """Check if Supplier is on Profile 'Find a Buyer' page.
 
     NOTE:
     Supplier has to be logged in to get to this page.
-
-    :param response: response object
     """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
+    if owner_transferred:
+        expected_query = "?owner-transferred"
+        with assertion_msg(
+                "Expected to see '{}' in the URL but got: '{}' instead"
+                .format(expected_query, response.url)):
+            assert expected_query in response.url
+        check_response(
+            response, 200, body_contains=EXPECTED_STRINGS_OWNER_TRANSFERRED)
     logging.debug("Successfully got to the Profile 'Find a Buyer' page")
 
 

--- a/tests/functional/pages/profile_ui_find_a_buyer.py
+++ b/tests/functional/pages/profile_ui_find_a_buyer.py
@@ -37,11 +37,6 @@ EXPECTED_STRINGS_USER_REMOVED = [
 
 
 def go_to(session: Session) -> Response:
-    """Go to the Profile 'Find a buyer' page / tab.
-
-    :param session: Supplier session object
-    :return: response object
-    """
     headers = {"Referer": get_absolute_url("profile:about")}
     response = make_request(Method.GET, URL, session=session, headers=headers)
     should_be_here(response)
@@ -84,8 +79,6 @@ def should_see_get_a_trade_profile(response: Response):
 
     NOTE:
     Supplier has to be logged in to get to this page.
-
-    :param response: response object
     """
     expected = EXPECTED_STRINGS + EXPECTED_STRINGS_NO_PROFILE
     check_response(response, 200, body_contains=expected)
@@ -98,8 +91,6 @@ def should_see_links_to_manage_trade_profile(response: Response):
 
     NOTE:
     Supplier has to be logged in to get to this page.
-
-    :param response: response object
     """
     expected = EXPECTED_STRINGS + EXPECTED_STRINGS_WITH_PROFILE
     check_response(response, 200, body_contains=expected)
@@ -111,9 +102,6 @@ def go_to_create_a_trade_profile(session: Session) -> Response:
 
     NOTE:
     This simulates a 'Click' on the 'Create a trade profile' button.
-
-    :param session: Supplier session object
-    :return: response object
     """
     url = get_absolute_url("ui-buyer:landing")
     response = make_request(Method.GET, url, session=session)

--- a/tests/functional/pages/profile_ui_landing.py
+++ b/tests/functional/pages/profile_ui_landing.py
@@ -6,41 +6,34 @@ from tests.functional.utils.request import check_response
 
 EXPECTED_STRINGS = [
     "Welcome to your great.gov.uk profile",
-    ("From now on, every time you sign in you’ll be able to quickly access all "
-     "of our exporting tools in one place. The tools are here to help your "
+    ("From now on, every time you sign in you’ll be able to quickly access all"
+     " of our exporting tools in one place. The tools are here to help your "
      "business succeed internationally."),
-    ("You can start using any of our exporting tools by clicking on the tabs on"
-     " your profile."), "Export opportunities", "Find a buyer",
+    ("You can start using any of our exporting tools by clicking on the tabs "
+     "on your profile."), "Export opportunities", "Find a buyer",
     "Selling online overseas",
     ("Find thousands of exporting opportunities, search and apply within your "
      "industry or a specific country, and sign up for email alerts so you’re "
      "the first to know of new opportunities."),
-    ("Promote your business to overseas buyers with your own trade profile, add"
-     " case studies of your company’s best work, and let buyers contact your "
-     "sales team directly."),
+    ("Promote your business to overseas buyers with your own trade profile, "
+     "add case studies of your company’s best work, and let buyers contact "
+     "your sales team directly."),
     ("Join major online marketplaces in other countries and access special "
      "offers negotiated by the Department for International Trade.")
 ]
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on SSO landing page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
 
 
 def should_be_logged_out(response: Response):
-    """Check if Supplier is logged out by checking the cookies.
-
-    :param response: response object
-    """
+    """Check if Supplier is logged out by checking the cookies."""
     with assertion_msg(
-            "Found sso_display_logged_in cookie in the response. Maybe user is "
-            "still logged in?"):
+            "Found sso_display_logged_in cookie in the response. Maybe user is"
+            " still logged in?"):
         assert "sso_display_logged_in" not in response.cookies
     with assertion_msg(
-            "Found directory_sso_dev_session cookie in the response. Maybe user"
-            " is still logged in?"):
+            "Found directory_sso_dev_session cookie in the response. Maybe "
+            "user is still logged in?"):
         assert "directory_sso_dev_session" not in response.cookies

--- a/tests/functional/pages/sso_ui_change_password.py
+++ b/tests/functional/pages/sso_ui_change_password.py
@@ -9,18 +9,10 @@ from tests.functional.utils.context_utils import Actor
 from tests.functional.utils.generic import assertion_msg
 from tests.functional.utils.request import Method, check_response, make_request
 
-EXPECTED_STRINGS = [
-    "Change Password",
-    "New Password:",
-    "New Password (again):", "change password"
-]
+EXPECTED_STRINGS = ["Change Password", "New Password:", "New Password (again)"]
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on SSO Change Password Page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Successfully got to the SSO Change Password page")
 
@@ -28,15 +20,6 @@ def should_be_here(response: Response):
 def submit(
         actor: Actor, action: str, *, password: str = None,
         password_again: str = None, referer: str = None) -> Response:
-    """Try to change the password to the SSO account.
-
-    :param actor: a namedtuple with Actor details
-    :param action: target form action
-    :param password: (optional) new password
-    :param password_again: (optional) password confirmation
-    :param referer: (optional) referer URL
-    :return: response object
-    """
     session = actor.session
     URL = urljoin(get_absolute_url("sso:landing"), action)
     profile_about = get_absolute_url("profile:about")

--- a/tests/functional/pages/sso_ui_confim_your_email.py
+++ b/tests/functional/pages/sso_ui_confim_your_email.py
@@ -15,21 +15,11 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on SSO Confirm your email Page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Successfully got to the SSO Confirm your email page")
 
 
 def open_confirmation_link(session: Session, link: str) -> Response:
-    """Open email confirmation link sent to the Supplier.
-
-    :param session: Supplier session object
-    :param link: email confirmation link
-    :return: response object
-    """
     with assertion_msg("Expected a non-empty email confirmation link"):
         assert link
     return make_request(Method.GET, link, session=session)
@@ -38,9 +28,7 @@ def open_confirmation_link(session: Session, link: str) -> Response:
 def confirm(actor: Actor, form_action_value: str) -> Response:
     """Confirm the email address provided by the Supplier.
 
-    :param actor: a namedtuple with Actor details
     :param form_action_value: form action from SSO Confirm your email page
-    :return: response object
     """
     session = actor.session
     # in order to be redirected to the correct URL we have `unquote`

--- a/tests/functional/pages/sso_ui_invalid_password_reset_link.py
+++ b/tests/functional/pages/sso_ui_invalid_password_reset_link.py
@@ -13,9 +13,5 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on SSO Change Password Page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Got to the SSO Invalid Password Reset Link page")

--- a/tests/functional/pages/sso_ui_login.py
+++ b/tests/functional/pages/sso_ui_login.py
@@ -16,7 +16,8 @@ EXPECTED_STRINGS = [
 
 
 def go_to(
-        session: Session, *, next_param: str = None, referer: str = None)-> Response:
+        session: Session, *, next_param: str = None, referer: str = None)\
+        -> Response:
     fab_landing = get_absolute_url("ui-buyer:landing")
     params = {"next": next_param or fab_landing}
     headers = {"Referer": referer or fab_landing}
@@ -26,10 +27,6 @@ def go_to(
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on SSO Verify your email Page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Successfully got to the SSO Verify your email page")
 
@@ -37,15 +34,6 @@ def should_be_here(response: Response):
 def login(
         actor: Actor, *, token: str = None, referer: str = None,
         next_param: str = None) -> Response:
-    """Try to sign in to FAB as a Supplier without verified email address.
-
-    :param actor: a namedtuple with Actor details
-    :param token: (optional) CSRF token required to submit the login form
-    :param referer: (optional) referer URL. Defaults to FAB Landing page
-    :param next_param: (optional) URL to go to after successful login.
-                       Defaults to FAB Landing page
-    :return: response object
-    """
     session = actor.session
     fab_landing = get_absolute_url("ui-buyer:landing")
 

--- a/tests/functional/pages/sso_ui_logout.py
+++ b/tests/functional/pages/sso_ui_logout.py
@@ -14,12 +14,6 @@ EXPECTED_STRINGS = [
 
 
 def go_to(session: Session, *, next_param: str = None) -> Response:
-    """Go to the SSO Logout page.
-
-    :param session: Supplier session object
-    :param next_param: (optional) URL to redirect to after successful login
-    :return: response object
-    """
     fab_landing = get_absolute_url("ui-buyer:landing")
     params = {"next": next_param or fab_landing}
     headers = {"Referer": get_absolute_url("ui-buyer:company-profile")}
@@ -29,22 +23,12 @@ def go_to(session: Session, *, next_param: str = None) -> Response:
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on SSO logout page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Successfully got to the SSO logout page")
 
 
-def logout(session: Session, token: str, *, next_param: str = None) -> Response:
-    """Sign out from SSO/FAB.
-
-    :param session: Supplier session object
-    :param token: CSRF token required to submit the login form
-    :param next_param: (optional) URL to redirect to after logging out
-    :return: response object
-    """
+def logout(
+        session: Session, token: str, *, next_param: str = None) -> Response:
     fab_landing = get_absolute_url("ui-buyer:landing")
     data = {
         "csrfmiddlewaretoken": token,

--- a/tests/functional/pages/sso_ui_password_reset.py
+++ b/tests/functional/pages/sso_ui_password_reset.py
@@ -34,34 +34,19 @@ def go_to(session: Session, *, next_param: str = None) -> Response:
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on SSO Password Reset Page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Successfully got to the SSO Password Reset page")
 
 
 def should_see_that_password_was_reset(response: Response):
-    """Check if Supplier is on SSO Password Reset confirmation Page.
-
-    :param response: response object
-    """
-    check_response(response, 200, body_contains=EXPECTED_STRINGS_PASSWORD_RESET)
+    check_response(
+        response, 200, body_contains=EXPECTED_STRINGS_PASSWORD_RESET)
     logging.debug("Successfully Reset Password")
 
 
 def reset(
         actor: Actor, token: str, *, referer: str = None,
         next_param: str = None) -> Response:
-    """Try to reset the password to the SSO account.
-
-    :param actor: a namedtuple with Actor details
-    :param token: CSRF token required to submit the password reset form
-    :param referer: (optional) referer URL
-    :param next_param: (optional) URL to go to after successful password reset
-    :return: response object
-    """
     session = actor.session
     fab_landing = get_absolute_url("ui-buyer:landing")
 

--- a/tests/functional/pages/sso_ui_register.py
+++ b/tests/functional/pages/sso_ui_register.py
@@ -24,17 +24,13 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on SSO Registration Page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Successfully got to the SSO Registration page")
 
 
 def go_to(
-        session: Session, *, next: str = None, referer: str = None) -> Response:
-    """Go to the SSO Registration page."""
+        session: Session, *, next: str = None, referer: str = None)\
+        -> Response:
     referer = referer or get_absolute_url("ui-buyer:landing")
     if next:
         url = urljoin(URL, "?next={}".format(next))

--- a/tests/functional/pages/sso_ui_verify_your_email.py
+++ b/tests/functional/pages/sso_ui_verify_your_email.py
@@ -14,9 +14,5 @@ EXPECTED_STRINGS = [
 
 
 def should_be_here(response: Response):
-    """Check if Supplier is on SSO Verify your email Page.
-
-    :param response: response object
-    """
     check_response(response, 200, body_contains=EXPECTED_STRINGS)
     logging.debug("Successfully got to the SSO Verify your email page")

--- a/tests/functional/registry/__init__.py
+++ b/tests/functional/registry/__init__.py
@@ -34,7 +34,8 @@ from tests.functional.pages import (
     fab_ui_confim_your_collaboration,
     fab_ui_account_transfer_ownership,
     fab_ui_account_confrim_password,
-    fab_ui_confim_your_ownership
+    fab_ui_confim_your_ownership,
+    fab_ui_account_remove_collaborator
 )
 
 from tests import get_absolute_url
@@ -223,6 +224,10 @@ FAB_PAGE_REGISTRY = {
         "url": "ui-buyer:account-add-collaborator",
         "po": fab_ui_account_add_collaborator
     },
+    "fab remove collaborator": {
+        "url": fab_ui_account_remove_collaborator.URL,
+        "po": fab_ui_account_remove_collaborator
+    },
     "fab confirm you want to be added to the profile": {
         "url": None,
         "po": fab_ui_confim_your_collaboration
@@ -235,7 +240,7 @@ FAB_PAGE_REGISTRY = {
         "url": fab_ui_account_confrim_password.URL,
         "po": fab_ui_account_confrim_password
     },
-    "": {
+    "fab confirm ownership transfer": {
         "url": fab_ui_confim_your_ownership.URL,
         "po": fab_ui_confim_your_ownership
     },

--- a/tests/functional/registry/__init__.py
+++ b/tests/functional/registry/__init__.py
@@ -31,7 +31,9 @@ from tests.functional.pages import (
     sud_ui_find_a_buyer,
     sud_ui_export_opportunities,
     fab_ui_account_add_collaborator,
-    fab_ui_confim_your_collaboration
+    fab_ui_confim_your_collaboration,
+    fab_ui_account_transfer_ownership,
+    fab_ui_account_confrim_password
 )
 
 from tests import get_absolute_url
@@ -223,7 +225,15 @@ FAB_PAGE_REGISTRY = {
     "fab confirm you want to be added to the profile": {
         "url": None,
         "po": fab_ui_confim_your_collaboration
-    }
+    },
+    "fab transfer ownership": {
+        "url": fab_ui_account_transfer_ownership.URL,
+        "po": fab_ui_account_transfer_ownership
+    },
+    "fab confirm password": {
+        "url": fab_ui_account_confrim_password.URL,
+        "po": fab_ui_account_confrim_password
+    },
 }
 
 SUD_PAGE_REGISTRY = {

--- a/tests/functional/registry/__init__.py
+++ b/tests/functional/registry/__init__.py
@@ -33,7 +33,8 @@ from tests.functional.pages import (
     fab_ui_account_add_collaborator,
     fab_ui_confim_your_collaboration,
     fab_ui_account_transfer_ownership,
-    fab_ui_account_confrim_password
+    fab_ui_account_confrim_password,
+    fab_ui_confim_your_ownership
 )
 
 from tests import get_absolute_url
@@ -233,6 +234,10 @@ FAB_PAGE_REGISTRY = {
     "fab confirm password": {
         "url": fab_ui_account_confrim_password.URL,
         "po": fab_ui_account_confrim_password
+    },
+    "": {
+        "url": fab_ui_confim_your_ownership.URL,
+        "po": fab_ui_confim_your_ownership
     },
 }
 

--- a/tests/functional/steps/fab_given_def.py
+++ b/tests/functional/steps/fab_given_def.py
@@ -35,6 +35,7 @@ from tests.functional.steps.fab_then_impl import (
 from tests.functional.steps.fab_when_impl import (
     fab_confirm_collaboration_request,
     fab_open_collaboration_request_link,
+    fab_transfer_ownership,
     go_to_page,
     prof_add_case_study,
     prof_add_collaborator,
@@ -257,3 +258,10 @@ def given_collaborator_confirms_the_collaboration_request(
         context, collaborator_alias, company_alias):
     fab_confirm_collaboration_request(
         context, collaborator_alias, company_alias)
+
+
+@given('"{supplier_alias}" transferred the ownership of company\'s "{company_alias}" Find a Buyer profile to "{new_owner_alias}"')
+def given_supplier_transfers_the_account_ownership(
+        context, supplier_alias, company_alias, new_owner_alias):
+    fab_transfer_ownership(
+        context, supplier_alias, company_alias, new_owner_alias)

--- a/tests/functional/steps/fab_given_def.py
+++ b/tests/functional/steps/fab_given_def.py
@@ -33,12 +33,12 @@ from tests.functional.steps.fab_then_impl import (
     sso_should_get_request_for_collaboration_email
 )
 from tests.functional.steps.fab_when_impl import (
+    fab_add_collaborator,
     fab_confirm_collaboration_request,
     fab_open_collaboration_request_link,
     fab_transfer_ownership,
     go_to_page,
     prof_add_case_study,
-    fab_add_collaborator,
     prof_add_online_profiles,
     prof_set_company_description,
     prof_sign_out_from_fab,

--- a/tests/functional/steps/fab_given_def.py
+++ b/tests/functional/steps/fab_given_def.py
@@ -38,7 +38,7 @@ from tests.functional.steps.fab_when_impl import (
     fab_transfer_ownership,
     go_to_page,
     prof_add_case_study,
-    prof_add_collaborator,
+    fab_add_collaborator,
     prof_add_online_profiles,
     prof_set_company_description,
     prof_sign_out_from_fab,
@@ -229,7 +229,7 @@ def given_actor_with_or_without_sso_account(
 @given('"{supplier_alias}" added "{collaborator_aliases}" as a collaborator')
 def given_supplier_added_a_collaborator(
         context, supplier_alias, collaborator_aliases):
-    prof_add_collaborator(context, supplier_alias, collaborator_aliases)
+    fab_add_collaborator(context, supplier_alias, collaborator_aliases)
 
 
 @given('"{supplier_alias}" has received an email with a request to confirm that he\'s been added to company "{company_alias}" Find a Buyer profile')

--- a/tests/functional/steps/fab_given_impl.py
+++ b/tests/functional/steps/fab_given_impl.py
@@ -233,7 +233,8 @@ def fab_find_published_company(
     logging.debug("%s found a published company: %s", actor_alias, company)
 
 
-def fas_get_company_slug(context: Context, actor_alias: str, company_alias: str):
+def fas_get_company_slug(
+        context: Context, actor_alias: str, company_alias: str):
     actor = context.get_actor(actor_alias)
     session = actor.session
     company = context.get_company(company_alias)

--- a/tests/functional/steps/fab_given_impl.py
+++ b/tests/functional/steps/fab_given_impl.py
@@ -64,9 +64,6 @@ def unauthenticated_supplier(supplier_alias: str) -> Actor:
         registration or signing-in.
      * initialize `requests` Session object that allows you to keep the cookies
         across multiple requests
-
-    :param supplier_alias: alias of the Actor used within the scenario's scope
-    :return: an Actor namedtuple with all required details
     """
     session = Session()
     email = ("test+{}{}@directory.uktrade.io"
@@ -88,9 +85,6 @@ def unauthenticated_buyer(buyer_alias: str) -> Actor:
      * set rudimentary Actor details, all omitted ones will default to None
      * initialize `requests` Session object that allows you to keep the cookies
         across multiple requests
-
-    :param buyer_alias: alias of the Actor used within the scenario's scope
-    :return: an Actor namedtuple with all required details
     """
     session = Session()
     email = ("test+buyer_{}{}@directory.uktrade.io"
@@ -278,12 +272,7 @@ def sso_get_password_reset_link(context: Context, supplier_alias: str):
 
 def reg_create_verified_sso_account_associated_with_company(
         context: Context, supplier_alias: str, company_alias: str):
-    """Select a Company, create a SSO account for it, and verify the email.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used within the scenario's scope
-    :param company_alias: alias of the Actor's Company
-    """
+    """Select a Company, create a SSO account for it, and verify the email."""
     reg_create_sso_account_associated_with_company(
         context, supplier_alias, company_alias)
     supplier = context.get_actor(supplier_alias)

--- a/tests/functional/steps/fab_given_impl.py
+++ b/tests/functional/steps/fab_given_impl.py
@@ -175,7 +175,8 @@ def reg_select_random_company_and_confirm_export_status(
     bp_should_be_prompted_to_build_your_profile(context, supplier_alias)
 
 
-def reg_create_unverified_profile(context, supplier_alias, company_alias):
+def reg_create_unverified_profile(
+        context: Context, supplier_alias: str, company_alias: str):
     supplier = unauthenticated_supplier(supplier_alias)
     context.add_actor(supplier)
     reg_create_sso_account_associated_with_company(
@@ -238,7 +239,7 @@ def fab_find_published_company(
     logging.debug("%s found a published company: %s", actor_alias, company)
 
 
-def fas_get_company_slug(context, actor_alias, company_alias):
+def fas_get_company_slug(context: Context, actor_alias: str, company_alias: str):
     actor = context.get_actor(actor_alias)
     session = actor.session
     company = context.get_company(company_alias)
@@ -252,7 +253,7 @@ def fas_get_company_slug(context, actor_alias, company_alias):
     context.set_company_details(company_alias, slug=slug)
 
 
-def reg_should_get_verification_letter(context, supplier_alias):
+def reg_should_get_verification_letter(context: Context, supplier_alias: str):
     actor = context.get_actor(supplier_alias)
     company = context.get_company(actor.company_alias)
     sent = is_verification_letter_sent(context, company.number)

--- a/tests/functional/steps/fab_then_def.py
+++ b/tests/functional/steps/fab_then_def.py
@@ -47,6 +47,7 @@ from tests.functional.steps.fab_then_impl import (
     reg_supplier_has_to_verify_email_first,
     reg_supplier_is_not_appropriate_for_fab,
     should_be_at,
+    should_not_be_able_to_access_page,
     should_see_message,
     should_see_selected_pages,
     sso_should_be_signed_in_to_sso_account,
@@ -55,8 +56,7 @@ from tests.functional.steps.fab_then_impl import (
     sso_should_get_request_for_collaboration_email,
     sso_should_see_invalid_password_reset_link_error,
     sud_should_not_see_options_to_manage_users,
-    sud_should_see_options_to_manage_users,
-    should_not_be_able_to_access_page
+    sud_should_see_options_to_manage_users
 )
 from tests.functional.steps.fab_when_impl import (
     fas_feedback_request_should_be_submitted,

--- a/tests/functional/steps/fab_then_def.py
+++ b/tests/functional/steps/fab_then_def.py
@@ -10,6 +10,7 @@ from tests.functional.steps.fab_then_impl import (
     fab_profile_is_verified,
     fab_should_be_asked_about_verification_form,
     fab_should_get_request_for_becoming_owner,
+    fab_should_not_see_collaborator,
     fab_should_see_all_case_studies,
     fab_should_see_case_study_error_message,
     fab_should_see_company_details,
@@ -397,3 +398,10 @@ def then_actor_should_receive_email_with_transfer_account_ownership_request(
         context, new_owner_alias, company_alias):
     fab_should_get_request_for_becoming_owner(
         context, new_owner_alias, company_alias)
+
+
+@then('"{supplier_alias}" should not see "{collaborators_aliases}" among the users associated with company\'s profile')
+def then_supplier_should_not_see_collaborator(
+        context, supplier_alias, collaborators_aliases):
+    fab_should_not_see_collaborator(
+        context, supplier_alias, collaborators_aliases)

--- a/tests/functional/steps/fab_then_def.py
+++ b/tests/functional/steps/fab_then_def.py
@@ -9,6 +9,7 @@ from tests.functional.steps.fab_then_impl import (
     fab_no_links_to_online_profiles_are_visible,
     fab_profile_is_verified,
     fab_should_be_asked_about_verification_form,
+    fab_should_get_request_for_becoming_owner,
     fab_should_see_all_case_studies,
     fab_should_see_case_study_error_message,
     fab_should_see_company_details,
@@ -389,3 +390,10 @@ def then_actor_should_see_options_to_manage_account_users(
 def then_actor_should_not_see_options_to_manage_account_users(
         context: Context, actor_alias: str):
     sud_should_not_see_options_to_manage_users(context, actor_alias)
+
+
+@then('"{new_owner_alias}" should receive an email with a request for becoming the owner of the company "{company_alias}" profile')
+def then_actor_should_receive_email_with_transfer_account_ownership_request(
+        context, new_owner_alias, company_alias):
+    fab_should_get_request_for_becoming_owner(
+        context, new_owner_alias, company_alias)

--- a/tests/functional/steps/fab_then_def.py
+++ b/tests/functional/steps/fab_then_def.py
@@ -55,7 +55,8 @@ from tests.functional.steps.fab_then_impl import (
     sso_should_get_request_for_collaboration_email,
     sso_should_see_invalid_password_reset_link_error,
     sud_should_not_see_options_to_manage_users,
-    sud_should_see_options_to_manage_users
+    sud_should_see_options_to_manage_users,
+    should_not_be_able_to_access_page
 )
 from tests.functional.steps.fab_when_impl import (
     fas_feedback_request_should_be_submitted,
@@ -405,3 +406,9 @@ def then_supplier_should_not_see_collaborator(
         context, supplier_alias, collaborators_aliases):
     fab_should_not_see_collaborator(
         context, supplier_alias, collaborators_aliases)
+
+
+@then('"{collaborator_alias}" should not be able to access "{page_name}" page')
+def then_collaborator_should_not_be_able_to_access_page(
+        context, collaborator_alias, page_name):
+    should_not_be_able_to_access_page(context, collaborator_alias, page_name)

--- a/tests/functional/steps/fab_then_impl.py
+++ b/tests/functional/steps/fab_then_impl.py
@@ -930,3 +930,19 @@ def fab_should_not_see_collaborator(
         collaborator = context.get_actor(collaborator_alias)
         fab_ui_account_remove_collaborator.should_not_see_collaborator(
             response, collaborator.email)
+
+
+def should_not_be_able_to_access_page(
+        context: Context, collaborator_alias: str, page_name: str):
+    collaborator = context.get_actor(collaborator_alias)
+    page_object = get_fabs_page_object(page_name)
+    response = page_object.go_to(collaborator.session)
+    try:
+        page_object.should_be_here(response)
+        raise Exception(
+            "%s was able to access '%' page", collaborator_alias, page_name)
+    except AssertionError:
+        logging.debug(
+            "As expected %s could not access '%s' page. Current URL is: %s",
+            collaborator_alias, page_name, response.url
+        )

--- a/tests/functional/steps/fab_then_impl.py
+++ b/tests/functional/steps/fab_then_impl.py
@@ -280,7 +280,8 @@ def fas_should_see_png_logo_thumbnail(context: Context, supplier_alias: str):
     logging.debug("Set Company's logo URL to: %s", visible_logo_url)
 
 
-def fas_should_see_different_png_logo_thumbnail(context, actor_alias):
+def fas_should_see_different_png_logo_thumbnail(
+        context: Context, actor_alias: str):
     """Will check if Company's Logo visible on FAS profile page is the same as
     the one uploaded on FAB.
 
@@ -555,8 +556,8 @@ def fas_should_find_with_company_details(
 
 
 def fas_pages_should_be_in_selected_language(
-        context, pages_table: Table, language, *, page_part: str = None,
-        probability: float = 0.9):
+        context: Context, pages_table: Table, language: str, *,
+        page_part: str = None, probability: float = 0.9):
     """Check if all viewed pages contain content in expected language
 
     NOTE:
@@ -650,7 +651,8 @@ def fas_supplier_should_receive_message_from_buyer(
     logging.debug("%s received message from %s", supplier_alias, buyer_alias)
 
 
-def fab_should_see_expected_error_messages(context, supplier_alias):
+def fab_should_see_expected_error_messages(
+        context: Context, supplier_alias: str):
     results = context.results
     logging.debug(results)
     for company, response, error in results:
@@ -665,7 +667,8 @@ def fab_should_see_expected_error_messages(context, supplier_alias):
     logging.debug("%s has seen all expected form errors", supplier_alias)
 
 
-def fas_should_be_on_selected_page(context, actor_alias, page_name):
+def fas_should_be_on_selected_page(
+        context: Context, actor_alias: str, page_name: str):
     response = context.response
     page_object = get_fabs_page_object(page_name)
     page_object.should_be_here(response)
@@ -673,7 +676,8 @@ def fas_should_be_on_selected_page(context, actor_alias, page_name):
         "%s successfully got to the %s FAS page", actor_alias, page_name)
 
 
-def fas_should_see_promoted_industries(context, actor_alias, table):
+def fas_should_see_promoted_industries(
+        context: Context, actor_alias: str, table: Table):
     industries = [row['industry'].lower() for row in table]
     response = context.response
     for industry in industries:
@@ -683,7 +687,7 @@ def fas_should_see_promoted_industries(context, actor_alias, table):
         industries)
 
 
-def fas_should_see_filtered_search_results(context, actor_alias):
+def fas_should_see_filtered_search_results(context: Context, actor_alias: str):
     results = context.results
     sector_filters_selector = "#id_sectors input"
     for industry, result in results.items():
@@ -711,7 +715,8 @@ def fas_should_see_filtered_search_results(context, actor_alias):
             ", ".join(result['sectors']))
 
 
-def fas_should_see_unfiltered_search_results(context, actor_alias):
+def fas_should_see_unfiltered_search_results(
+        context: Context, actor_alias: str):
     response = context.response
     content = response.content.decode("utf-8")
     sector_filters_selector = "#id_sectors input"
@@ -745,7 +750,8 @@ def fas_should_see_company_once_in_search_results(
         len(results) + 1)
 
 
-def fas_should_see_highlighted_search_term(context, actor_alias, search_term):
+def fas_should_see_highlighted_search_term(
+        context: Context, actor_alias: str, search_term: str):
     response = context.response
     content = response.content.decode("utf-8")
     search_summaries_selector = ".ed-company-search-summary"
@@ -770,14 +776,15 @@ def fas_should_see_highlighted_search_term(context, actor_alias, search_term):
             results=len(summaries)))
 
 
-def fab_company_should_be_verified(context, supplier_alias):
+def fab_company_should_be_verified(context: Context, supplier_alias: str):
     response = context.response
     fab_ui_verify_company.should_see_company_is_verified(response)
     logging.debug(
         "%s saw that his company's FAB profile is verified", supplier_alias)
 
 
-def fab_should_see_case_study_error_message(context, supplier_alias):
+def fab_should_see_case_study_error_message(
+        context: Context, supplier_alias: str):
     results = context.results
     logging.debug(results)
     for field, value_type, case_study, response, error in results:

--- a/tests/functional/steps/fab_then_impl.py
+++ b/tests/functional/steps/fab_then_impl.py
@@ -11,6 +11,7 @@ from retrying import retry
 from scrapy import Selector
 from tests import get_absolute_url
 from tests.functional.pages import (
+    fab_ui_account_remove_collaborator,
     fab_ui_build_profile_basic,
     fab_ui_confirm_identity,
     fab_ui_edit_online_profiles,
@@ -916,3 +917,16 @@ def fab_should_get_request_for_becoming_owner(
     context.update_actor(
         new_owner_alias, ownership_request_link=link,
         company_alias=company_alias)
+
+
+def fab_should_not_see_collaborator(
+        context: Context, supplier_alias: str, collaborators_aliases: str):
+    aliases = [alias.strip() for alias in collaborators_aliases.split(",")]
+    supplier = context.get_actor(supplier_alias)
+    response = fab_ui_account_remove_collaborator.go_to(supplier.session)
+    context.response = response
+
+    for collaborator_alias in aliases:
+        collaborator = context.get_actor(collaborator_alias)
+        fab_ui_account_remove_collaborator.should_not_see_collaborator(
+            response, collaborator.email)

--- a/tests/functional/steps/fab_then_impl.py
+++ b/tests/functional/steps/fab_then_impl.py
@@ -53,7 +53,6 @@ from tests.functional.utils.gov_notify import (
     get_password_reset_link,
     get_verification_link
 )
-from tests.functional.utils.request import Method, make_request
 from tests.settings import (
     FAS_LOGO_PLACEHOLDER_IMAGE,
     FAS_MESSAGE_FROM_BUYER_SUBJECT,
@@ -67,9 +66,6 @@ def reg_sso_account_should_be_created(response: Response, supplier_alias: str):
     Note:
     It's a very crude check, as it will only check if the response body
     contains selected phrases.
-
-    :param response: response object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
     """
     sso_ui_verify_your_email.should_be_here(response)
     logging.debug(
@@ -77,11 +73,7 @@ def reg_sso_account_should_be_created(response: Response, supplier_alias: str):
 
 
 def reg_should_get_verification_email(context: Context, alias: str):
-    """Will check if the Supplier received an email verification message.
-
-    :param context: behave `context` object
-    :param alias: alias of the Actor used in the scope of the scenario
-    """
+    """Will check if the Supplier received an email verification message."""
     logging.debug("Searching for an email verification message...")
     actor = context.get_actor(alias)
     link = get_verification_link(actor.email)
@@ -156,11 +148,7 @@ def sso_should_be_signed_in_to_sso_account(
 
 def sso_should_be_signed_out_from_sso_account(
         context: Context, supplier_alias: str):
-    """Sign out from SSO.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    """
+    """Sign out from SSO."""
     actor = context.get_actor(supplier_alias)
     session = actor.session
 
@@ -206,22 +194,14 @@ def prof_should_be_told_about_invalid_links(
 
 
 def fab_should_see_all_case_studies(context: Context, supplier_alias: str):
-    """Check if Supplier can see all case studies on FAB profile page.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    """
+    """Check if Supplier can see all case studies on FAB profile page."""
     actor = context.get_actor(supplier_alias)
     case_studies = context.get_company(actor.company_alias).case_studies
     fab_ui_profile.should_see_case_studies(case_studies, context.response)
 
 
 def fas_should_see_all_case_studies(context: Context, supplier_alias: str):
-    """Check if Supplier can see all case studies on FAS profile page.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    """
+    """Check if Supplier can see all case studies on FAS profile page."""
     actor = context.get_actor(supplier_alias)
     company = context.get_company(actor.company_alias)
     response = fas_ui_profile.go_to(actor.session, company.number)
@@ -235,9 +215,6 @@ def fas_should_see_all_case_studies(context: Context, supplier_alias: str):
 def prof_should_see_logo_picture(context: Context, supplier_alias: str):
     """Will check if Company's Logo visible on FAB profile page is the same as
     the uploaded one.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
     """
     actor = context.get_actor(supplier_alias)
     company = context.get_company(actor.company_alias)
@@ -253,11 +230,7 @@ def prof_should_see_logo_picture(context: Context, supplier_alias: str):
 
 
 def fas_should_see_png_logo_thumbnail(context: Context, supplier_alias: str):
-    """Will check if Company's PNG thumbnail logo visible on FAS profile.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    """
+    """Will check if Company's PNG thumbnail logo visible on FAS profile."""
     actor = context.get_actor(supplier_alias)
     session = actor.session
     company = context.get_company(actor.company_alias)
@@ -284,9 +257,6 @@ def fas_should_see_different_png_logo_thumbnail(
         context: Context, actor_alias: str):
     """Will check if Company's Logo visible on FAS profile page is the same as
     the one uploaded on FAB.
-
-    :param context: behave `context` object
-    :param actor_alias: alias of the Actor used in the scope of the scenario
     """
     actor = context.get_actor(actor_alias)
     session = actor.session
@@ -319,9 +289,6 @@ def prof_all_unsupported_files_should_be_rejected(
     NOTE:
     This require `context.rejections` to be set.
     It should be a list of bool values.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
     """
     assert hasattr(context, "rejections")
     with assertion_msg(
@@ -333,11 +300,7 @@ def prof_all_unsupported_files_should_be_rejected(
 
 
 def fab_should_see_online_profiles(context: Context, supplier_alias: str):
-    """Check if Supplier can see all online Profiles on FAB Profile page.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    """
+    """Check if Supplier can see all online Profiles on FAB Profile page."""
     actor = context.get_actor(supplier_alias)
     company = context.get_company(actor.company_alias)
     response = context.response
@@ -347,9 +310,6 @@ def fab_should_see_online_profiles(context: Context, supplier_alias: str):
 def fab_no_links_to_online_profiles_are_visible(
         context: Context, supplier_alias: str):
     """Supplier should't see any links to Online Profiles on FAB Profile page.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
     """
     response = context.response
     fab_ui_profile.should_not_see_online_profiles(response)
@@ -361,9 +321,6 @@ def fab_no_links_to_online_profiles_are_visible(
 def fas_no_links_to_online_profiles_are_visible(
         context: Context, supplier_alias: str):
     """Supplier should't see any links to Online Profiles on FAS Profile page.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
     """
     response = context.response
     fas_ui_profile.should_not_see_online_profiles(response)
@@ -373,22 +330,14 @@ def fas_no_links_to_online_profiles_are_visible(
 
 
 def fab_profile_is_verified(context: Context, supplier_alias: str):
-    """Check if Supplier was told that Company's profile is verified.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    """
+    """Check if Supplier was told that Company's profile is verified."""
     response = context.response
     fab_ui_profile.should_see_profile_is_verified(response)
     logging.debug("%s was told that the profile is verified.", supplier_alias)
 
 
 def fab_should_see_company_details(context: Context, supplier_alias: str):
-    """Supplier should see all expected Company details of FAB profile page.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    """
+    """Supplier should see all expected details of FAB profile page."""
     actor = context.get_actor(supplier_alias)
     company = context.get_company(actor.company_alias)
     response = context.response
@@ -399,22 +348,14 @@ def fab_should_see_company_details(context: Context, supplier_alias: str):
 
 def profile_supplier_should_be_on_landing_page(
         context: Context, supplier_alias: str):
-    """Check if Supplier is on Profile Landing page.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    """
+    """Check if Supplier is on Profile Landing page."""
     response = context.response
     profile_ui_landing.should_be_here(response)
     logging.debug("%s got to the SSO landing page.", supplier_alias)
 
 
 def fas_should_see_company_details(context: Context, supplier_alias: str):
-    """Supplier should see all expected Company details of FAS profile page.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    """
+    """Supplier should see all expected details of FAS profile page."""
     actor = context.get_actor(supplier_alias)
     company = context.get_company(actor.company_alias)
     session = actor.session
@@ -539,10 +480,6 @@ def fas_should_find_with_company_details(
 
     NOTE:
     This step requires the search_results dict to be stored in context
-
-    :param context: behave `context` object
-    :param buyer_alias: alias of the Actor used in the scope of the scenario
-    :param company_alias: alias of the Company used in the scenario
     """
     assert hasattr(context, "search_results")
     company = context.get_company(company_alias)
@@ -613,11 +550,7 @@ def fas_pages_should_be_in_selected_language(
 
 
 def fas_should_find_all_sought_companies(context: Context, buyer_alias: str):
-    """Check if all Buyer was able to find Supplier using all provided terms.
-
-    :param context: behave `context` object
-    :param buyer_alias: alias of the Actor used in the scope of the scenario
-    """
+    """Check if Buyer was able to find Supplier using all provided terms."""
     with assertion_msg(
             "Context has no required `search_details` dict. Please check if "
             "one of previous steps sets it correctly."):

--- a/tests/functional/steps/fab_when_def.py
+++ b/tests/functional/steps/fab_when_def.py
@@ -15,6 +15,7 @@ from tests.functional.steps.fab_when_impl import (
     fab_select_preferred_countries_of_export,
     fab_send_transfer_ownership_request,
     fab_submit_verification_code,
+    fab_transfer_ownership,
     fab_update_case_study,
     fas_browse_suppliers_by_company_sectors,
     fas_browse_suppliers_by_invalid_sectors,
@@ -399,4 +400,11 @@ def when_collaborator_creates_sso_account_and_confirms_email(
 def when_supplier_decides_to_transfer_profile_ownership(
         context, supplier_alias, company_alias, new_owner_alias):
     fab_send_transfer_ownership_request(
+        context, supplier_alias, company_alias, new_owner_alias)
+
+
+@when('"{supplier_alias}" transfers the ownership of company\'s "{company_alias}" Find a Buyer profile to "{new_owner_alias}"')
+def when_supplier_transfers_the_account_ownership(
+        context, supplier_alias, company_alias, new_owner_alias):
+    fab_transfer_ownership(
         context, supplier_alias, company_alias, new_owner_alias)

--- a/tests/functional/steps/fab_when_def.py
+++ b/tests/functional/steps/fab_when_def.py
@@ -44,6 +44,7 @@ from tests.functional.steps.fab_when_impl import (
     prof_update_company_details,
     prof_verify_company,
     prof_view_published_profile,
+    profile_send_transfer_ownership_request,
     reg_confirm_company_selection,
     reg_confirm_export_status,
     reg_create_sso_account,
@@ -392,3 +393,10 @@ def when_collaborator_creates_sso_account_and_confirms_email(
         context, collaborator_alias, company_alias):
     fab_collaborator_create_sso_account_and_confirm_email(
         context, collaborator_alias, company_alias)
+
+
+@when('"{supplier_alias}" decides to transfer the ownership of company\'s "{company_alias}" Find a Buyer profile to "{collaborator_alias}"')
+def when_supplier_decides_to_transfer_profile_ownership(
+        context, supplier_alias, company_alias, collaborator_alias):
+    profile_send_transfer_ownership_request(
+        context, supplier_alias, company_alias, collaborator_alias)

--- a/tests/functional/steps/fab_when_def.py
+++ b/tests/functional/steps/fab_when_def.py
@@ -13,6 +13,7 @@ from tests.functional.steps.fab_when_impl import (
     fab_go_to_letter_verification,
     fab_provide_company_details,
     fab_select_preferred_countries_of_export,
+    fab_send_transfer_ownership_request,
     fab_submit_verification_code,
     fab_update_case_study,
     fas_browse_suppliers_by_company_sectors,
@@ -44,7 +45,6 @@ from tests.functional.steps.fab_when_impl import (
     prof_update_company_details,
     prof_verify_company,
     prof_view_published_profile,
-    profile_send_transfer_ownership_request,
     reg_confirm_company_selection,
     reg_confirm_export_status,
     reg_create_sso_account,
@@ -395,8 +395,8 @@ def when_collaborator_creates_sso_account_and_confirms_email(
         context, collaborator_alias, company_alias)
 
 
-@when('"{supplier_alias}" decides to transfer the ownership of company\'s "{company_alias}" Find a Buyer profile to "{collaborator_alias}"')
+@when('"{supplier_alias}" decides to transfer the ownership of company\'s "{company_alias}" Find a Buyer profile to "{new_owner_alias}"')
 def when_supplier_decides_to_transfer_profile_ownership(
-        context, supplier_alias, company_alias, collaborator_alias):
-    profile_send_transfer_ownership_request(
-        context, supplier_alias, company_alias, collaborator_alias)
+        context, supplier_alias, company_alias, new_owner_alias):
+    fab_send_transfer_ownership_request(
+        context, supplier_alias, company_alias, new_owner_alias)

--- a/tests/functional/steps/fab_when_def.py
+++ b/tests/functional/steps/fab_when_def.py
@@ -35,7 +35,7 @@ from tests.functional.steps.fab_when_impl import (
     go_to_page,
     go_to_pages,
     prof_add_case_study,
-    prof_add_collaborator,
+    fab_add_collaborator,
     prof_add_invalid_online_profiles,
     prof_add_online_profiles,
     prof_attempt_to_sign_in_to_fab,
@@ -377,7 +377,7 @@ def when_supplier_tries_to_change_password_to_letters_only(
 @when('"{supplier_alias}" decides to add "{collaborator_aliases}" as a collaborator')
 def when_owner_adds_a_collaborator(
         context, supplier_alias, collaborator_aliases):
-    prof_add_collaborator(context, supplier_alias, collaborator_aliases)
+    fab_add_collaborator(context, supplier_alias, collaborator_aliases)
 
 
 @when('"{collaborator_alias}" confirms that he wants to be added to the company "{company_alias}" Find a Buyer profile')

--- a/tests/functional/steps/fab_when_def.py
+++ b/tests/functional/steps/fab_when_def.py
@@ -6,12 +6,14 @@ from tests.functional.steps.fab_when_impl import (
     bp_provide_company_details,
     bp_select_random_sector_and_export_to_country,
     bp_verify_identity_with_letter,
+    fab_add_collaborator,
     fab_attempt_to_add_case_study,
     fab_choose_to_verify_with_code,
     fab_collaborator_create_sso_account_and_confirm_email,
     fab_confirm_collaboration_request,
     fab_go_to_letter_verification,
     fab_provide_company_details,
+    fab_remove_collaborators,
     fab_select_preferred_countries_of_export,
     fab_send_transfer_ownership_request,
     fab_submit_verification_code,
@@ -35,7 +37,6 @@ from tests.functional.steps.fab_when_impl import (
     go_to_page,
     go_to_pages,
     prof_add_case_study,
-    fab_add_collaborator,
     prof_add_invalid_online_profiles,
     prof_add_online_profiles,
     prof_attempt_to_sign_in_to_fab,
@@ -408,3 +409,10 @@ def when_supplier_transfers_the_account_ownership(
         context, supplier_alias, company_alias, new_owner_alias):
     fab_transfer_ownership(
         context, supplier_alias, company_alias, new_owner_alias)
+
+
+@when('"{supplier_alias}" removes "{collaborators_aliases}" from the list of collaborators to the company "{company_alias}"')
+def when_supplier_removes_collaborators(
+        context, supplier_alias, collaborators_aliases, company_alias):
+    fab_remove_collaborators(
+        context, supplier_alias, collaborators_aliases, company_alias)

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -2157,21 +2157,32 @@ def fab_remove_collaborators(
         context: Context, supplier_alias: str, collaborators_aliases: str,
         company_alias: str):
     aliases = [alias.strip() for alias in collaborators_aliases.split(",")]
+    emails = [context.get_actor(alias).email for alias in aliases]
+    supplier = context.get_actor(supplier_alias)
+    company = context.get_company(company_alias)
 
-    for collaborator_alias in aliases:
-        supplier = context.get_actor(supplier_alias)
-        company = context.get_company(company_alias)
-        collaborator = context.get_actor(collaborator_alias)
-        response = fab_ui_account_remove_collaborator.go_to(supplier.session)
-        context.response = response
+    # Step 1: go to the remove collaborators page
+    response = fab_ui_account_remove_collaborator.go_to(supplier.session)
+    context.response = response
 
-        token = extract_csrf_middleware_token(response)
-        context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
+    token = extract_csrf_middleware_token(response)
+    context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
-        response = fab_ui_account_remove_collaborator.remove(
-            supplier.session, token, collaborator.email)
+    # Step 2: extract SSO IDs for users to remove
+    emails_to_sso_id = fab_ui_account_remove_collaborator.extract_sso_ids(
+        response)
+    logging.debug("SSO IDs for specific actor: %s", emails_to_sso_id)
+    sso_ids = [sso_id
+               for email, sso_id in emails_to_sso_id.items()
+               if email in emails]
+    logging.debug("List of SSO IDs to remove: %s", sso_ids)
 
-        profile_ui_find_a_buyer.should_be_here(response)
-        collaborators = company.collaborators
-        collaborators.remove(collaborator_alias)
-        context.set_company_details(company.alias, collaborators=collaborators)
+    # Step 3: send the request with SSO IDs of users to remove
+    response = fab_ui_account_remove_collaborator.remove(
+        supplier.session, token, sso_ids)
+    context.response = response
+
+    profile_ui_find_a_buyer.should_be_here(response, user_removed=True)
+    collaborators = company.collaborators
+    collaborators = [alias for alias in collaborators if alias not in aliases]
+    context.set_company_details(company.alias, collaborators=collaborators)

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -555,14 +555,8 @@ def prof_sign_out_from_fab(context, supplier_alias):
     context.reset_actor_session(supplier_alias)
 
 
-def prof_sign_in_to_fab(context, supplier_alias):
-    """Sign in to Find a Buyer.
-
-    :param context: behave `context` object
-    :type context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
-    """
+def prof_sign_in_to_fab(context: Context, supplier_alias: str):
+    """Sign in to Find a Buyer."""
     actor = context.get_actor(supplier_alias)
     session = actor.session
 
@@ -657,7 +651,7 @@ def sso_collaborator_confirm_email_address(
     context.update_actor(supplier_alias, has_sso_account=True)
 
 
-def sso_supplier_confirms_email_address(context, supplier_alias):
+def sso_supplier_confirms_email_address(context: Context, supplier_alias: str):
     """Given Supplier has clicked on the email confirmation link, Suppliers has
     to confirm that the provided email address is the correct one.
 
@@ -680,7 +674,7 @@ def sso_supplier_confirms_email_address(context, supplier_alias):
     context.update_actor(supplier_alias, has_sso_account=True)
 
 
-def sso_go_to_create_trade_profile(context, supplier_alias):
+def sso_go_to_create_trade_profile(context: Context, supplier_alias: str):
     """Follow the 'Create a trade profile' button on the "Find a Buyer" tab.
 
     NOTE:
@@ -706,18 +700,13 @@ def sso_go_to_create_trade_profile(context, supplier_alias):
     fab_ui_landing.should_be_here(response)
 
 
-def prof_upload_logo(context, supplier_alias, picture: str):
+def prof_upload_logo(context: Context, supplier_alias: str, picture: str):
     """Upload Company's logo & extract newly uploaded logo image URL.
 
     NOTE:
     picture must represent file stored in ./tests/functional/files
 
-    :param context: behave `context` object
-    :type  context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type  supplier_alias: str
     :param picture: name of the picture file stored in ./tests/functional/files
-    :type  picture: str
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
@@ -739,18 +728,14 @@ def prof_upload_logo(context, supplier_alias, picture: str):
         actor.company_alias, picture=picture, hash=md5_hash, url=logo_url)
 
 
-def prof_upload_unsupported_file_as_logo(context, supplier_alias, file):
+def prof_upload_unsupported_file_as_logo(
+        context: Context, supplier_alias: str, file: str):
     """Try to upload unsupported file type as Company's logo.
 
     NOTE:
     file must exist in ./tests/functional/files
 
-    :param context: behave `context` object
-    :type  context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type  supplier_alias: str
     :param file: name of the file stored in ./tests/functional/files
-    :type  file: str
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
@@ -775,13 +760,10 @@ def prof_upload_unsupported_file_as_logo(context, supplier_alias, file):
     return rejected
 
 
-def prof_supplier_uploads_logo(context, supplier_alias, picture):
+def prof_supplier_uploads_logo(
+        context: Context, supplier_alias: str, picture: str):
     """Upload a picture and set it as Company's logo.
 
-    :param context: behave `context` object
-    :type context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
     :param picture: name of the picture file stored in ./tests/functional/files
     """
     actor = context.get_actor(supplier_alias)
@@ -897,13 +879,7 @@ def prof_update_company_details(
 
 def prof_add_online_profiles(
         context: Context, supplier_alias: str, online_profiles: Table):
-    """Update links to Company's Online Profiles.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :param online_profiles: context.table containing data table
-            see: https://pythonhosted.org/behave/gherkin.html#table
-    """
+    """Update links to Company's Online Profiles."""
     actor = context.get_actor(supplier_alias)
     session = actor.session
     company = context.get_company(actor.company_alias)
@@ -940,11 +916,6 @@ def prof_add_online_profiles(
 def prof_add_invalid_online_profiles(
         context: Context, supplier_alias: str, online_profiles: Table):
     """Attempt to update links to Company's Online Profiles using invalid URLs.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :param online_profiles: context.table containing data table
-            see: https://pythonhosted.org/behave/gherkin.html#table
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
@@ -985,12 +956,9 @@ def prof_add_invalid_online_profiles(
     context.response = response
 
 
-def prof_remove_links_to_online_profiles(context, supplier_alias):
-    """Will remove links to existing Online Profiles.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    """
+def prof_remove_links_to_online_profiles(
+        context: Context, supplier_alias: str):
+    """Will remove links to existing Online Profiles."""
     actor = context.get_actor(supplier_alias)
     company = context.get_company(actor.company_alias)
 
@@ -1003,13 +971,9 @@ def prof_remove_links_to_online_profiles(context, supplier_alias):
     context.response = response
 
 
-def prof_add_case_study(context, supplier_alias, case_alias):
-    """Will add a complete case study (all fields will be filled out).
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :param case_alias: alias of the Case Study used in the scenario
-    """
+def prof_add_case_study(
+        context: Context, supplier_alias: str, case_alias: str):
+    """Will add a complete case study (all fields will be filled out)."""
     actor = context.get_actor(supplier_alias)
     session = actor.session
     case_study = random_case_study_data(case_alias)
@@ -1183,20 +1147,21 @@ def fas_view_pages_in_selected_language(
     context.views = views
 
 
-def fas_view_page(context, actor_alias, page_name):
+def fas_view_page(context: Context, actor_alias: str, page_name: str):
     actor = context.get_actor(actor_alias)
     session = actor.session
     page_object = get_fabs_page_object(page_name)
     context.response = page_object.go_to(session)
 
 
-def fas_search_with_empty_query(context, buyer_alias):
+def fas_search_with_empty_query(context: Context, buyer_alias: str):
     actor = context.get_actor(buyer_alias)
     session = actor.session
     context.response = fas_ui_find_supplier.go_to(session, term="")
 
 
-def fas_should_be_told_about_empty_search_results(context, buyer_alias):
+def fas_should_be_told_about_empty_search_results(
+        context: Context, buyer_alias: str):
     fas_ui_find_supplier.should_see_no_matches(context.response)
     logging.debug(
         "%s was told that the search did not match any UK trade profiles",
@@ -1431,7 +1396,8 @@ def fab_provide_company_details(
     context.results = results
 
 
-def fas_follow_case_study_links_to_related_sectors(context, actor_alias):
+def fas_follow_case_study_links_to_related_sectors(
+        context: Context, actor_alias: str):
     actor = context.get_actor(actor_alias)
     session = actor.session
     content = context.response.content.decode("utf-8")
@@ -1594,8 +1560,8 @@ def fas_browse_suppliers_by_company_sectors(
     context.results = results
 
 
-def fas_get_case_study_slug(context: Context, actor_alias: str,
-                            case_alias: str):
+def fas_get_case_study_slug(
+        context: Context, actor_alias: str, case_alias: str):
     result = None
     actor = context.get_actor(actor_alias)
     company = context.get_company(actor.company_alias)
@@ -1617,7 +1583,7 @@ def fas_get_case_study_slug(context: Context, actor_alias: str,
         "%s got case study '%s' slug: '%s'", actor_alias, case_alias, result)
 
 
-def fas_search_with_term(context, actor_alias, search_term):
+def fas_search_with_term(context: Context, actor_alias: str, search_term: str):
     actor = context.get_actor(actor_alias)
     session = actor.session
     context.response = fas_ui_find_supplier.go_to(session, term=search_term)
@@ -1660,7 +1626,7 @@ def fab_choose_to_verify_with_code(context: Context, supplier_alias: str):
     fab_ui_verify_company.should_be_here(response)
 
 
-def fab_submit_verification_code(context, supplier_alias):
+def fab_submit_verification_code(context: Context, supplier_alias: str):
     actor = context.get_actor(supplier_alias)
     company = context.get_company(actor.company_alias)
     verification_code = company.verification_code

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -181,7 +181,7 @@ def reg_confirm_company_selection(
     context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
 
-def reg_supplier_is_not_ready_to_export(context, supplier_alias):
+def reg_supplier_is_not_ready_to_export(context: Context, supplier_alias: str):
     """Supplier decides that her/his company is not ready to export.
 
     :param context: behave `context` object
@@ -229,7 +229,8 @@ def reg_confirm_export_status(
         context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
 
-def reg_create_sso_account(context, supplier_alias, alias):
+def reg_create_sso_account(
+        context: Context, supplier_alias: str, company_alias: str):
     """Will create a SSO account for selected company.
 
     NOTE:
@@ -244,14 +245,14 @@ def reg_create_sso_account(context, supplier_alias, alias):
     :type alias: str
     """
     actor = context.get_actor(supplier_alias)
-    company = context.get_company(alias)
+    company = context.get_company(company_alias)
     exported = context.exported
 
     # Submit SSO Registration form with Supplier's & Company's required details
     context.response = sso_ui_register.submit(actor, company, exported)
 
 
-def reg_open_email_confirmation_link(context, supplier_alias):
+def reg_open_email_confirmation_link(context: Context, supplier_alias: str):
     """Given Supplier has received a message with email confirmation link
     Then Supplier has to click on that link.
 
@@ -280,7 +281,7 @@ def reg_open_email_confirmation_link(context, supplier_alias):
     context.form_action_value = form_action_value
 
 
-def reg_supplier_confirms_email_address(context, supplier_alias):
+def reg_supplier_confirms_email_address(context: Context, supplier_alias: str):
     """Given Supplier has clicked on the email confirmation link, Suppliers has
     to confirm that the provided email address is the correct one.
 
@@ -296,7 +297,7 @@ def reg_supplier_confirms_email_address(context, supplier_alias):
     context.response = response
 
 
-def bp_provide_company_details(context, supplier_alias):
+def bp_provide_company_details(context: Context, supplier_alias: str):
     """Build Profile - Provide company details: website (optional), keywords
     and number of employees.
 
@@ -332,7 +333,8 @@ def bp_provide_company_details(context, supplier_alias):
     context.update_actor(supplier_alias, csrfmiddlewaretoken=token)
 
 
-def bp_select_random_sector_and_export_to_country(context, supplier_alias):
+def bp_select_random_sector_and_export_to_country(
+        context: Context, supplier_alias: str):
     """Build Profile - Randomly select one of available sectors our company is
     interested in working in.
 
@@ -395,7 +397,7 @@ def bp_verify_identity_with_letter(context: Context, supplier_alias: str):
     fab_ui_profile.should_see_missing_description(response)
 
 
-def prof_set_company_description(context, supplier_alias):
+def prof_set_company_description(context: Context, supplier_alias: str):
     """Edit Profile - Will set company description.
 
     This is quasi-mandatory (*) step before Supplier can verify the company
@@ -436,7 +438,7 @@ def prof_set_company_description(context, supplier_alias):
     logging.debug("Supplier is back to the Profile Page")
 
 
-def prof_verify_company(context, supplier_alias):
+def prof_verify_company(context: Context, supplier_alias: str):
     """Will verify the company by submitting the verification code that is sent
     by post to the company's address.
 
@@ -475,7 +477,7 @@ def prof_verify_company(context, supplier_alias):
     fab_ui_profile.should_see_profile_is_verified(response)
 
 
-def prof_view_published_profile(context, supplier_alias):
+def prof_view_published_profile(context: Context, supplier_alias: str):
     """Whilst being of FAB company profile page it will `click` on
     the `View published profile` link.
 
@@ -494,7 +496,7 @@ def prof_view_published_profile(context, supplier_alias):
     logging.debug("Supplier is on the company's FAS page")
 
 
-def prof_attempt_to_sign_in_to_fab(context, supplier_alias):
+def prof_attempt_to_sign_in_to_fab(context: Context, supplier_alias: str):
     """Try to sign in to FAB as a Supplier without verified email address.
 
     :param context: behave `context` object
@@ -523,7 +525,7 @@ def prof_attempt_to_sign_in_to_fab(context, supplier_alias):
     context.response = response
 
 
-def prof_sign_out_from_fab(context, supplier_alias):
+def prof_sign_out_from_fab(context: Context, supplier_alias: str):
     """Sign out from Find a Buyer.
 
     :param context: behave `context` object

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -2060,7 +2060,7 @@ def fab_send_transfer_ownership_request(
     )
 
 
-def fab_open_transfer_ownership_request_link(
+def fab_open_transfer_ownership_request_link_and_create_sso_account_if_needed(
         context: Context, new_owner_alias: str, company_alias: str):
     new_owner = context.get_actor(new_owner_alias)
     session = new_owner.session
@@ -2113,7 +2113,7 @@ def fab_transfer_ownership(
         context, supplier_alias, company_alias, new_owner_alias)
     fab_should_get_request_for_becoming_owner(
         context, new_owner_alias, company_alias)
-    fab_open_transfer_ownership_request_link(
+    fab_open_transfer_ownership_request_link_and_create_sso_account_if_needed(
         context, new_owner_alias, company_alias)
     fab_confirm_account_ownership_request(
         context, new_owner_alias, company_alias)

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -103,10 +103,6 @@ def select_random_company(
 
     Once a matching company is found, then it's data will be stored in:
         context.scenario_data.companies[]
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :param company_alias: alias of the company used in the scenario
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
@@ -151,12 +147,7 @@ def select_random_company(
 
 def reg_confirm_company_selection(
         context: Context, supplier_alias: str, company_alias: str):
-    """Will confirm that the selected company is the right one.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :param company_alias: alias of the company used in the scenario
-    """
+    """Will confirm that the selected company is the right one."""
     actor = context.get_actor(supplier_alias)
     token = actor.csrfmiddlewaretoken
     has_sso_account = actor.has_sso_account
@@ -182,13 +173,7 @@ def reg_confirm_company_selection(
 
 
 def reg_supplier_is_not_ready_to_export(context: Context, supplier_alias: str):
-    """Supplier decides that her/his company is not ready to export.
-
-    :param context: behave `context` object
-    :type context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
-    """
+    """Supplier decides that her/his company is not ready to export."""
     actor = context.get_actor(supplier_alias)
     session = actor.session
     token = actor.csrfmiddlewaretoken
@@ -205,10 +190,6 @@ def reg_supplier_is_not_ready_to_export(context: Context, supplier_alias: str):
 def reg_confirm_export_status(
         context: Context, supplier_alias: str, exported: bool):
     """Will confirm the current export status of selected unregistered company.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :param exported: True is exported in the past, False if not
     """
     actor = context.get_actor(supplier_alias)
     has_sso_account = actor.has_sso_account
@@ -236,13 +217,6 @@ def reg_create_sso_account(
     NOTE:
     Will use credentials randomly generated at Actor's initialization.
     It will also store final response in `context`
-
-    :param context: behave `context` object
-    :type context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
-    :param alias: alias of the company used in the scope of the scenario
-    :type alias: str
     """
     actor = context.get_actor(supplier_alias)
     company = context.get_company(company_alias)
@@ -255,11 +229,6 @@ def reg_create_sso_account(
 def reg_open_email_confirmation_link(context: Context, supplier_alias: str):
     """Given Supplier has received a message with email confirmation link
     Then Supplier has to click on that link.
-
-    :param context: behave `context` object
-    :type context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
@@ -284,11 +253,6 @@ def reg_open_email_confirmation_link(context: Context, supplier_alias: str):
 def reg_supplier_confirms_email_address(context: Context, supplier_alias: str):
     """Given Supplier has clicked on the email confirmation link, Suppliers has
     to confirm that the provided email address is the correct one.
-
-    :param context: behave `context` object
-    :type context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
     """
     actor = context.get_actor(supplier_alias)
     form_action_value = context.form_action_value
@@ -300,9 +264,6 @@ def reg_supplier_confirms_email_address(context: Context, supplier_alias: str):
 def bp_provide_company_details(context: Context, supplier_alias: str):
     """Build Profile - Provide company details: website (optional), keywords
     and number of employees.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
     """
     actor = context.get_actor(supplier_alias)
     company = context.get_company(actor.company_alias)
@@ -341,11 +302,6 @@ def bp_select_random_sector_and_export_to_country(
     NOTE:
     This will set `context.details` which will contain company details
     extracted from the page displayed after Supplier selects the sector.
-
-    :param context: behave `context` object
-    :type context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
     """
     actor = context.get_actor(supplier_alias)
     sector = choice(SECTORS)
@@ -363,11 +319,7 @@ def bp_select_random_sector_and_export_to_country(
 
 
 def bp_verify_identity_with_letter(context: Context, supplier_alias: str):
-    """Build Profile - verify identity with a physical letter.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    """
+    """Build Profile - verify identity with a physical letter."""
     actor = context.get_actor(supplier_alias)
     session = actor.session
 
@@ -406,11 +358,6 @@ def prof_set_company_description(context: Context, supplier_alias: str):
     (*) it's quasi mandatory, because Supplier can actually go to the company
     verification page using the link provided in the letter without the need
     to set company description.
-
-    :param context: behave `context` object
-    :type context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
@@ -441,11 +388,6 @@ def prof_set_company_description(context: Context, supplier_alias: str):
 def prof_verify_company(context: Context, supplier_alias: str):
     """Will verify the company by submitting the verification code that is sent
     by post to the company's address.
-
-    :param context: behave `context` object
-    :type context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
     """
     actor = context.get_actor(supplier_alias)
     company = context.get_company(actor.company_alias)
@@ -480,11 +422,6 @@ def prof_verify_company(context: Context, supplier_alias: str):
 def prof_view_published_profile(context: Context, supplier_alias: str):
     """Whilst being of FAB company profile page it will `click` on
     the `View published profile` link.
-
-    :param context: behave `context` object
-    :type context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
@@ -497,13 +434,7 @@ def prof_view_published_profile(context: Context, supplier_alias: str):
 
 
 def prof_attempt_to_sign_in_to_fab(context: Context, supplier_alias: str):
-    """Try to sign in to FAB as a Supplier without verified email address.
-
-    :param context: behave `context` object
-    :type context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
-    """
+    """Try to sign in to FAB as a Supplier without verified email address."""
     actor = context.get_actor(supplier_alias)
     session = actor.session
 
@@ -526,13 +457,7 @@ def prof_attempt_to_sign_in_to_fab(context: Context, supplier_alias: str):
 
 
 def prof_sign_out_from_fab(context: Context, supplier_alias: str):
-    """Sign out from Find a Buyer.
-
-    :param context: behave `context` object
-    :type context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
-    """
+    """Sign out from Find a Buyer."""
     actor = context.get_actor(supplier_alias)
     session = actor.session
 
@@ -599,9 +524,6 @@ def reg_create_standalone_unverified_sso_account(
 
     NOTE:
     There will be no association between this account and any company.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
@@ -672,11 +594,6 @@ def sso_new_onwer_confirm_email_address(
 def sso_supplier_confirms_email_address(context: Context, supplier_alias: str):
     """Given Supplier has clicked on the email confirmation link, Suppliers has
     to confirm that the provided email address is the correct one.
-
-    :param context: behave `context` object
-    :type context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
     """
     actor = context.get_actor(supplier_alias)
     form_action_value = context.form_action_value
@@ -698,11 +615,6 @@ def sso_go_to_create_trade_profile(context: Context, supplier_alias: str):
     NOTE:
     It's assumed that Supplier already has a standalone SSO/great.gov.uk
     account
-
-    :param context: behave `context` object
-    :type context: behave.runner.Context
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :type supplier_alias: str
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
@@ -801,13 +713,7 @@ def prof_supplier_uploads_logo(
 
 def prof_to_upload_unsupported_logos(
         context: Context, supplier_alias: str, table: Table):
-    """Upload a picture and set it as Company's logo.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :param table: context.table containing data table
-                  see: https://pythonhosted.org/behave/gherkin.html#table
-    """
+    """Upload a picture and set it as Company's logo."""
     actor = context.get_actor(supplier_alias)
     session = actor.session
     files = [row['file'] for row in table]
@@ -829,11 +735,6 @@ def prof_update_company_details(
     Passing `table_of_details` can be avoided as we already have access to
     `context` object, yet in order to be more explicit, we're making it
     a mandatory argument.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Actor used in the scope of the scenario
-    :param table_of_details: context.table containing data table
-            see: https://pythonhosted.org/behave/gherkin.html#table
     """
     actor = context.get_actor(supplier_alias)
     session = actor.session
@@ -1076,14 +977,7 @@ def fab_update_case_study(
 def fas_search_using_company_details(
         context: Context, buyer_alias: str, company_alias: str, *,
         table_of_details: Table = None):
-    """Search for Company on FAS using it's all or selected details.
-
-    :param context: behave `context` object
-    :param buyer_alias: alias of the Actor used in the scope of the scenario
-    :param company_alias: alias of the Company used in the scenario
-    :param table_of_details: (optional) a table with selected company details
-                             which will be used in search
-    """
+    """Search for Company on FAS using it's all or selected details."""
     actor = context.get_actor(buyer_alias)
     session = actor.session
     company = context.get_company(company_alias)
@@ -1147,11 +1041,6 @@ def fas_view_pages_in_selected_language(
 
     NOTE:
     This will store a dict with all page views responses in context.views
-
-    :param context: behave `context` object
-    :param buyer_alias: alias of the Buyer Actor
-    :param pages_table: a table with FAS pages to view
-    :param language: expected language of the view FAS page content
     """
     pages = [row['page'] for row in pages_table]
     views = {}
@@ -1273,10 +1162,6 @@ def fas_search_with_product_service_keyword(
     * keyword
 
     NOTE: this will add a dictionary `search_results` to `context`
-
-    :param context: behave `context` object
-    :param buyer_alias: alias of the Buyer Actor
-    :param search_table: a table with FAS pages to view
     """
     actor = context.get_actor(buyer_alias)
     session = actor.session
@@ -1345,10 +1230,6 @@ def fab_provide_company_details(
     * Company namedtuple (with details used in the request)
     * response object
     * expected error message
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Supplier Actor
-    :param table: a table with company details to update & expected error msg
     """
     actor = context.get_actor(supplier_alias)
     original_details = context.get_company(actor.company_alias)
@@ -1783,11 +1664,7 @@ def sso_request_password_reset(context: Context, supplier_alias: str):
 
 
 def sso_sign_in(context: Context, supplier_alias: str):
-    """Sign in to standalone SSO account.
-
-    :param context: behave `context` object
-    :param supplier_alias: alias of the Supplier Actor
-    """
+    """Sign in to standalone SSO account."""
     actor = context.get_actor(supplier_alias)
     next_param = get_absolute_url("profile:about")
     referer = get_absolute_url("profile:about")

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -1910,7 +1910,7 @@ def finish_registration_after_flagging_as_verified(
     context.response = response
 
 
-def prof_add_collaborator(
+def fab_add_collaborator(
         context: Context, supplier_alias: str, collaborator_aliases: str):
 
     aliases = [alias.strip() for alias in collaborator_aliases.split(",")]

--- a/tests/functional/steps/fab_when_impl.py
+++ b/tests/functional/steps/fab_when_impl.py
@@ -2042,7 +2042,7 @@ def fab_collaborator_create_sso_account_and_confirm_email(
         context, collaborator_alias, company_alias, open_invitation_link=False)
 
 
-def profile_send_transfer_ownership_request(
+def fab_send_transfer_ownership_request(
         context: Context, supplier_alias: str, company_alias: str,
         new_owner_alias: str):
     """

--- a/tests/functional/utils/context_utils.py
+++ b/tests/functional/utils/context_utils.py
@@ -18,7 +18,8 @@ Actor = namedtuple(
     [
         'alias', 'email', 'password', 'session', 'csrfmiddlewaretoken',
         'email_confirmation_link', 'company_alias', 'has_sso_account', 'type',
-        'password_reset_link', 'invitation_for_collaboration_link'
+        'password_reset_link', 'invitation_for_collaboration_link', 'ex_owner',
+        'ownership_request_link'
     ]
 )
 CaseStudy = namedtuple(
@@ -46,7 +47,7 @@ Company = namedtuple(
         'companies_house_details', 'facebook', 'linkedin', 'twitter',
         'case_studies', 'logo_picture', 'logo_url', 'logo_hash',
         'export_to_countries', 'fas_profile_endpoint', 'slug',
-        'verification_code', 'collaborators', 'deleted'
+        'verification_code', 'collaborators', 'deleted', 'owner', 'owner_email'
     ]
 )
 Feedback = namedtuple(

--- a/tests/functional/utils/context_utils.py
+++ b/tests/functional/utils/context_utils.py
@@ -210,15 +210,14 @@ def add_case_study(
                   "Case Study Data: %s", case_alias, company_alias, case_study)
 
 
-def update_case_study(self, company_alias, case_alias, *, slug=None):
-    # cases = self.get_company(company_alias).case_studies
+def update_case_study(self, company, case, *, slug=None):
     companies = self.scenario_data.companies
     if slug:
-        companies[company_alias].case_studies[case_alias] = companies[company_alias].case_studies[case_alias]._replace(slug=slug)
-        # cases[case_alias] = cases[case_alias]._replace(slug=slug)
+        cases = companies[company].case_studies[case]._replace(slug=slug)
+        companies[company].case_studies[case] = cases
 
     logging.debug("Successfully updated Case Study '%s' for Company %s",
-                  case_alias, company_alias)
+                  case, company)
 
 
 def patch_context(context):
@@ -238,4 +237,5 @@ def patch_context(context):
     context.add_case_study = MethodType(add_case_study, context)
     context.update_case_study = MethodType(update_case_study, context)
     context.set_company_details = MethodType(set_company_details, context)
-    context.set_company_logo_detail = MethodType(set_company_logo_detail, context)
+    context.set_company_logo_detail = MethodType(
+        set_company_logo_detail, context)

--- a/tests/functional/utils/generic.py
+++ b/tests/functional/utils/generic.py
@@ -356,7 +356,8 @@ def log_response(response: Response, *, trim: bool = True):
                 content = decode_as_utf8(r.content)
                 if trim or len(r.content) > trim_offset:
                     logging.debug(
-                        "Intermediate RESP Content: %s", content[0:trim_offset])
+                        "Intermediate RESP Content: %s",
+                        content[0:trim_offset])
                 else:
                     logging.debug("Intermediate RSP Content: %s", content)
         logging.debug(
@@ -475,8 +476,8 @@ def get_absolute_path_of_file(filename):
     relative_path = os.path.join("tests", "functional", "files", filename)
     absolute_path = os.path.abspath(relative_path)
     with assertion_msg(
-            "Could not find '%s' in ./tests/functional/files. Please check the "
-            "filename!", filename):
+            "Could not find '%s' in ./tests/functional/files. Please check the"
+            " filename!", filename):
         assert os.path.exists(absolute_path)
 
     return absolute_path
@@ -516,7 +517,7 @@ def extract_logo_url(response, *, fas: bool = False):
     edit profile page content.
 
     :param response: response with the contents of edit profile page
-    :param fas: Use FAS specific CSS selector if True, if False use FAB selector
+    :param fas: Use FAS specific CSS selector if True, else use FAB selector
     :return: a URL to the company's logo image
     """
     css_selector = ".logo-container img::attr(src)"
@@ -550,9 +551,9 @@ def assertion_msg(message: str, *args):
         * print the traceback (stack trace)
         * raise the original AssertionError exception
 
-    :param message: a message that will be printed & logged when assertion fails
-    :param args: values that will replace % conversion specifications in message
-                 like: %s, %d
+    :param message: to be printed & logged when assertion fails
+    :param args: values that will replace % conversion specifications in
+                 message like: %s, %d
     """
     try:
         yield
@@ -733,15 +734,18 @@ def find_active_company_without_fas_profile(alias: str) -> Company:
         random_company_number = str(random.randint(0, 9999999)).zfill(8)
         has_profile = has_fas_profile(random_company_number)
         if has_profile:
-            logging.debug("Selected company has a FAS profile: %s. Will try a "
-                          "different one.", random_company_number)
+            logging.debug(
+                "Selected company has a FAS profile: %s. Will try a "
+                "different one.", random_company_number)
         else:
-            logging.debug("Found a company without a FAS profile: %s.",
-                          random_company_number)
+            logging.debug(
+                "Found a company without a FAS profile: %s.",
+                random_company_number)
         is_registered = already_registered(random_company_number)
         if is_registered:
-            logging.debug("Company %s is already registered with FAB. Will try "
-                          "a different one.", random_company_number)
+            logging.debug(
+                "Company %s is already registered with FAB. Will try a "
+                "different one.", random_company_number)
         else:
             logging.debug("Company %s is not registered with FAB: Getting "
                           "it details from CH...", random_company_number)
@@ -753,18 +757,20 @@ def find_active_company_without_fas_profile(alias: str) -> Company:
             if json[0]["company_status"] == "active":
                 active = True
                 with assertion_msg(
-                        "Expected to get details of company no.: %s but got %s",
+                        "Expected to get details of company no: %s but got %s",
                         random_company_number, json[0]["company_number"]):
                     assert json[0]["company_number"] == random_company_number
             else:
                 counter += 1
-                has_profile, is_registered, exists, active = True, True, False, False
+                has_profile, is_registered, exists, active = \
+                    True, True, False, False
                 logging.debug("Company with number %s is not active. It's %s. "
                               "Trying a different one...",
                               random_company_number, json[0]["company_status"])
         else:
             counter += 1
-            has_profile, is_registered, exists, active = True, True, False, False
+            has_profile, is_registered, exists, active = \
+                True, True, False, False
             logging.debug("Company with number %s does not exist. Trying a "
                           "different one...", random_company_number)
 
@@ -833,7 +839,7 @@ def get_companies(*, number: int = 100) -> CompaniesList:
     """Find a number of active companies without FAS profile.
 
     NOTE:
-    The search is pretty slow. It takes roughly 10 minutes to find 100 companies
+    The search is pretty slow. It takes roughly 10 mins to find 100 companies
 
     :param number: (optional) expected number of companies to find
     :return: a list of Company named tuples (all with "test" alias)
@@ -895,7 +901,7 @@ def update_companies():
                     delete_supplier_data_from_dir(company.number)
                     email_address = get_company_email(company.number)
                     delete_supplier_data_from_sso(email_address)
-                    blue("Successfully deleted company data from DIR & SSO DBs")
+                    blue("Successfully deleted company from DIR & SSO DBs")
                     is_registered = False
             else:
                 inactive_counter += 1
@@ -932,7 +938,7 @@ def escape_html(text: str, *, upper: bool = False) -> str:
     """Escape some of the special characters that are replaced by FAB/SSO.
 
     :param text: a string to escape
-    :param upper: (optional) change to upper case before escaping the characters
+    :param upper: (optional) change to upper case before escaping characters
     :return: a string with escaped characters
     """
     html_escape_table = {"&": "&amp;", "'": "&#39;"}
@@ -1087,7 +1093,9 @@ def detect_page_language(
 
     # clear the page content from the specified characters
     text = re.sub(ignored_characters, '', soup.get_text())
-    lines = [line.strip().lower() for line in text.splitlines() if line.strip()]
+    lines = [line.strip().lower()
+             for line in text.splitlines()
+             if line.strip()]
     results = {}
     for x in range(rounds):
         results[x] = detect_langs('\n'.join(lines))

--- a/tests/functional/utils/request.py
+++ b/tests/functional/utils/request.py
@@ -32,8 +32,8 @@ REQUEST_EXCEPTIONS = (
     BaseHTTPError, RequestException, HTTPError, ConnectionError, ProxyError,
     SSLError, Timeout, ConnectTimeout, ReadTimeout, URLRequired,
     TooManyRedirects, MissingSchema, InvalidSchema, InvalidURL, InvalidHeader,
-    ChunkedEncodingError, ContentDecodingError, StreamConsumedError, RetryError,
-    UnrewindableBodyError
+    ChunkedEncodingError, ContentDecodingError, StreamConsumedError,
+    RetryError, UnrewindableBodyError
 )
 
 
@@ -80,7 +80,7 @@ def make_request(
                   For more details please refer to:
                   http://docs.python-requests.org/en/master/user/quickstart/#post-a-multipart-encoded-file
     :param allow_redirects: Follow or do not follow redirects
-    :param auth: (optional) authentication tuple, e.g.: ("username", "password")
+    :param auth: (optional) authentication tuple, e.g. ("username", "password")
     :param trim: (optional) trim long request body/response content if True
     :return: a response object
     """
@@ -143,10 +143,10 @@ def make_request(
     return res
 
 
-def check_response(response: Response, status_code: int, *,
-                   location: str = None, locations: list = None,
-                   location_starts_with: str = None, body_contains: list = None,
-                   unexpected_strings: list = None):
+def check_response(
+        response: Response, status_code: int, *, location: str = None,
+        locations: list = None, location_starts_with: str = None,
+        body_contains: list = None, unexpected_strings: list = None):
     """Check if SUT replied with an expected response.
 
     :param response: Response object return by `requests`
@@ -166,7 +166,7 @@ def check_response(response: Response, status_code: int, *,
         assert response.status_code == status_code
 
     if body_contains:
-        with assertion_msg("Expected response with content, got an empty one!"):
+        with assertion_msg("Expected response with content, got an empty one"):
             assert response.content
         content = response.content.decode("utf-8")
         for string in body_contains:
@@ -174,7 +174,7 @@ def check_response(response: Response, status_code: int, *,
                 assert string in content
 
     if unexpected_strings:
-        with assertion_msg("Expected response with content, got an empty one!"):
+        with assertion_msg("Expected response with content, got an empty one"):
             assert response.content
         content = response.content.decode("utf-8")
         for string in unexpected_strings:

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -39,6 +39,8 @@ FAS_MESSAGE_FROM_BUYER_SUBJECT = ("Someone is interested in your Find a Buyer "
                                   "profile")
 FAB_CONFIRM_COLLABORATION_SUBJECT = ("Confirm you’ve been added to {}’s Find a"
                                      " buyer profile")
+FAB_TRANSFER_OWNERSHIP_SUBJECT = ("Confirm ownership of {}’s Find a buyer "
+                                  "profile")
 SSO_PASSWORD_RESET_MSG_SUBJECT = "Reset your great.gov.uk password"
 NO_OF_EMPLOYEES = ["1-10", "11-50", "51-200", "201-500", "501-1000",
                    "1001-10000", "10001+"]


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-3561)

Scenario:
```gherkin
  Scenario Outline: New Account Owner which "<has or does not have>" a SSO/great.gov.uk account should receive an email with a request for becoming the owner of "<a>" company profile
    Given "Peter Alder" has created "<a>" profile for randomly selected company "Y"
    And "Annette Geissinger" "<has or does not have>" an SSO/great.gov.uk account

    When "Peter Alder" decides to transfer the ownership of company's "Y" Find a Buyer profile to "Annette Geissinger"

    Then "Annette Geissinger" should receive an email with a request for becoming the owner of the company "Y" profile

    Examples:
      | has or does not have | a             |
      | has                  | a verified    |
      | has                  | an unverified |
      | does not have        | a verified    |
      | does not have        | an unverified |
```

Apart from the main scenario, few other related ones where implemented:
`ED-3562`, `ED-3570`, `ED-3571`, `ED-3564`, `ED-3565`  

```gherkin
  @ED-3562
  @multi-user
  @transfer-ownership
  @bug
  @ED-2268
  Scenario Outline: Company account owner should be able to transfer the ownership of "<a>" profile to a user who "<has or does not have>" an SSO/great.gov.uk account
    Given "Peter Alder" has created "<a>" profile for randomly selected company "Y"
    And "Annette Geissinger" "<has or does not have>" an SSO/great.gov.uk account

    When "Peter Alder" transfers the ownership of company's "Y" Find a Buyer profile to "Annette Geissinger"

    Then "Annette Geissinger" should see options to manage Find a Buyer profile users on SSO Profile
    And "Peter Alder" should not see options to manage Find a Buyer profile users on SSO Profile

    Examples:
      | a             | has or does not have |
      | a verified    | has                  |
      | a verified    | does not have        |
      | an unverified | has                  |
      | an unverified | does not have        |
```

```gherkin
  @bug
  @ED-3882
  @fixme
  @ED-3570
  @multi-user
  @edge-case
  @fake-sso-email-verification
  Scenario: New account owner should be able to transfer it back to the original owner
    Given "Peter Alder" has created "an unverified" profile for randomly selected company "Y"
    And "Annette Geissinger" "has" an SSO/great.gov.uk account

    When "Peter Alder" transfers the ownership of company's "Y" Find a Buyer profile to "Annette Geissinger"
    Then "Annette Geissinger" should see options to manage Find a Buyer profile users on SSO Profile
    And "Peter Alder" should not see options to manage Find a Buyer profile users on SSO Profile

    When "Annette Geissinger" transfers the ownership of company's "Y" Find a Buyer profile to "Peter Alder"
    Then "Peter Alder" should see options to manage Find a Buyer profile users on SSO Profile
    And "Annette Geissinger" should not see options to manage Find a Buyer profile users on SSO Profile
```

```gherkin
  @bug
  @ED-3882
  @fixme
  @ED-3571
  @multi-user
  @edge-case
  @fake-sso-email-verification
  Scenario: New account owner should be able to add the original owner as a collaborator to the company profile
    Given "Peter Alder" has created "an unverified" profile for randomly selected company "Y"
    And "Annette Geissinger" "has" an SSO/great.gov.uk account
    And "Peter Alder" transferred the ownership of company's "Y" Find a Buyer profile to "Annette Geissinger"

    When "Annette Geissinger" decides to add "Peter Alder" as a collaborator
    When "Peter Alder" confirms that he wants to be added to the company "Y" Find a Buyer profile

    Then "Peter Alder" should see "FAB Company profile" page
```

```gherkin
  @ED-3564
  @multi-user
  @remove-collaborator
  @fake-sso-email-verification
  Scenario: Account owner should be able to remove one account collaborator
    Given "Peter Alder" has created "an unverified" profile for randomly selected company "Y"
    And "Annette Geissinger" "has" an SSO/great.gov.uk account
    And "Peter Alder" added "Annette Geissinger" as a collaborator
    And "Annette Geissinger" has received an email with a request to confirm that she's been added to company "Y" Find a Buyer profile
    And "Annette Geissinger" confirmed that she wants to be added to the company "Y" Find a Buyer profile

    When "Peter Alder" removes "Annette Geissinger" from the list of collaborators to the company "Y"

    Then "Peter Alder" should not see "Annette Geissinger" among the users associated with company's profile
    And "Annette Geissinger" should not be able to access "FAB company profile" page
```

```gherkin
  @ED-3565
  @multi-user
  @remove-collaborator
  @fake-sso-email-verification
  Scenario: Account owner should be able to remove multiple account collaborators
    Given "Peter Alder" has created "an unverified" profile for randomly selected company "Y"
    And "Annette Geissinger, Betty Jones, James Weir" "have" an SSO/great.gov.uk account
    And "Peter Alder" added "Annette Geissinger, Betty Jones, James Weir" as a collaborator
    And "Annette Geissinger" has received an email with a request to confirm that she's been added to company "Y" Find a Buyer profile
    And "Betty Jones" has received an email with a request to confirm that she's been added to company "Y" Find a Buyer profile
    And "James Weir" has received an email with a request to confirm that she's been added to company "Y" Find a Buyer profile
    And "Annette Geissinger" confirmed that she wants to be added to the company "Y" Find a Buyer profile
    And "Betty Jones" confirmed that she wants to be added to the company "Y" Find a Buyer profile
    And "James Weir" confirmed that he wants to be added to the company "Y" Find a Buyer profile

    When "Peter Alder" removes "Annette Geissinger, Betty Jones, James Weir" from the list of collaborators to the company "Y"

    Then "Peter Alder" should not see "Annette Geissinger, Betty Jones, James Weir" among the users associated with company's profile
    And "Annette Geissinger" should not be able to access "FAB company profile" page
    And "Betty Jones" should not be able to access "FAB company profile" page
    And "James Weir" should not be able to access "FAB company profile" page
```
