### PR TITLE
CMS-160 invest - automate scenarios for indutry pages

### DIFF
--- a/tests/browser/features/invest/industry.feature
+++ b/tests/browser/features/invest/industry.feature
@@ -3,7 +3,7 @@
 Feature: Industry pages
 
   Scenario Outline: Visitors should be able to see the "Invest <industry>" page
-    Given "Robert" visits the "Invest <industry>" page
+    Given "Robert" visits the "Invest - <selected> industry" page
 
     Then "Robert" should see expected page sections
       | Header     |
@@ -14,75 +14,75 @@ Feature: Industry pages
       | Footer     |
 
     Examples: Industries
-      | industry                                     |
-      | Invest - Advanced manufacturing              |
-      | Invest - Aerospace                           |
-      | Invest - Agri-tech                           |
-      | Invest - Asset management                    |
-      | Invest - Automotive                          |
-      | Invest - Automotive research and development |
-      | Invest - Automotive supply chain             |
-      | Invest - Capital Investment                  |
-      | Invest - Chemicals                           |
-      | Invest - Creative content and production     |
-      | Invest - Creative industries                 |
-      | Invest - Data Analytics                      |
-      | Invest - Digital media                       |
-      | Invest - Electrical networks                 |
-      | Invest - Energy                              |
-      | Invest - Energy from waste                   |
-      | Invest - Financial services                  |
-      | Invest - Financial technology                |
-      | Invest - Food and drink                      |
-      | Invest - Free-from foods                     |
-      | Invest - Health and life sciences            |
-      | Invest - Meat, poultry and dairy             |
-      | Invest - Medical technology                  |
-      | Invest - Motorsport                          |
-      | Invest - Nuclear energy                      |
-      | Invest - Offshore wind energy                |
-      | Invest - Oil and gas                         |
-      | Invest - Pharmaceutical manufacturing        |
-      | Invest - Retail                              |
-      | Invest - Technology                          |
+      | selected                            |
+      | Advanced manufacturing              |
+      | Aerospace                           |
+      | Agri-tech                           |
+      | Asset management                    |
+      | Automotive                          |
+      | Automotive research and development |
+      | Automotive supply chain             |
+      | Capital Investment                  |
+      | Chemicals                           |
+      | Creative content and production     |
+      | Creative industries                 |
+      | Data Analytics                      |
+      | Digital media                       |
+      | Electrical networks                 |
+      | Energy                              |
+      | Energy from waste                   |
+      | Financial services                  |
+      | Financial technology                |
+      | Food and drink                      |
+      | Free-from foods                     |
+      | Health and life sciences            |
+      | Meat, poultry and dairy             |
+      | Medical technology                  |
+      | Motorsport                          |
+      | Nuclear energy                      |
+      | Offshore wind energy                |
+      | Oil and gas                         |
+      | Pharmaceutical manufacturing        |
+      | Retail                              |
+      | Technology                          |
 
 
   Scenario Outline: Visitors should be able to read through all of the sections on the "Invest <industry>" page
-    Given "Robert" visits the "Invest <industry>" page
+    Given "Robert" visits the "Invest - <selected> industry" page
 
     When "Robert" unfolds all content sections
 
     Then "Robert" should see content for every section
 
     Examples: Industries
-      | industry                                     |
-      | Invest - Advanced manufacturing              |
-      | Invest - Aerospace                           |
-      | Invest - Agri-tech                           |
-      | Invest - Asset management                    |
-      | Invest - Automotive                          |
-      | Invest - Automotive research and development |
-      | Invest - Automotive supply chain             |
-      | Invest - Capital Investment                  |
-      | Invest - Chemicals                           |
-      | Invest - Creative content and production     |
-      | Invest - Creative industries                 |
-      | Invest - Data Analytics                      |
-      | Invest - Digital media                       |
-      | Invest - Electrical networks                 |
-      | Invest - Energy                              |
-      | Invest - Energy from waste                   |
-      | Invest - Financial services                  |
-      | Invest - Financial technology                |
-      | Invest - Food and drink                      |
-      | Invest - Free-from foods                     |
-      | Invest - Health and life sciences            |
-      | Invest - Meat, poultry and dairy             |
-      | Invest - Medical technology                  |
-      | Invest - Motorsport                          |
-      | Invest - Nuclear energy                      |
-      | Invest - Offshore wind energy                |
-      | Invest - Oil and gas                         |
-      | Invest - Pharmaceutical manufacturing        |
-      | Invest - Retail                              |
-      | Invest - Technology                          |
+      | selected                                     |
+      | Advanced manufacturing              |
+      | Aerospace                           |
+      | Agri-tech                           |
+      | Asset management                    |
+      | Automotive                          |
+      | Automotive research and development |
+      | Automotive supply chain             |
+      | Capital Investment                  |
+      | Chemicals                           |
+      | Creative content and production     |
+      | Creative industries                 |
+      | Data Analytics                      |
+      | Digital media                       |
+      | Electrical networks                 |
+      | Energy                              |
+      | Energy from waste                   |
+      | Financial services                  |
+      | Financial technology                |
+      | Food and drink                      |
+      | Free-from foods                     |
+      | Health and life sciences            |
+      | Meat, poultry and dairy             |
+      | Medical technology                  |
+      | Motorsport                          |
+      | Nuclear energy                      |
+      | Offshore wind energy                |
+      | Oil and gas                         |
+      | Pharmaceutical manufacturing        |
+      | Retail                              |
+      | Technology                          |

--- a/tests/browser/features/invest/industry.feature
+++ b/tests/browser/features/invest/industry.feature
@@ -1,4 +1,3 @@
-@wip
 @industry
 Feature: Industry pages
 
@@ -6,14 +5,17 @@ Feature: Industry pages
   Scenario Outline: Visitors should be able to see the "Invest - <selected> industry" page
     Given "Robert" visits the "Invest - <selected> industry" page
 
-    Then "Robert" should see expected sections on "Invest - Industry" page
+    When "Robert" unfolds all topic sections on "Invest - <selected> industry" page
+
+    Then "Robert" should see expected sections on "Invest - <selected> industry" page
       | Sections         |
       | Header           |
       | Beta bar         |
       | Hero             |
       | Industry pullout |
       | Big number       |
-      | Content          |
+      | Topics           |
+      | Topics contents  |
       | Report this page |
       | Footer           |
 
@@ -48,14 +50,17 @@ Feature: Industry pages
   Scenario Outline: Visitors should be able to see the "Invest - <selected> industry" page with related Industries
     Given "Robert" visits the "Invest - <selected> industry" page
 
-    Then "Robert" should see expected sections on "Invest - Industry" page
+    When "Robert" unfolds all topic sections on "Invest - <selected> industry" page
+
+    Then "Robert" should see expected sections on "Invest - <selected> industry" page
       | Sections           |
       | Header             |
       | Beta bar           |
       | Hero               |
       | Industry pullout   |
       | Big number         |
-      | Content            |
+      | Topics             |
+      | Topics contents    |
       | Related industries |
       | Report this page   |
       | Footer             |
@@ -69,41 +74,3 @@ Feature: Industry pages
       | Food and drink           |
       | Health and life sciences |
       | Technology               |
-    Given "Robert" visits the "Invest - <selected> industry" page
-
-    When "Robert" unfolds all content sections
-
-    Then "Robert" should see content for every section
-
-    Examples: Industries
-      | selected                                     |
-      | Advanced manufacturing              |
-      | Aerospace                           |
-      | Agri-tech                           |
-      | Asset management                    |
-      | Automotive                          |
-      | Automotive research and development |
-      | Automotive supply chain             |
-      | Capital Investment                  |
-      | Chemicals                           |
-      | Creative content and production     |
-      | Creative industries                 |
-      | Data Analytics                      |
-      | Digital media                       |
-      | Electrical networks                 |
-      | Energy                              |
-      | Energy from waste                   |
-      | Financial services                  |
-      | Financial technology                |
-      | Food and drink                      |
-      | Free-from foods                     |
-      | Health and life sciences            |
-      | Meat, poultry and dairy             |
-      | Medical technology                  |
-      | Motorsport                          |
-      | Nuclear energy                      |
-      | Offshore wind energy                |
-      | Oil and gas                         |
-      | Pharmaceutical manufacturing        |
-      | Retail                              |
-      | Technology                          |

--- a/tests/browser/features/invest/industry.feature
+++ b/tests/browser/features/invest/industry.feature
@@ -2,16 +2,20 @@
 @industry
 Feature: Industry pages
 
-  Scenario Outline: Visitors should be able to see the "Invest <industry>" page
+  @CMS-160
+  Scenario Outline: Visitors should be able to see the "Invest - <selected> industry" page
     Given "Robert" visits the "Invest - <selected> industry" page
 
-    Then "Robert" should see expected page sections
-      | Header     |
-      | Beta bar   |
-      | Hero       |
-      | Statistics |
-      | Content    |
-      | Footer     |
+    Then "Robert" should see expected sections on "Invest - Industry" page
+      | Sections         |
+      | Header           |
+      | Beta bar         |
+      | Hero             |
+      | Industry pullout |
+      | Big number       |
+      | Content          |
+      | Report this page |
+      | Footer           |
 
     Examples: Industries
       | selected                            |
@@ -19,23 +23,17 @@ Feature: Industry pages
       | Aerospace                           |
       | Agri-tech                           |
       | Asset management                    |
-      | Automotive                          |
       | Automotive research and development |
       | Automotive supply chain             |
       | Capital Investment                  |
       | Chemicals                           |
       | Creative content and production     |
-      | Creative industries                 |
       | Data Analytics                      |
       | Digital media                       |
       | Electrical networks                 |
-      | Energy                              |
       | Energy from waste                   |
-      | Financial services                  |
       | Financial technology                |
-      | Food and drink                      |
       | Free-from foods                     |
-      | Health and life sciences            |
       | Meat, poultry and dairy             |
       | Medical technology                  |
       | Motorsport                          |
@@ -44,10 +42,33 @@ Feature: Industry pages
       | Oil and gas                         |
       | Pharmaceutical manufacturing        |
       | Retail                              |
-      | Technology                          |
 
 
-  Scenario Outline: Visitors should be able to read through all of the sections on the "Invest <industry>" page
+  @CMS-160
+  Scenario Outline: Visitors should be able to see the "Invest - <selected> industry" page with related Industries
+    Given "Robert" visits the "Invest - <selected> industry" page
+
+    Then "Robert" should see expected sections on "Invest - Industry" page
+      | Sections           |
+      | Header             |
+      | Beta bar           |
+      | Hero               |
+      | Industry pullout   |
+      | Big number         |
+      | Content            |
+      | Related industries |
+      | Report this page   |
+      | Footer             |
+
+    Examples: Industries
+      | selected                 |
+      | Automotive               |
+      | Creative industries      |
+      | Energy                   |
+      | Financial services       |
+      | Food and drink           |
+      | Health and life sciences |
+      | Technology               |
     Given "Robert" visits the "Invest - <selected> industry" page
 
     When "Robert" unfolds all content sections

--- a/tests/browser/pages/invest_industry.py
+++ b/tests/browser/pages/invest_industry.py
@@ -67,7 +67,10 @@ class URLS(Enum):
     RETAIL = urljoin(BASE_URL, "retail/")
     TECHNOLOGY = urljoin(BASE_URL, "technology/")
 
-TOPIC_EXPANDERS = Selector(By.CSS_SELECTOR, "section.industry-page-accordions a.accordion-expander")
+
+TOPIC_EXPANDERS = Selector(
+    By.CSS_SELECTOR, "section.industry-page-accordions a.accordion-expander"
+)
 
 SECTIONS = {
     "header": {
@@ -83,10 +86,10 @@ SECTIONS = {
     },
     "hero": {"self": Selector(By.CSS_SELECTOR, "#content > section.hero")},
     "industry pullout": {
-        "self": Selector(By.CSS_SELECTOR, "section.industry-pullout"),
+        "self": Selector(By.CSS_SELECTOR, "section.industry-pullout")
     },
     "big number": {
-        "self": Selector(By.CSS_SELECTOR, "section.industry-pullout div.data"),
+        "self": Selector(By.CSS_SELECTOR, "section.industry-pullout div.data")
     },
     "topics": {
         "self": Selector(By.CSS_SELECTOR, "section.industry-page-accordions"),
@@ -101,8 +104,7 @@ SECTIONS = {
     "related industries": {
         "self": Selector(By.CSS_SELECTOR, "section.industry-page-related"),
         "industry cards": Selector(
-            By.CSS_SELECTOR,
-            "section.industry-page-related a.labelled-card",
+            By.CSS_SELECTOR, "section.industry-page-related a.labelled-card"
         ),
     },
     "report this page": {
@@ -194,6 +196,10 @@ def should_see_content_for(driver: WebDriver, industry_name: str):
 
 def unfold_topics(driver: WebDriver):
     expanders = find_elements(driver, by_css=TOPIC_EXPANDERS.value)
-    assert expanders, "Expected to see at least 1 topic but found 0 on {}".format(driver.current_url)
+    assert (
+        expanders
+    ), "Expected to see at least 1 topic but found 0 on {}".format(
+        driver.current_url
+    )
     for expander in expanders:
         expander.click()

--- a/tests/browser/pages/invest_industry.py
+++ b/tests/browser/pages/invest_industry.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
-from utils import assertion_msg, find_element, take_screenshot
+from utils import assertion_msg, find_element, take_screenshot, find_elements
 
 from pages import (
     AssertionExecutor,
@@ -67,6 +67,7 @@ class URLS(Enum):
     RETAIL = urljoin(BASE_URL, "retail/")
     TECHNOLOGY = urljoin(BASE_URL, "technology/")
 
+TOPIC_EXPANDERS = Selector(By.CSS_SELECTOR, "section.industry-page-accordions a.accordion-expander")
 
 SECTIONS = {
     "header": {
@@ -186,3 +187,10 @@ def should_see_content_for(driver: WebDriver, industry_name: str):
         driver.current_url,
     ):
         assert industry_name.lower() in source.lower()
+
+
+def unfold_topics(driver: WebDriver):
+    expanders = find_elements(driver, by_css=TOPIC_EXPANDERS.value)
+    assert expanders, "Expected to see at least 1 topic but found 0 on {}".format(driver.current_url)
+    for expander in expanders:
+        expander.click()

--- a/tests/browser/pages/invest_industry.py
+++ b/tests/browser/pages/invest_industry.py
@@ -88,12 +88,15 @@ SECTIONS = {
     "big number": {
         "self": Selector(By.CSS_SELECTOR, "section.industry-pullout div.data"),
     },
-    "content": {
+    "topics": {
         "self": Selector(By.CSS_SELECTOR, "section.industry-page-accordions"),
         "accordion expanders": Selector(
             By.CSS_SELECTOR,
             "section.industry-page-accordions a.accordion-expander",
         ),
+    },
+    "topics contents": {
+        "paragraphs": Selector(By.CSS_SELECTOR, "div.accordion-content p")
     },
     "related industries": {
         "self": Selector(By.CSS_SELECTOR, "section.industry-page-related"),

--- a/tests/browser/pages/invest_industry.py
+++ b/tests/browser/pages/invest_industry.py
@@ -83,13 +83,22 @@ SECTIONS = {
     "hero": {"self": Selector(By.CSS_SELECTOR, "#content > section.hero")},
     "industry pullout": {
         "self": Selector(By.CSS_SELECTOR, "section.industry-pullout"),
-        "data": Selector(By.CSS_SELECTOR, "section.industry-pullout div.data"),
     },
-    "industry accordions": {
+    "big number": {
+        "self": Selector(By.CSS_SELECTOR, "section.industry-pullout div.data"),
+    },
+    "content": {
         "self": Selector(By.CSS_SELECTOR, "section.industry-page-accordions"),
         "accordion expanders": Selector(
             By.CSS_SELECTOR,
             "section.industry-page-accordions a.accordion-expander",
+        ),
+    },
+    "related industries": {
+        "self": Selector(By.CSS_SELECTOR, "section.industry-page-related"),
+        "industry cards": Selector(
+            By.CSS_SELECTOR,
+            "section.industry-page-related a.labelled-card",
         ),
     },
     "report this page": {

--- a/tests/browser/steps/when_def.py
+++ b/tests/browser/steps/when_def.py
@@ -30,6 +30,7 @@ from steps.when_impl import (
     generic_open_guide_link,
     generic_open_industry_page,
     generic_see_more_industries,
+    generic_unfold_topics,
     guidance_open_category,
     guidance_read_through_all_articles,
     header_footer_click_on_dit_logo,
@@ -62,7 +63,7 @@ from steps.when_impl import (
     triage_say_whether_you_use_online_marketplaces,
     triage_should_see_answers_to_questions,
     triage_what_is_your_company_name,
-    visit_page
+    visit_page,
 )
 
 
@@ -437,3 +438,9 @@ def actor_decides_to_read_more(context: Context, actor_alias: str):
 def when_actor_goes_to_guide(
         context: Context, actor_alias: str, guide_name: str):
     generic_open_guide_link(context, actor_alias, guide_name)
+
+
+@when('"{actor_alias}" unfolds all topic sections on "{page_name}" page')
+def when_actor_unfolds_all_topic_sections(
+        context: Context, actor_alias: str, page_name: str):
+    generic_unfold_topics(context, actor_alias, page_name)

--- a/tests/browser/steps/when_impl.py
+++ b/tests/browser/steps/when_impl.py
@@ -1777,3 +1777,11 @@ def generic_open_guide_link(
     logging.debug(
         "%s opened '%s' page on %s", actor_alias, guide_name, page.URL
     )
+
+
+def generic_unfold_topics(context: Context, actor_alias: str, page_name: str):
+    page = get_page_object(page_name)
+    assert hasattr(page, "unfold_topics")
+    page.unfold_topics(context.driver)
+    update_actor(context, actor_alias, visited_page=page_name)
+    logging.debug("%s unfolded all topics on %s", actor_alias, page_name)


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-)

Scenario:
```gherkin
  @CMS-160
  Scenario Outline: Visitors should be able to see the "Invest - <selected> industry" page
    Given "Robert" visits the "Invest - <selected> industry" page

    When "Robert" unfolds all topic sections on "Invest - <selected> industry" page

    Then "Robert" should see expected sections on "Invest - <selected> industry" page
      | Sections         |
      | Header           |
      | Beta bar         |
      | Hero             |
      | Industry pullout |
      | Big number       |
      | Topics           |
      | Topics contents  |
      | Report this page |
      | Footer           |

    Examples: Industries
      | selected                            |
      | Advanced manufacturing              |
      | Aerospace                           |
      | Agri-tech                           |
      | Asset management                    |
      | Automotive research and development |
      | Automotive supply chain             |
      | Capital Investment                  |
      | Chemicals                           |
      | Creative content and production     |
      | Data Analytics                      |
      | Digital media                       |
      | Electrical networks                 |
      | Energy from waste                   |
      | Financial technology                |
      | Free-from foods                     |
      | Meat, poultry and dairy             |
      | Medical technology                  |
      | Motorsport                          |
      | Nuclear energy                      |
      | Offshore wind energy                |
      | Oil and gas                         |
      | Pharmaceutical manufacturing        |
      | Retail                              |
```

```gherkin
  @CMS-160
  Scenario Outline: Visitors should be able to see the "Invest - <selected> industry" page with related Industries
    Given "Robert" visits the "Invest - <selected> industry" page

    When "Robert" unfolds all topic sections on "Invest - <selected> industry" page

    Then "Robert" should see expected sections on "Invest - <selected> industry" page
      | Sections           |
      | Header             |
      | Beta bar           |
      | Hero               |
      | Industry pullout   |
      | Big number         |
      | Topics             |
      | Topics contents    |
      | Related industries |
      | Report this page   |
      | Footer             |

    Examples: Industries
      | selected                 |
      | Automotive               |
      | Creative industries      |
      | Energy                   |
      | Financial services       |
      | Food and drink           |
      | Health and life sciences |
      | Technology               |
```
