### PR TITLE
TT-444 check pdf links

### DIFF
--- a/requirements_browser.in
+++ b/requirements_browser.in
@@ -6,6 +6,7 @@ directory-sso-api-client
 nodeenv
 notifications-python-client
 paver
+pdfminer2
 requests
 retrying
 selenium

--- a/requirements_browser.txt
+++ b/requirements_browser.txt
@@ -12,7 +12,7 @@ directory-api-client==10.0.2
 directory-client-core==4.0.2  # via directory-api-client, directory-sso-api-client
 directory-constants==8.0.4
 directory-sso-api-client==3.0.2
-django==1.11.15           # via directory-api-client, directory-constants, sigauth
+django==1.11.16           # via directory-api-client, directory-constants, sigauth
 djangorestframework==3.8.2  # via sigauth
 docopt==0.6.2             # via notifications-python-client
 future==0.16.0            # via notifications-python-client
@@ -24,12 +24,13 @@ notifications-python-client==5.2.0
 parse-type==0.4.2         # via behave
 parse==1.8.4              # via behave, parse-type
 paver==1.3.4
+pdfminer2==20151206
 pyjwt==1.6.4              # via notifications-python-client
 pytz==2018.5              # via django
 requests==2.19.1
 retrying==1.3.3
 selenium==3.14.1
 sigauth==4.0.1
-six==1.11.0               # via behave, mohawk, parse-type, paver, retrying
+six==1.11.0               # via behave, mohawk, parse-type, paver, pdfminer2, retrying
 termcolor==1.1.0
 urllib3==1.23

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -35,8 +35,8 @@ urls = {
 
     # SSO API
     'sso-api:landing': '',
-    'sso-api:healthcheck-database': 'api/v1/healthcheck/database/',
-    'sso-api:healthcheck-ping': 'api/v1/healthcheck/ping/',
+    'sso-api:healthcheck-database': 'healthcheck/database/',
+    'sso-api:healthcheck-ping': 'healthcheck/ping/',
     'sso-api:user': 'api/v1/session-user/',
 
     # UI-BUYER
@@ -89,9 +89,13 @@ urls = {
 
     # API
     'api:docs': 'docs/',
-    'api:healthcheck-database': 'healthcheck/database/',
     'api:healthcheck-cache': 'healthcheck/cache/',
+    'api:healthcheck-database': 'healthcheck/database/',
     'api:healthcheck-elasticsearch': 'healthcheck/elasticsearch/',
+    'api:healthcheck-single-sign-on': 'healthcheck/single-sign-on/',
+    'api:healthcheck-sentry': 'healthcheck/sentry/',
+    'api:healthcheck-ping': 'healthcheck/ping/',
+
     'api:enrolment': 'enrolment/',
     'api:company': 'supplier/{sso_id}/company/',
     'api:user': 'supplier/{sso_id}/',
@@ -102,8 +106,9 @@ urls = {
     'internal-api:companies-house-search': 'api/internal/companies-house-search/',
 
     # SSO-PROFILE
-    'profile:healthcheck-api': 'healthcheck/api/',
-    'profile:healthcheck-sso-proxy': 'healthcheck/single-sign-on/',
+    'profile:healthcheck-ping': 'healthcheck/ping/',
+    'profile:healthcheck-sentry': 'healthcheck/sentry/',
+    'profile:healthcheck-sso': 'healthcheck/single-sign-on/',
     'profile:soo': 'selling-online-overseas/',
     'profile:fab': 'find-a-buyer/',
     'profile:exops-alerts': 'export-opportunities/email-alerts/',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -35,8 +35,9 @@ urls = {
 
     # SSO API
     'sso-api:landing': '',
-    'sso-api:healthcheck-database': 'healthcheck/database/',
-    'sso-api:healthcheck-ping': 'healthcheck/ping/',
+    'sso-api:healthcheck-database': 'api/v1/healthcheck/database/',
+    'sso-api:healthcheck-ping': 'api/v1/healthcheck/ping/',
+    'sso-api:healthcheck-sentry': 'api/v1/healthcheck/sentry/',
     'sso-api:user': 'api/v1/session-user/',
 
     # UI-BUYER

--- a/tests/browser/features/invest/hpo_pdfs.feature
+++ b/tests/browser/features/invest/hpo_pdfs.feature
@@ -1,0 +1,27 @@
+@invest
+@hpo
+@pdf
+Feature: HPO PDFs sent after
+
+
+  @TT-444
+  Scenario Outline: Check PDFs listed on "Thank you for your enquiry" page
+    Given "Peter Alder" got in touch with us via "Invest - <selected> - HPO Contact Us" page
+    And "Peter Alder" is on the "Invest - Thank you for your enquiry - HPO Contact us" page
+
+    When "Peter Alder" downloads all visible PDFs
+
+    Then "Peter Alder" should see correct details in every downloaded PDF
+      | telephone number = +44(0) 207 000 9012    |
+      | email address = enquiries@invest-trade.uk |
+    And there should not be any dead links in every downloaded PDF
+
+    Examples:
+      | selected                          |
+      | High productivity food production |
+
+    @full
+    Examples:
+      | selected                          |
+      | Lightweight structures            |
+      | Rail infrastructure               |

--- a/tests/browser/steps/given_def.py
+++ b/tests/browser/steps/given_def.py
@@ -21,6 +21,7 @@ from steps.when_impl import (
     case_studies_go_to_random,
     click_on_page_element,
     export_readiness_open_category,
+    generic_get_in_touch,
     generic_open_industry_page,
     get_geo_ip,
     guidance_open_category,
@@ -32,7 +33,7 @@ from steps.when_impl import (
     start_triage,
     triage_classify_as,
     triage_create_exporting_journey,
-    visit_page
+    visit_page,
 )
 
 
@@ -228,3 +229,9 @@ def given_actor_decided_to_click_on_page_element(
 def fas_given_actor_opened_industry_page(
         context: Context, actor_alias: str, industry_name: str):
     generic_open_industry_page(context, actor_alias, industry_name)
+
+
+@given('"{actor_alias}" got in touch with us via "{page_name}" page')
+def given_actor_got_in_touch_with_us(
+        context: Context, actor_alias: str, page_name: str):
+    generic_get_in_touch(context, actor_alias, page_name)

--- a/tests/browser/steps/then_def.py
+++ b/tests/browser/steps/then_def.py
@@ -47,6 +47,8 @@ from steps.then_impl import (
     language_selector_keyboard_should_be_trapped,
     language_selector_should_not_see_it,
     language_selector_should_see_it,
+    pdf_check_expected_details,
+    pdf_check_for_dead_links,
     personalised_journey_should_not_see_banner_and_top_10_table,
     personalised_journey_should_see_banner_and_top_10_table,
     personalised_journey_should_see_read_counter,
@@ -425,3 +427,14 @@ def then_hpo_agent_should_receive_hpo_enquiry_email(
 def then_actor_should_see_form_element_in_specific_stage(
         context: Context, actor_alias: str, element: str, state: str):
     form_check_state_of_element(context, actor_alias, element, state)
+
+
+@then('"{actor_alias}" should see correct details in every downloaded PDF')
+def then_pdfs_should_contain_expected_details(
+        context: Context, actor_alias: str):
+    pdf_check_expected_details(context, actor_alias, context.table)
+
+
+@then('there should not be any dead links in every downloaded PDF')
+def then_should_not_see_dead_links_in_pdf(context: Context):
+    pdf_check_for_dead_links(context)

--- a/tests/browser/steps/when_def.py
+++ b/tests/browser/steps/when_def.py
@@ -28,6 +28,8 @@ from steps.when_impl import (
     fas_view_more_companies,
     fas_view_selected_company_profile,
     generic_click_on_uk_gov_logo,
+    generic_download_all_pdfs,
+    generic_fill_out_and_submit_form,
     generic_open_guide_link,
     generic_open_industry_page,
     generic_see_more_industries,
@@ -65,7 +67,6 @@ from steps.when_impl import (
     triage_should_see_answers_to_questions,
     triage_what_is_your_company_name,
     visit_page,
-    generic_fill_out_and_submit_form
 )
 
 
@@ -462,3 +463,8 @@ def when_actor_clicks_on_uk_gov_logo(
 @when('"{actor_alias}" fills out and submits the form')
 def when_actor_fills_out_and_submits_the_form(context: Context, actor_alias: str):
     generic_fill_out_and_submit_form(context, actor_alias)
+
+
+@when('"{actor_alias}" downloads all visible PDFs')
+def when_actor_downloads_all_visible_pdfs(context: Context, actor_alias: str):
+    generic_download_all_pdfs(context, actor_alias)

--- a/tests/browser/steps/when_impl.py
+++ b/tests/browser/steps/when_impl.py
@@ -1877,3 +1877,9 @@ def generic_fill_out_and_submit_form(context: Context, actor_alias: str):
 def generic_get_in_touch(context: Context, actor_alias: str, page_name: str):
     visit_page(context, actor_alias, page_name)
     generic_fill_out_and_submit_form(context, actor_alias)
+
+
+def generic_download_all_pdfs(context: Context, actor_alias: str):
+    page = get_last_visited_page(context, actor_alias)
+    has_action(page, "download_all_pdfs")
+    context.pdfs = page.download_all_pdfs(context.driver)

--- a/tests/browser/steps/when_impl.py
+++ b/tests/browser/steps/when_impl.py
@@ -1872,3 +1872,8 @@ def generic_fill_out_and_submit_form(context: Context, actor_alias: str):
     details = generate_form_details(page, actor)
     page.fill_out(context.driver, details)
     page.submit(context.driver)
+
+
+def generic_get_in_touch(context: Context, actor_alias: str, page_name: str):
+    visit_page(context, actor_alias, page_name)
+    generic_fill_out_and_submit_form(context, actor_alias)

--- a/tests/browser/utils/pdf.py
+++ b/tests/browser/utils/pdf.py
@@ -1,0 +1,38 @@
+import io
+
+from pdfminer.converter import TextConverter
+from pdfminer.layout import LAParams
+from pdfminer.pdfinterp import PDFPageInterpreter, PDFResourceManager
+from pdfminer.pdfpage import PDFPage
+
+
+def extract_text_from_pdf_bytes(
+        pdf_bytes: bytes,
+        *,
+        codec: str = "utf-8",
+        password: str = "",
+        maxpages: int = 0,
+        caching: bool = True,
+        remove_empty_lines: bool = True,
+) -> str:
+    rsrcmgr = PDFResourceManager()
+    retstr = io.StringIO()
+    laparams = LAParams()
+    device = TextConverter(rsrcmgr, retstr, codec=codec, laparams=laparams)
+    pdf_file = io.BytesIO(pdf_bytes)
+    interpreter = PDFPageInterpreter(rsrcmgr, device)
+    pagenos = set()
+    pdf_pages = PDFPage.get_pages(
+        pdf_file, pagenos, maxpages=maxpages, password=password,
+        caching=caching, check_extractable=True)
+    for page in pdf_pages:
+        interpreter.process_page(page)
+
+    text = retstr.getvalue()
+
+    pdf_file.close()
+    device.close()
+    retstr.close()
+    if remove_empty_lines:
+        text = "\n".join([line for line in text.splitlines() if line.strip()])
+    return text

--- a/tests/smoke/test_api.py
+++ b/tests/smoke/test_api.py
@@ -8,11 +8,22 @@ from tests.settings import DIRECTORY_API_HEALTH_CHECK_TOKEN as TOKEN
 
 
 @pytest.mark.parametrize("absolute_url", [
-    get_absolute_url('api:healthcheck-database'),
     get_absolute_url('api:healthcheck-cache'),
+    get_absolute_url('api:healthcheck-database'),
     get_absolute_url('api:healthcheck-elasticsearch'),
 ])
-def test_health_check_endpoints(absolute_url):
+def test_healthcheck_endpoints(absolute_url):
+    params = {'token': TOKEN}
+    response = requests.get(absolute_url, params=params)
+    assert response.status_code == http.client.OK
+
+
+@pytest.mark.parametrize("absolute_url", [
+    # get_absolute_url('api:healthcheck-single-sign-on'),
+    get_absolute_url('api:healthcheck-sentry'),
+    get_absolute_url('api:healthcheck-ping'),
+])
+def test_directory_healthcheck_endpoints(absolute_url):
     params = {'token': TOKEN}
     response = requests.get(absolute_url, params=params)
     assert response.status_code == http.client.OK

--- a/tests/smoke/test_profile.py
+++ b/tests/smoke/test_profile.py
@@ -63,10 +63,19 @@ def test_directory_supplier_invalid_user_token():
 
 
 @pytest.mark.parametrize("absolute_url", [
-    get_absolute_url('profile:healthcheck-api'),
-    get_absolute_url('profile:healthcheck-sso-proxy'),
+    get_absolute_url('profile:healthcheck-ping'),
 ])
 def test_health_check_endpoints(absolute_url):
+    response = requests.get(absolute_url)
+    assert response.status_code == http.client.OK
+
+
+@pytest.mark.parametrize("absolute_url", [
+    get_absolute_url('profile:healthcheck-ping'),
+    get_absolute_url('profile:healthcheck-sentry'),
+    get_absolute_url('profile:healthcheck-sso'),
+])
+def test_health_check_endpoints_auth(absolute_url):
     params = {'token': TOKEN}
     response = requests.get(absolute_url, params=params)
     assert response.status_code == http.client.OK

--- a/tests/smoke/test_sso_api.py
+++ b/tests/smoke/test_sso_api.py
@@ -9,11 +9,15 @@ from tests.settings import DIRECTORY_API_HEALTH_CHECK_TOKEN as TOKEN
 
 
 @pytest.mark.session_auth
-def test_health_check_database():
+@pytest.mark.parametrize("absolute_url", [
+    get_absolute_url('sso-api:healthcheck-database'),
+    get_absolute_url('sso-api:healthcheck-ping'),
+    get_absolute_url('sso-api:healthcheck-sentry'),
+])
+def test_health_check_database(absolute_url):
     """This endpoint still uses session auth instead of HAWK signature check"""
     params = {'token': TOKEN}
-    response = requests.get(
-            get_absolute_url('sso-api:healthcheck-database'), params=params)
+    response = requests.get(absolute_url, params=params)
     assert response.status_code == http.client.OK
 
 


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/ED-)

Scenario:
```gherkin
@TT-444
  Scenario Outline: Check PDFs listed on "Thank you for your enquiry" page
    Given "Peter Alder" got in touch with us via "Invest - <selected> - HPO Contact Us" page
    And "Peter Alder" is on the "Invest - Thank you for your enquiry - HPO Contact us" page
     When "Peter Alder" downloads all visible PDFs
     Then "Peter Alder" should see correct details in every downloaded PDF
      | telephone number = +44(0) 207 000 9012    |
      | email address = enquiries@invest-trade.uk |
    And there should not be any dead links in every downloaded PDF
     Examples:
      | selected                          |
      | High productivity food production |
     @full
    Examples:
      | selected                          |
      | Lightweight structures            |
      | Rail infrastructure               |
```
