### PR TITLE
TT-758 - scenarios for the new contact us application

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,8 @@
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+combine_as_imports=True
+line_length=80
+sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+no_lines_before=LOCALFOLDER

--- a/tests/browser/.behaverc
+++ b/tests/browser/.behaverc
@@ -8,3 +8,6 @@ junit_directory=./reports/
 verbose=True
 log_capture=False
 logging_level=DEBUG
+
+[behave.formatters]
+mini = behave_ext.mini_formatter:MiniFormatter

--- a/tests/browser/behave_ext/mini_formatter.py
+++ b/tests/browser/behave_ext/mini_formatter.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from behave.formatter.base import Formatter
+
+
+class MiniFormatter(Formatter):
+    """
+    Provides a simple plain formatter without coloring/formatting.
+    The formatter displays only scenario name
+    """
+    name = "plain"
+    description = "Very basic formatter with maximum compatibility"
+
+    SHOW_MULTI_LINE = False
+    SHOW_TAGS = False
+    SHOW_ALIGNED_KEYWORDS = False
+    indent_size = 0
+    RAISE_OUTPUT_ERRORS = True
+
+    def scenario(self, scenario):
+        skip_config_tags = [
+            tag.replace("-", "")
+            for tag in str(self.config.tags).split()
+            if tag.startswith("-")
+        ]
+        has_feature_skip_tags = any(
+            skip_tag in scenario.feature.tags
+            for skip_tag in skip_config_tags
+        )
+        has_scenario_skip_tags = any(
+            skip_tag in scenario.tags
+            for skip_tag in skip_config_tags
+        )
+        if not has_scenario_skip_tags and not has_feature_skip_tags:
+            self.stream.write(f"{scenario.name}\n")
+

--- a/tests/browser/environment.py
+++ b/tests/browser/environment.py
@@ -63,7 +63,17 @@ def start_driver_session(context: Context, session_name: str):
                 )
         else:
             print("Will use default browser capabilities")
-            context.driver = drivers[browser_name.lower()]()
+            import os
+            from selenium.webdriver.chrome.options import Options
+            options = Options()
+            if os.getenv("HEADLESS", "false") == "true":
+                options.add_argument("--headless")
+                options.add_argument("--window-size=1600x2200")
+            options.add_argument("--start-maximized")
+            options.add_argument("--whitelisted-ips=")
+            options.add_argument("--disable-extensions")
+            options.add_argument("--no-sandbox")
+            context.driver = drivers[browser_name.lower()](options=options)
     context.driver.set_page_load_timeout(time_to_wait=27.0)
     try:
         context.driver.maximize_window()

--- a/tests/browser/features/exred/header-footer.feature
+++ b/tests/browser/features/exred/header-footer.feature
@@ -195,8 +195,13 @@ Feature: Header-Footer
       | specific                                        |
       | Export Readiness - Home                         |
       | Export Readiness - Interim Export Opportunities |
-      | Export Opportunities - Home                     |
       | Find a Buyer - Home                             |
+
+    @bug
+    @fixme
+    Examples: invalid link to "Your export journey" on ExOpps site
+      | specific                                        |
+      | Export Opportunities - Home                     |
 
     @bug
     @ED-3282
@@ -222,8 +227,13 @@ Feature: Header-Footer
       | specific                                        |
       | Export Readiness - Home                         |
       | Export Readiness - Interim Export Opportunities |
-      | Export Opportunities - Home                     |
       | Find a Buyer - Home                             |
+
+    @bug
+    @fixme
+    Examples: invalid link to "Your export journey" on ExOpps site
+      | specific                                        |
+      | Export Opportunities - Home                     |
 
     @bug
     @ED-3282

--- a/tests/browser/features/exred/international-page.feature
+++ b/tests/browser/features/exred/international-page.feature
@@ -11,7 +11,7 @@ Feature: International Page
       | Header bar        |
       | Beta bar          |
       | Header menu       |
-      | EU Exit updates   |
+#      | EU Exit updates   |  # EU Exit feature is turned off
       | Intro             |
       | Buy from the UK   |
       | Invest in the UK  |

--- a/tests/browser/features/exred/new-contact-us.feature
+++ b/tests/browser/features/exred/new-contact-us.feature
@@ -260,7 +260,6 @@ Feature:  new contact us forms
   @TT-758
   @CMS-506
   @eu_exit
-  @work_in_progress
   @feature_flagged
   Scenario: Exporters should be able to get to the "Domestic EU Exit short contact-us form"
     Given "Robert" got to the "Export Readiness - What can we help you with? - Domestic Contact us" page via "The UK"
@@ -270,18 +269,19 @@ Feature:  new contact us forms
     Then "Robert" should be on the "Export Readiness - Domestic EU Exit contact form" page
 
 
-  # partially covered by CMS-506
-  @wip
+  @TT-758
+  @CMS-506
+  @dev-only
+  @captcha
   @eu_exit
-  @work_in_progress
   @feature_flagged
   Scenario: Exporters should be able to contact "EU Exit mailbox"
-    Given "Robert" got to the "Domestic EU Exit contact-us form" page via EU exit option
+    Given "Robert" got to the "Export Readiness - Domestic EU Exit contact form" page via "The UK -> EU Exit"
 
     When "Robert" fills out and submits the form
 
-    Then "Robert" should be on the "Thank you for your enquiry" page
-    And an email is submitted to "Zendesk for the attention of EU Exit team"
+    Then "Robert" should be on the "Export Readiness - Thank you for your enquiry - Domestic EU Exit Contact us" page
+    And "Robert" should receive an "Thank you for your EU exit enquiry" confirmation email
 
 
   @wip

--- a/tests/browser/features/exred/new-contact-us.feature
+++ b/tests/browser/features/exred/new-contact-us.feature
@@ -58,6 +58,8 @@ Feature:  new contact us forms
 
   @TT-758
   @ita
+  @captcha
+  @dev-only
   @exporting_from_the_UK
   Scenario: Domestic Enquirers should be able to contact relevant ITA based on the postcode provided
     Given "Robert" got to the "Export Readiness - Long (Export Advice Comment)" page via "The UK -> Advice to export from the UK"
@@ -281,6 +283,7 @@ Feature:  new contact us forms
   @TT-758
   @CMS-506
   @eu_exit
+  @dev-only
   @feature_flagged
   Scenario: Exporters should be able to get to the "Domestic EU Exit short contact-us form"
     Given "Robert" got to the "Export Readiness - What can we help you with? - Domestic Contact us" page via "The UK"

--- a/tests/browser/features/exred/new-contact-us.feature
+++ b/tests/browser/features/exred/new-contact-us.feature
@@ -81,6 +81,7 @@ Feature:  new contact us forms
 
 
   @TT-758
+  @exopps
   @account_support
   Scenario: Domestic enquirers should see all expected help options for "Export opportunities service"
     Given "Robert" got to the "Export Readiness - Export opportunities service" page via "The UK -> Great.gov.uk account and services support -> Export opportunities service"
@@ -93,6 +94,7 @@ Feature:  new contact us forms
 
 
   @TT-758
+  @greatgovuk_account
   @account_support
   Scenario: Domestic enquirers should see all expected help options for "Great.gov.uk account"
     Given "Robert" got to the "Export Readiness - Great.gov.uk account" page via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk"
@@ -108,6 +110,7 @@ Feature:  new contact us forms
 
 
   @TT-758
+  @short_domestic
   @account_support
   Scenario: Domestic enquirers should be able to get to the "Short Contact Us" form via "The UK -> Great.gov.uk account and services support -> Other"
     Given "Robert" got to the "Export Readiness - Great.gov.uk account and services support" page via "The UK -> Great.gov.uk account and services support"
@@ -118,7 +121,9 @@ Feature:  new contact us forms
 
 
   @TT-758
-  @account_support
+  @short_domestic
+  @greatgovuk_account
+  @support
   Scenario: Domestic enquirers should be able to get to the "Short Contact Us" form via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk -> Other"
     Given "Robert" got to the "Export Readiness - Great.gov.uk account" page via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk"
 

--- a/tests/browser/features/exred/new-contact-us.feature
+++ b/tests/browser/features/exred/new-contact-us.feature
@@ -326,7 +326,25 @@ Feature:  new contact us forms
       | selected option                         | appropriate                                                  | expected recipient |
       | Events                                  | Thank you for your Events enquiry                            | Events mailbox     |
       | Defence and Security Organisation (DSO) | Thank you for your Defence and Security Organisation enquiry | DSO mailbox        |
-      | Other                                   | Thank you for your enquiry                                   | DIT Enquiry unit   |
+
+
+  @TT-758
+  @dev-only
+  @captcha
+  @short_form
+  Scenario Outline: Exporters should be able to contact "<expected recipient>" using "Short contact form (<selected option>)" page accessed via "The UK -> <selected option>"
+    Given "Robert" got to the "Export Readiness - Short contact form (<selected option>)" page via "The UK -> <selected option>"
+
+    When "Robert" fills out and submits the form
+
+    Then "Robert" should be on the "Export Readiness - Thank you for your enquiry (<selected option>) - Short Domestic Contact us" page
+    And "Robert" should receive a "<appropriate>" confirmation email from Zendesk
+    # TODO check if email is sent to dedicated mailbox
+#    And an email is submitted to "<expected recipient>"
+
+    Examples:
+      | selected option | appropriate               | expected recipient |
+      | Other           | great.gov.uk contact form | DIT Enquiry unit   |
 
 
   @TT-758

--- a/tests/browser/features/exred/new-contact-us.feature
+++ b/tests/browser/features/exred/new-contact-us.feature
@@ -89,7 +89,6 @@ Feature:  new contact us forms
       | radio elements                                              |
       | I haven't had a response from the opportunity I applied for |
       | My daily alerts are not relevant to me                      |
-      | I need more details about the opportunity                   |
       | Other                                                       |
 
 

--- a/tests/browser/features/exred/new-contact-us.feature
+++ b/tests/browser/features/exred/new-contact-us.feature
@@ -180,7 +180,7 @@ Feature:  new contact us forms
     And "Robert" fills out and submits the form
 
     Then "Robert" should be on the "Export Readiness - Thank you for your enquiry (<selected topic>)" page
-    And "Robert" should receive a "Great.gov.uk contact form" confirmation email from Zendesk
+    And "Robert" should receive a "great.gov.uk contact form" confirmation email from Zendesk
 
     Examples:
       | selected topic                                                 |
@@ -209,7 +209,7 @@ Feature:  new contact us forms
     And "Robert" fills out and submits the form
 
     Then "Robert" should be on the "Export Readiness - Thank you for your enquiry (<selected topic>) - Short Domestic Contact us" page
-    And "Robert" should receive a "Great.gov.uk contact form" confirmation email from Zendesk
+    And "Robert" should receive a "great.gov.uk contact form" confirmation email from Zendesk
 
     Examples:
       | selected topic                                              |
@@ -230,7 +230,7 @@ Feature:  new contact us forms
     When "Robert" fills out and submits the form
 
     Then "Robert" should be on the "Export Readiness - Thank you for your enquiry (<selected topic>) - Short Domestic Contact us" page
-    And "Robert" should receive a "Great.gov.uk contact form" confirmation email from Zendesk
+    And "Robert" should receive a "great.gov.uk contact form" confirmation email from Zendesk
 
     Examples:
       | selected topic |

--- a/tests/browser/features/exred/new-contact-us.feature
+++ b/tests/browser/features/exred/new-contact-us.feature
@@ -128,15 +128,14 @@ Feature:  new contact us forms
     Then "Robert" should be on the "Export Readiness - Short contact form (Tell us how we can help)" page
 
 
-  # define PO with names for all support pages
-  @wip
+  @TT-758
   @account_support
   Scenario: Domestic enquirers should be able to find answers to sought topic about "Great.gov.uk account"
     Given "Robert" got to the "Export Readiness - Great.gov.uk account" page via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk"
 
-    When "Robert" checks any available option except "Other"
+    When "Robert" chooses any available option except "Other"
 
-    Then "Robert" should be on the "Export Readiness - Dedicated Support Content" page
+    Then "Robert" should be on the "Export Readiness - Great.gov.uk account - Dedicated Support Content" page
 
 
   # there's no "finish & close" option on the support pages
@@ -145,7 +144,7 @@ Feature:  new contact us forms
   Scenario: Domestic enquirers should be able to return to the Home page after they found find answers to sought topic about "Great.gov.uk account"
     Given "Robert" got to the "Export Readiness - Great.gov.uk account" page via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk"
 
-    When "Robert" checks any available option except "Other"
+    When "Robert" chooses any available option except "Other"
     And "Robert" decides to "finish & close"
 
     Then "Robert" should be on the "Export Readiness - Home" page
@@ -207,15 +206,14 @@ Feature:  new contact us forms
       | Other                                                       |
 
 
-  # define PO with names for all support pages
-  @wip
+  @TT-758
   @export_opportunities
-  Scenario: Exporters should be to contact Export Opportunities team via Zendesk using "Short contact form (Tell us how we can help)" page accessed via "The UK -> Great.gov.uk account and services support -> Export opportunities service -> <selected topic>"
+  Scenario: Exporters should be able to find answers to "My daily alerts are not relevant to me" topic
     Given "Robert" got to the "Export Readiness - Export opportunities service" page via "The UK -> Great.gov.uk account and services support -> Export opportunities service"
 
     When "Robert" chooses "My daily alerts are not relevant to me" option
 
-    Then "Robert" should be on the "Export Readiness - My daily alerts are not relevant to me - Support" page
+    Then "Robert" should be on the "Export Readiness - My daily alerts are not relevant to me - Dedicated Support Content" page
 
 
   @TT-758

--- a/tests/browser/features/exred/new-contact-us.feature
+++ b/tests/browser/features/exred/new-contact-us.feature
@@ -56,16 +56,22 @@ Feature:  new contact us forms
     Then "Robert" should be on the "Export Readiness - Long (Export Advice Comment) - Contact us" page
 
 
-  @wip
+  @TT-758
   @ita
   @exporting_from_the_UK
   Scenario: Domestic Enquirers should be able to contact relevant ITA based on the postcode provided
     Given "Robert" got to the "Export Readiness - Long (Export Advice Comment)" page via "The UK -> Advice to export from the UK"
 
     When "Robert" fills out and submits the form
+    Then "Robert" should be on the "Export Readiness - Long (Personal details) - Contact us" page
+    When "Robert" fills out and submits the form
+    Then "Robert" should be on the "Export Readiness - Long (Business details) - Contact us" page
+    When "Robert" fills out and submits the form
 
-    Then "Robert" should be on the "Thank you for your enquiry" page
-    And an email is submitted to relevant "ITA" (based on the postcode provided)
+    Then "Robert" should be on the "Export Readiness - Thank you for your enquiry" page
+    And "Robert" should receive "Thank you for your enquiry" confirmation email
+    # TODO check if this email is being actually sent
+#    And an email is submitted to relevant "ITA" (based on the postcode provided)
 
 
   @TT-758
@@ -248,6 +254,7 @@ Feature:  new contact us forms
     When "Robert" fills out and submits the form
 
     Then "Robert" should be on the "Export Readiness - Thank you - UKEF Contact us" page
+    # No confirmation email is sent to the user
     # TODO check if email is sent to dedicated mailbox
     And an email is submitted to "UKEF mailbox"
 

--- a/tests/browser/features/exred/new-contact-us.feature
+++ b/tests/browser/features/exred/new-contact-us.feature
@@ -357,7 +357,7 @@ Feature:  new contact us forms
     Examples:
       | selected            | expected                                                   |
       | Investing in the UK | Invest - Contact us                                        |
-      | Buying from the UK  | Export Readiness - Short contact form (Buying from the UK) |
+      | Buying from the UK  | Find a Supplier - Contact us                               |
 #      | EU Exit             | Export Readiness - International EU Exit - Contact Us      |
       | Other               | Export Readiness - International Contact us                |
 

--- a/tests/browser/features/exred/new-contact-us.feature
+++ b/tests/browser/features/exred/new-contact-us.feature
@@ -1,0 +1,378 @@
+@new_contact_us
+Feature:  new contact us forms
+
+  @TT-758
+  @enquirer_location
+  Scenario: Enquirers should see all expected contact location options on the "Export Readiness - Contact us"
+    Given "Robert" visits the "Export Readiness - Contact us" page
+
+    Then "Robert" should be on the "Export Readiness - Contact us" page
+    And "Robert" should see following form choices
+      | radio elements |
+      | The UK         |
+      | Outside the UK |
+
+
+  @TT-758
+  @enquirer_location
+  @domestic_enquiry_page
+  Scenario: Domestic Enquirers should see all expected contact options on the "Domestic - What can we help you with?" page
+    Given "Robert" visits the "Export Readiness - Contact us" page
+
+    When "Robert" says that his business is in "The UK"
+
+    Then "Robert" should be on the "Export Readiness - What can we help you with? - Domestic Contact us" page
+    And "Robert" should see following form choices
+      | radio elements                            |
+      | Find your local trade office              |
+      | Advice to export from the UK              |
+      | Great.gov.uk account and services support |
+      | UK Export Finance (UKEF)                  |
+      | EU Exit                                   |
+      | Events                                    |
+      | Defence and Security Organisation (DSO)   |
+      | Other                                     |
+
+
+  @TT-758
+  @office_finder
+  Scenario: Domestic Enquirers should be able to get to the "Existing Office finder - Home" page
+    Given "Robert" visits the "Export Readiness - Contact us" page
+
+    When "Robert" says that his business is in "the UK"
+    And "Robert" chooses "Find your local trade office" option
+
+    Then "Robert" should be on the "EXISTING Office finder - Home" page
+
+
+  @TT-758
+  @exporting_from_the_UK
+  Scenario: Domestic Enquirers should be able to get to the "Long (Export Advice Comment) - Contact us" form
+    Given "Robert" visits the "Export Readiness - Contact us" page
+
+    When "Robert" says that his business is in "the UK"
+    And "Robert" chooses "Advice to export from the UK" option
+
+    Then "Robert" should be on the "Export Readiness - Long (Export Advice Comment) - Contact us" page
+
+
+  @wip
+  @ita
+  @exporting_from_the_UK
+  Scenario: Domestic Enquirers should be able to contact relevant ITA based on the postcode provided
+    Given "Robert" got to the "Export Readiness - Long (Export Advice Comment)" page via "The UK -> Advice to export from the UK"
+
+    When "Robert" fills out and submits the form
+
+    Then "Robert" should be on the "Thank you for your enquiry" page
+    And an email is submitted to relevant "ITA" (based on the postcode provided)
+
+
+  @TT-758
+  @account_support
+  Scenario: Domestic enquirers should see all expected help options on the "Great.gov.uk account and services support" page
+    Given "Robert" got to the "Export Readiness - Great.gov.uk account and services support" page via "The UK -> Great.gov.uk account and services support"
+
+    Then "Robert" should see following form choices
+      | radio elements               |
+      | Export opportunities service |
+      | Your account on Great.gov.uk |
+      | Other                        |
+
+
+  @TT-758
+  @account_support
+  Scenario: Domestic enquirers should see all expected help options for "Export opportunities service"
+    Given "Robert" got to the "Export Readiness - Export opportunities service" page via "The UK -> Great.gov.uk account and services support -> Export opportunities service"
+
+    Then "Robert" should see following form choices
+      | radio elements                                              |
+      | I haven't had a response from the opportunity I applied for |
+      | My daily alerts are not relevant to me                      |
+      | I need more details about the opportunity                   |
+      | Other                                                       |
+
+
+  @TT-758
+  @account_support
+  Scenario: Domestic enquirers should see all expected help options for "Great.gov.uk account"
+    Given "Robert" got to the "Export Readiness - Great.gov.uk account" page via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk"
+
+    Then "Robert" should see following form choices
+      | radio elements                                                 |
+      | I have not received an email confirmation                      |
+      | I need to reset my password                                    |
+      | My Companies House login is not working                        |
+      | I do not know where to enter my verification code              |
+      | I have not received my letter containing the verification code |
+      | Other                                                          |
+
+
+  @TT-758
+  @account_support
+  Scenario: Domestic enquirers should be able to get to the "Short Contact Us" form via "The UK -> Great.gov.uk account and services support -> Other"
+    Given "Robert" got to the "Export Readiness - Great.gov.uk account and services support" page via "The UK -> Great.gov.uk account and services support"
+
+    When "Robert" chooses "Other" option
+
+    Then "Robert" should be on the "Export Readiness - Short contact form (Tell us how we can help)" page
+
+
+  @TT-758
+  @account_support
+  Scenario: Domestic enquirers should be able to get to the "Short Contact Us" form via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk -> Other"
+    Given "Robert" got to the "Export Readiness - Great.gov.uk account" page via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk"
+
+    When "Robert" chooses "Other" option
+
+    Then "Robert" should be on the "Export Readiness - Short contact form (Tell us how we can help)" page
+
+
+  # define PO with names for all support pages
+  @wip
+  @account_support
+  Scenario: Domestic enquirers should be able to find answers to sought topic about "Great.gov.uk account"
+    Given "Robert" got to the "Export Readiness - Great.gov.uk account" page via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk"
+
+    When "Robert" checks any available option except "Other"
+
+    Then "Robert" should be on the "Export Readiness - Dedicated Support Content" page
+
+
+  # there's no "finish & close" option on the support pages
+  @wip
+  @account_support
+  Scenario: Domestic enquirers should be able to return to the Home page after they found find answers to sought topic about "Great.gov.uk account"
+    Given "Robert" got to the "Export Readiness - Great.gov.uk account" page via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk"
+
+    When "Robert" checks any available option except "Other"
+    And "Robert" decides to "finish & close"
+
+    Then "Robert" should be on the "Export Readiness - Home" page
+
+
+  @wip
+  @zendesk
+  @account_support
+  Scenario Outline: Domestic Enquirers should be able to contact Great Support team via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk -> <selected topic>"
+    Given "Robert" got to the "Export Readiness - Dedicated support content page for selected topic" page via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk -> <selected topic>"
+
+    When "Robert" decides to "Submit an enquiry"
+    And "Robert" fills out and submits the form
+
+    Then "Robert" should be on the "Thank you for your enquiry" page
+    And an email is submitted to "Zendesk"
+
+    Examples:
+      | selected topic                         |
+      | I have not received an email confirmation                      |
+      | I need to reset my password                                    |
+      | My Companies House login is not working                        |
+      | I do not know where to enter my verification code              |
+      | I have not received my letter containing the verification code |
+
+
+  # Choosing "Other" on the Your account on Great.gov.uk page takes us directly
+  # to the Short contact us form
+  @wip
+  @zendesk
+  @account_support
+  Scenario Outline: Domestic Enquirers should be able to contact Great Support team via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk -> <selected topic>"
+    Given "Robert" got to the "Export Readiness - Short contact form (Tell us how we can help)" page via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk -> <selected topic>"
+
+    When "Robert" fills out and submits the form
+
+    Then "Robert" should be on the "Thank you for your enquiry" page
+    And an email is submitted to "Zendesk"
+
+    Examples:
+      | selected topic |
+      | Other          |
+
+
+  @wip
+  @export_opportunities
+  Scenario Outline: Exporters should be to contact Export Opportunities team via Zendesk using "Short contact form (Tell us how we can help)" page accessed via "The UK -> Great.gov.uk account and services support -> Export opportunities service -> <selected topic>"
+    Given "Robert" got to the "Export Readiness - Short contact form (Tell us how we can help)" page via "The UK -> Great.gov.uk account and services support -> Export opportunities service -> <selected topic>"
+
+    When "Robert" fills out and submits the form
+
+    Then "Robert" should be on the "Thank you for your enquiry" page
+    And an email is submitted to "Zendesk"
+
+    Examples:
+      | selected topic |
+      | I haven't had a response from the opportunity I applied for |
+      | I need more details about the opportunity                   |
+      | Other                                                       |
+
+
+  # define PO with names for all support pages
+  @wip
+  @export_opportunities
+  Scenario: Exporters should be to contact Export Opportunities team via Zendesk using "Short contact form (Tell us how we can help)" page accessed via "The UK -> Great.gov.uk account and services support -> Export opportunities service -> <selected topic>"
+    Given "Robert" got to the "Export Readiness - Export opportunities service" page via "The UK -> Great.gov.uk account and services support -> Export opportunities service"
+
+    When "Robert" chooses "My daily alerts are not relevant to me" option
+
+    Then "Robert" should be on the "Export Readiness - My daily alerts are not relevant to me - Support" page
+
+
+  @TT-758
+  @ukef
+  Scenario: Exporters should be able to get to the UKEF Check your eligibility contact-us form
+    Given "Robert" got to the "Export Readiness - What can we help you with? - Domestic Contact us" page via "The UK"
+
+    When "Robert" chooses "UK Export Finance (UKEF)" option
+
+    Then "Robert" should be on the "Export Readiness - What would you like to know more about? - UKEF Contact us" page
+
+
+  # already partially covered by stories for TT-585
+  @wip
+  @ukef
+  Scenario: Exporters should be able to contact UKEF mailbox
+    Given "Robert" got to the "Export Readiness - What would you like to know more about? - UKEF Contact us" page via "The UK -> UK Export Finance (UKEF)"
+
+    When "Robert" fills out and submits the form
+
+    Then "Robert" should be on the "Export Readiness - Thank you - UKEF Contact us" page
+    And an email is submitted to "UKEF mailbox"
+
+
+  @TT-758
+  @investing_overseas
+  @events
+  @dso
+  @short_form
+  Scenario Outline: Domestic enquirers should get to the "Short contact us form" via "The UK -> <selected option>"
+    Given "Robert" got to the "Export Readiness - What can we help you with? - Domestic Contact us" page via "The UK"
+
+    When "Robert" chooses "<selected option>" option
+
+    Then "Robert" should be on the "Export Readiness - Short contact form (<selected option>)" page
+
+    Examples:
+      | selected option                         |
+      | Events                                  |
+      | Defence and Security Organisation (DSO) |
+      | Other                                   |
+
+
+  @TT-758
+  @CMS-506
+  @eu_exit
+  @work_in_progress
+  @feature_flagged
+  Scenario: Exporters should be able to get to the "Domestic EU Exit short contact-us form"
+    Given "Robert" got to the "Export Readiness - What can we help you with? - Domestic Contact us" page via "The UK"
+
+    When "Robert" chooses "EU Exit" option
+
+    Then "Robert" should be on the "Export Readiness - Domestic EU Exit contact form" page
+
+
+  # partially covered by CMS-506
+  @wip
+  @eu_exit
+  @work_in_progress
+  @feature_flagged
+  Scenario: Exporters should be able to contact "EU Exit mailbox"
+    Given "Robert" got to the "Domestic EU Exit contact-us form" page via EU exit option
+
+    When "Robert" fills out and submits the form
+
+    Then "Robert" should be on the "Thank you for your enquiry" page
+    And an email is submitted to "Zendesk for the attention of EU Exit team"
+
+
+  @wip
+  @short_form
+  Scenario Outline: Exporters should be able to contact "<expected recipient>"  using "Short contact form (<selected option>)" page accessed via "The UK -> <selected option>"
+    Given "Robert" got to the "Export Readiness - Short contact form (<selected option>)" page via "The UK -> <selected option>"
+
+    When "Robert" fills out and submits the form
+
+    Then "Robert" should be on the "Thank you for your enquiry" page
+    And an email is submitted to "<expected recipient>"
+
+    Examples:
+      | selected option                         | expected recipient |
+      | Events                                  | Events mailbox     |
+      | Defence and Security Organisation (DSO) | DSO mailbox        |
+      | Other                                   | DIT Enquiry unit   |
+
+
+  @TT-758
+  @international
+  Scenario: International Enquirers should be able to see all expected contact options on the "International - What would you like to know more about?" page
+    Given "Robert" visits the "Export Readiness - Contact us" page
+
+    When "Robert" says that his business is "Outside the UK"
+
+    Then "Robert" should be on the "Export Readiness - What would you like to know more about? - International Contact us" page
+    And "Robert" should see following form choices
+      | radio elements                    |
+      | Investing in the UK               |
+      | Buying from the UK                |
+      | EU Exit                           |
+      | Other                             |
+
+
+  @TT-758
+  @international
+  Scenario Outline: International Enquirers should be able to get to the "<expected>" form for "<selected>"
+    Given "Robert" got to the "Export Readiness - What would you like to know more about? - International Contact us" page via "Outside the UK"
+
+    When "Robert" chooses "<selected>" option
+
+    Then "Robert" should be on the "<expected>" page
+
+    Examples:
+      | selected            | expected                                                   |
+      | Investing in the UK | Invest - Contact us                                        |
+      | Buying from the UK  | Export Readiness - Short contact form (Buying from the UK) |
+      | EU Exit             | Export Readiness - International EU Exit - Contact Us      |
+      | Other               | Export Readiness - International Contact us                |
+
+
+###### These scenarios will be implemented when v2 is ready
+
+  @wip
+  @v2_or_v1_if_we_have_time
+  @office_finder
+  Scenario: Domestic Enquirers should be able to get to the NEW Office finder page
+    Given "Robert" visits the "Export Readiness - Contact us" page
+
+    When "Robert" says that his business is in "the UK"
+    And "Robert" decides to "Find your local trade office"
+
+    Then "Robert" should be on the "NEW Office finder" page
+
+
+  @wip
+  @v2_or_v1_if_we_have_time
+  @office_finder
+  Scenario: Domestic Enquirers should be able to get to the NEW Office finder page
+    Given "Robert" visits the "Export Readiness - Contact us" page
+
+    When "Robert" says that his business is in "the UK"
+    And "Robert" decides to "Find local trade office"
+    And "Robert" found his local trade office by providing his company's postcode
+    And "Robert" decides to "Contact the local trade office"
+
+    Then "Robert" should be on the "Short contact us form" page
+
+
+  @wip
+  @captcha
+  @dev-only
+  @v2_or_v1_if_we_have_time
+  @office_finder
+  Scenario: Domestic Enquirers should be able to contact
+    Given "Robert" got to the "Short contact-us form" page via "Find local trade office"
+
+    When "Robert" fills out and submits the form
+
+    Then "Robert" should be on the "Thank you for your enquiry" page
+    And an email is submitted to "appropriate local office based on the postcode provided"

--- a/tests/browser/features/exred/new-contact-us.feature
+++ b/tests/browser/features/exred/new-contact-us.feature
@@ -142,16 +142,8 @@ Feature:  new contact us forms
     Then "Robert" should be on the "Export Readiness - Great.gov.uk account - Dedicated Support Content" page
 
 
-  # there's no "finish & close" option on the support pages
-  @wip
-  @account_support
-  Scenario: Domestic enquirers should be able to return to the Home page after they found find answers to sought topic about "Great.gov.uk account"
-    Given "Robert" got to the "Export Readiness - Great.gov.uk account" page via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk"
 
-    When "Robert" chooses any available option except "Other"
-    And "Robert" decides to "finish & close"
 
-    Then "Robert" should be on the "Export Readiness - Home" page
 
 
   @wip
@@ -341,7 +333,37 @@ Feature:  new contact us forms
       | Other               | Export Readiness - International Contact us                |
 
 
+  @TT-758
+  @going_back
+  Scenario Outline: Enquirers should be able to navigate back to previous pages
+    Given "Robert" navigates via "<path>"
+
+    When "Robert" decides to use "back" link
+
+    Then "Robert" should be on the "<expected>" page
+
+    Examples:
+      | path                                                                                | expected                                                            |
+      | The UK                                                                              | Export Readiness - Contact us                                       |
+      | Outside the UK                                                                      | Export Readiness - Contact us                                       |
+      | The UK -> Great.gov.uk account and services support                                 | Export Readiness - What can we help you with? - Domestic Contact us |
+      | The UK -> Great.gov.uk account and services support -> Export opportunities service | Export Readiness - Great.gov.uk account and services support        |
+      | The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk | Export Readiness - Great.gov.uk account and services support        |
+
+
 ###### These scenarios will be implemented when v2 is ready
+
+  # there's no "finish & close" option on the support pages
+  @wip
+  @account_support
+  Scenario: Domestic enquirers should be able to return to the Home page after they found find answers to sought topic about "Great.gov.uk account"
+    Given "Robert" got to the "Export Readiness - Great.gov.uk account" page via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk"
+
+    When "Robert" chooses any available option except "Other"
+    And "Robert" decides to "finish & close"
+
+    Then "Robert" should be on the "Export Readiness - Home" page
+
 
   @wip
   @v2_or_v1_if_we_have_time

--- a/tests/browser/features/exred/new-contact-us.feature
+++ b/tests/browser/features/exred/new-contact-us.feature
@@ -284,21 +284,24 @@ Feature:  new contact us forms
     And "Robert" should receive an "Thank you for your EU exit enquiry" confirmation email
 
 
-  @wip
+  @TT-758
+  @dev-only
+  @captcha
   @short_form
-  Scenario Outline: Exporters should be able to contact "<expected recipient>"  using "Short contact form (<selected option>)" page accessed via "The UK -> <selected option>"
+  Scenario Outline: Exporters should be able to contact "<expected recipient>" using "Short contact form (<selected option>)" page accessed via "The UK -> <selected option>"
     Given "Robert" got to the "Export Readiness - Short contact form (<selected option>)" page via "The UK -> <selected option>"
 
     When "Robert" fills out and submits the form
 
-    Then "Robert" should be on the "Thank you for your enquiry" page
-    And an email is submitted to "<expected recipient>"
+    Then "Robert" should be on the "Export Readiness - Thank you for your enquiry (<selected option>) - Short Domestic Contact us" page
+    And "Robert" should receive an "<appropriate>" confirmation email
+#    And an email is submitted to "<expected recipient>"
 
     Examples:
-      | selected option                         | expected recipient |
-      | Events                                  | Events mailbox     |
-      | Defence and Security Organisation (DSO) | DSO mailbox        |
-      | Other                                   | DIT Enquiry unit   |
+      | selected option                         | appropriate                                                  | expected recipient |
+      | Events                                  | Thank you for your Events enquiry                            | Events mailbox     |
+      | Defence and Security Organisation (DSO) | Thank you for your Defence and Security Organisation enquiry | DSO mailbox        |
+      | Other                                   | Thank you for your enquiry                                   | DIT Enquiry unit   |
 
 
   @TT-758

--- a/tests/browser/features/exred/new-contact-us.feature
+++ b/tests/browser/features/exred/new-contact-us.feature
@@ -28,7 +28,7 @@ Feature:  new contact us forms
       | Advice to export from the UK              |
       | Great.gov.uk account and services support |
       | UK Export Finance (UKEF)                  |
-      | EU Exit                                   |
+#      | EU Exit                                   |
       | Events                                    |
       | Defence and Security Organisation (DSO)   |
       | Other                                     |
@@ -338,7 +338,7 @@ Feature:  new contact us forms
       | radio elements                    |
       | Investing in the UK               |
       | Buying from the UK                |
-      | EU Exit                           |
+#      | EU Exit                           |
       | Other                             |
 
 
@@ -355,7 +355,7 @@ Feature:  new contact us forms
       | selected            | expected                                                   |
       | Investing in the UK | Invest - Contact us                                        |
       | Buying from the UK  | Export Readiness - Short contact form (Buying from the UK) |
-      | EU Exit             | Export Readiness - International EU Exit - Contact Us      |
+#      | EU Exit             | Export Readiness - International EU Exit - Contact Us      |
       | Other               | Export Readiness - International Contact us                |
 
 

--- a/tests/browser/features/exred/new-contact-us.feature
+++ b/tests/browser/features/exred/new-contact-us.feature
@@ -231,6 +231,7 @@ Feature:  new contact us forms
     When "Robert" fills out and submits the form
 
     Then "Robert" should be on the "Export Readiness - Thank you - UKEF Contact us" page
+    # TODO check if email is sent to dedicated mailbox
     And an email is submitted to "UKEF mailbox"
 
 
@@ -277,7 +278,7 @@ Feature:  new contact us forms
     When "Robert" fills out and submits the form
 
     Then "Robert" should be on the "Export Readiness - Thank you for your enquiry - Domestic EU Exit Contact us" page
-    And "Robert" should receive an "Thank you for your EU exit enquiry" confirmation email
+    And "Robert" should receive "Thank you for your EU exit enquiry" confirmation email
 
 
   @TT-758
@@ -290,7 +291,8 @@ Feature:  new contact us forms
     When "Robert" fills out and submits the form
 
     Then "Robert" should be on the "Export Readiness - Thank you for your enquiry (<selected option>) - Short Domestic Contact us" page
-    And "Robert" should receive an "<appropriate>" confirmation email
+    And "Robert" should receive "<appropriate>" confirmation email
+    # TODO check if email is sent to dedicated mailbox
 #    And an email is submitted to "<expected recipient>"
 
     Examples:

--- a/tests/browser/features/exred/new-contact-us.feature
+++ b/tests/browser/features/exred/new-contact-us.feature
@@ -133,8 +133,9 @@ Feature:  new contact us forms
 
 
   @TT-758
-  @account_support
-  Scenario: Domestic enquirers should be able to find answers to sought topic about "Great.gov.uk account"
+  @greatgovuk_account
+  @support
+  Scenario: Domestic enquirers should be able to find answers to sought topic about "Your account on Great.gov.uk"
     Given "Robert" got to the "Export Readiness - Great.gov.uk account" page via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk"
 
     When "Robert" chooses any available option except "Other"
@@ -142,24 +143,44 @@ Feature:  new contact us forms
     Then "Robert" should be on the "Export Readiness - Great.gov.uk account - Dedicated Support Content" page
 
 
+  @TT-758
+  @export_opportunities
+  @support
+  Scenario Outline: Exporters should be able to find answers to Export Opportunities related topic "<selected>"
+    Given "Robert" got to the "Export Readiness - Export opportunities service" page via "The UK -> Great.gov.uk account and services support -> Export opportunities service"
 
+    When "Robert" chooses "<selected>" option
 
-
-
-  @wip
-  @zendesk
-  @account_support
-  Scenario Outline: Domestic Enquirers should be able to contact Great Support team via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk -> <selected topic>"
-    Given "Robert" got to the "Export Readiness - Dedicated support content page for selected topic" page via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk -> <selected topic>"
-
-    When "Robert" decides to "Submit an enquiry"
-    And "Robert" fills out and submits the form
-
-    Then "Robert" should be on the "Thank you for your enquiry" page
-    And an email is submitted to "Zendesk"
+    Then "Robert" should be on the "Export Readiness - <selected> - Dedicated Support Content" page
 
     Examples:
-      | selected topic                         |
+      | selected                                                    |
+      | I haven't had a response from the opportunity I applied for |
+      | My daily alerts are not relevant to me                      |
+
+
+  @TT-758
+  @zendesk
+  @dev-only
+  @captcha
+  @account_support
+  Scenario Outline: Domestic Enquirers should be able to contact Great Support team via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk -> <selected topic>"
+    Given "Robert" got to the "Export Readiness - <selected topic> - Dedicated Support Content" page via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk -> <selected topic>"
+
+    When "Robert" decides to "Submit an enquiry"
+    And "Robert" is on the "Export Readiness - Short contact form (Tell us how we can help)" page
+    And "Robert" fills out and submits the form
+
+    Then "Robert" should be on the "Export Readiness - Thank you for your enquiry (<selected topic>)" page
+    And "Robert" should receive a "Great.gov.uk contact form" confirmation email from Zendesk
+
+    Examples:
+      | selected topic                                                 |
+      | I have not received an email confirmation                      |
+
+    @full
+    Examples:
+      | selected topic                                                 |
       | I have not received an email confirmation                      |
       | I need to reset my password                                    |
       | My Companies House login is not working                        |
@@ -167,49 +188,45 @@ Feature:  new contact us forms
       | I have not received my letter containing the verification code |
 
 
-  # Choosing "Other" on the Your account on Great.gov.uk page takes us directly
-  # to the Short contact us form
-  @wip
+  @TT-758
   @zendesk
+  @dev-only
+  @captcha
+  @export_opportunities
+  Scenario Outline: Exporters should be to contact Export Opportunities team via Zendesk using "Short contact form" page accessed via "The UK -> Great.gov.uk account and services support -> Export opportunities service -> <selected topic>"
+    Given "Robert" got to the "Export Readiness - <selected topic> - Dedicated Support Content" page via "The UK -> Great.gov.uk account and services support -> Export opportunities service -> <selected topic>"
+
+    When "Robert" decides to "Submit an enquiry"
+    And "Robert" is on the "Export Readiness - Short contact form (Tell us how we can help)" page
+    And "Robert" fills out and submits the form
+
+    Then "Robert" should be on the "Export Readiness - Thank you for your enquiry (<selected topic>) - Short Domestic Contact us" page
+    And "Robert" should receive a "Great.gov.uk contact form" confirmation email from Zendesk
+
+    Examples:
+      | selected topic                                              |
+      | I haven't had a response from the opportunity I applied for |
+      | My daily alerts are not relevant to me                      |
+
+
+  # Choosing "Other" on the "Your account on Great.gov.uk" page takes us
+  # directly to the short contact us form
+  @TT-758
+  @zendesk
+  @dev-only
+  @captcha
   @account_support
   Scenario Outline: Domestic Enquirers should be able to contact Great Support team via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk -> <selected topic>"
     Given "Robert" got to the "Export Readiness - Short contact form (Tell us how we can help)" page via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk -> <selected topic>"
 
     When "Robert" fills out and submits the form
 
-    Then "Robert" should be on the "Thank you for your enquiry" page
-    And an email is submitted to "Zendesk"
+    Then "Robert" should be on the "Export Readiness - Thank you for your enquiry (<selected topic>) - Short Domestic Contact us" page
+    And "Robert" should receive a "Great.gov.uk contact form" confirmation email from Zendesk
 
     Examples:
       | selected topic |
       | Other          |
-
-
-  @wip
-  @export_opportunities
-  Scenario Outline: Exporters should be to contact Export Opportunities team via Zendesk using "Short contact form (Tell us how we can help)" page accessed via "The UK -> Great.gov.uk account and services support -> Export opportunities service -> <selected topic>"
-    Given "Robert" got to the "Export Readiness - Short contact form (Tell us how we can help)" page via "The UK -> Great.gov.uk account and services support -> Export opportunities service -> <selected topic>"
-
-    When "Robert" fills out and submits the form
-
-    Then "Robert" should be on the "Thank you for your enquiry" page
-    And an email is submitted to "Zendesk"
-
-    Examples:
-      | selected topic |
-      | I haven't had a response from the opportunity I applied for |
-      | I need more details about the opportunity                   |
-      | Other                                                       |
-
-
-  @TT-758
-  @export_opportunities
-  Scenario: Exporters should be able to find answers to "My daily alerts are not relevant to me" topic
-    Given "Robert" got to the "Export Readiness - Export opportunities service" page via "The UK -> Great.gov.uk account and services support -> Export opportunities service"
-
-    When "Robert" chooses "My daily alerts are not relevant to me" option
-
-    Then "Robert" should be on the "Export Readiness - My daily alerts are not relevant to me - Dedicated Support Content" page
 
 
   @TT-758

--- a/tests/browser/features/exred/news-domestic.feature
+++ b/tests/browser/features/exred/news-domestic.feature
@@ -1,4 +1,5 @@
 @news
+@eu-exit
 @domestic
 Feature: Updates for UK companies on EU Exit
 

--- a/tests/browser/features/exred/news-international.feature
+++ b/tests/browser/features/exred/news-international.feature
@@ -1,4 +1,5 @@
 @news
+@eu-exit
 @international
 Feature: Updates for non-UK companies on EU Exit
 

--- a/tests/browser/pages/__init__.py
+++ b/tests/browser/pages/__init__.py
@@ -139,22 +139,22 @@ def get_page_object(service_and_page: str) -> ModuleType:
         matched_name = False
 
         if sought_service.lower() == page_object.service.lower():
-            logging.debug(f"matched service {sought_service}: {page_object.service}")
+            logging.debug(f"PO search: matched service '{sought_service}'")
             matched_service = True
         else:
             continue
 
         # try to find a match based on the PO.NAME
         if sought_page.lower() == page_object.name.lower():
-            logging.debug(f"matched page name {sought_page}: {page_object.name}")
+            logging.debug(f"PO search: matched name '{sought_page}'")
             matched_name = True
         else:
             # if that doesn't work, then try to do a check PO.NAMES
             if hasattr(page_object.value, "NAMES"):
                 names = page_object.value.NAMES
                 if sought_page.lower() in [name.lower() for name in names]:
-                    logging.debug(f"matched page name {sought_page}: "
-                          f"{page_object.value.NAMES}")
+                    logging.debug(
+                        f"PO search: matched one of names '{sought_page}'")
                     matched_name = True
                 else:
                     continue
@@ -163,7 +163,7 @@ def get_page_object(service_and_page: str) -> ModuleType:
 
         if sought_type:
             if sought_type.lower() == page_object.type.lower():
-                logging.debug(f"matched page type {sought_type}: {page_object.type}")
+                logging.debug(f"PO search: matched type '{sought_type}'")
                 matched_type = True
             else:
                 continue
@@ -189,5 +189,5 @@ def get_page_object(service_and_page: str) -> ModuleType:
             f"'{sought_service}' package. Here's a list of available Page "
             f"Objects: {keys}"
         )
-    logging.debug(f"Found PO for: {service_and_page} → {result}")
+    logging.debug(f"PO search: found 1 PO for: {service_and_page} → {result}")
     return result

--- a/tests/browser/pages/common_actions.py
+++ b/tests/browser/pages/common_actions.py
@@ -916,6 +916,20 @@ def choose_one_form_option(
     check_radio(driver, radio_selectors, form_details)
 
 
+def choose_one_form_option_except(
+        driver: WebDriver, radio_selectors: Dict[str, Selector],
+        ignored: List[str]) -> str:
+    all_keys = list(radio_selectors.keys())
+    without_ignored = list(set(all_keys) - set(ignored))
+    selected = random.choice(without_ignored)
+    form_details = defaultdict(bool)
+    for key in radio_selectors.keys():
+        form_details[key] = (key == selected)
+    logging.debug(f"Form details (with ignored: {ignored}): {form_details}")
+    check_radio(driver, radio_selectors, form_details)
+    return selected
+
+
 def tick_checkboxes(
         driver: WebDriver, form_selectors: Dict[str, Selector],
         form_details: dict):

--- a/tests/browser/pages/common_actions.py
+++ b/tests/browser/pages/common_actions.py
@@ -11,6 +11,7 @@ import string
 import sys
 import traceback
 import uuid
+from collections import defaultdict
 from collections.__init__ import namedtuple
 from contextlib import contextmanager
 from datetime import datetime
@@ -890,6 +891,29 @@ def pick_option_from_autosuggestion(
             option_value_selector = "option[value='{}']".format(option)
             option_element = select.find_element_by_css_selector(option_value_selector)
             option_element.click()
+
+
+def check_radio(
+        driver: WebDriver, form_selectors: Dict[str, Selector],
+        form_details: dict):
+    radio_selectors = get_selectors(form_selectors, ElementType.RADIO)
+    for key, selector in radio_selectors.items():
+        assert key in form_details, f"Can't find form detail for '{key}'"
+        if form_details[key]:
+            radio = find_element(
+                driver, selector, element_name=key, wait_for_it=False)
+            if not radio.get_property("checked"):
+                logging.debug(f"Checking '{key}' radio")
+                radio.click()
+
+
+def choose_one_form_option(
+        driver: WebDriver, radio_selectors: Dict[str, Selector], name: str):
+    form_details = defaultdict(bool)
+    for key in radio_selectors.keys():
+        form_details[key] = (key == name.lower())
+    logging.debug(f"Form details: {form_details}")
+    check_radio(driver, radio_selectors, form_details)
 
 
 def tick_checkboxes(

--- a/tests/browser/pages/common_actions.py
+++ b/tests/browser/pages/common_actions.py
@@ -924,7 +924,7 @@ def choose_one_form_option_except(
     selected = random.choice(without_ignored)
     form_details = defaultdict(bool)
     for key in radio_selectors.keys():
-        form_details[key] = (key == selected)
+        form_details[key.lower()] = (key.lower() == selected)
     logging.debug(f"Form details (with ignored: {ignored}): {form_details}")
     check_radio(driver, radio_selectors, form_details)
     return selected

--- a/tests/browser/pages/exread/contact_us_long_export_advice_business.py
+++ b/tests/browser/pages/exread/contact_us_long_export_advice_business.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+"""Export Readiness - First page of Long Contact us form"""
+import logging
+import random
+from types import ModuleType
+from urllib.parse import urljoin
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from pages import ElementType
+from pages.common_actions import (
+    Actor,
+    Selector,
+    check_radio,
+    check_url,
+    fill_out_input_fields,
+    find_element,
+    go_to_url,
+    pick_option,
+    take_screenshot,
+    tick_captcha_checkbox,
+    tick_checkboxes,
+)
+from pages.exread import contact_us_short_domestic_thank_you
+from settings import EXRED_UI_URL
+
+NAME = "Long (Business details)"
+SERVICE = "Export Readiness"
+TYPE = "Contact us"
+URL = urljoin(EXRED_UI_URL, "contact/export-advice/business/")
+PAGE_TITLE = "Welcome to great.gov.uk"
+
+SUBMIT_BUTTON = Selector(
+    By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON
+)
+SELECTORS = {
+    "form": {
+        "itself": Selector(By.CSS_SELECTOR, "#lede form"),
+        "uk private or public limited company": Selector(
+            By.ID, "id_business-company_type_0", type=ElementType.RADIO
+        ),
+        "other type of uk organisation": Selector(
+            By.ID, "id_business-company_type_1", type=ElementType.RADIO
+        ),
+        "organisation name": Selector(
+            By.ID, "id_business-organisation_name", type=ElementType.INPUT
+        ),
+        "postcode": Selector(By.ID, "id_business-postcode", type=ElementType.INPUT),
+        "industry": Selector(By.ID, "id_business-industry", type=ElementType.SELECT),
+        "turnover": Selector(By.ID, "id_business-turnover", type=ElementType.SELECT),
+        "size": Selector(By.ID, "id_business-employees", type=ElementType.SELECT),
+        "terms and conditions": Selector(
+            By.ID, "id_business-terms_agreed", type=ElementType.CHECKBOX
+        ),
+    }
+}
+
+CH_NUMBER_SELECTORS = {
+    "ch number": Selector(
+        By.ID, "id_business-companies_house_number", type=ElementType.INPUT
+    )
+}
+OTHER_SELECTORS = {
+    "other": Selector(By.ID, "id_business-company_type_other", type=ElementType.SELECT)
+}
+
+
+def visit(driver: WebDriver, *, first_time: bool = False):
+    go_to_url(driver, URL, NAME, first_time=first_time)
+
+
+def should_be_here(driver: WebDriver):
+    take_screenshot(driver, NAME)
+    check_url(driver, URL)
+
+
+def generate_form_details(actor: Actor) -> dict:
+    is_company = random.choice([True, False])
+    result = {
+        "uk private or public limited company": is_company,
+        "other type of uk organisation": not is_company,
+        "organisation name": "automated tests",
+        "postcode": "DIT",
+        "industry": None,
+        "turnover": None,
+        "size": None,
+        "terms and conditions": True,
+    }
+    if is_company:
+        result.update({"ch number": "DIT"})
+        SELECTORS["form"].update(CH_NUMBER_SELECTORS)
+        # In order to avoid situation when previous scenario example modified
+        # SELECTORS we have to remove OTHER_SELECTORS that were then added
+        SELECTORS["form"] = dict(
+            set(SELECTORS["form"].items()) - set(OTHER_SELECTORS.items())
+        )
+    else:
+        SELECTORS["form"].update(OTHER_SELECTORS)
+        SELECTORS["form"] = dict(
+            set(SELECTORS["form"].items()) - set(CH_NUMBER_SELECTORS.items())
+        )
+
+    logging.debug(f"Generated form details: {result}")
+    return result
+
+
+def fill_out(driver: WebDriver, details: dict):
+    form_selectors = SELECTORS["form"]
+    check_radio(driver, form_selectors, details)
+    fill_out_input_fields(driver, form_selectors, details)
+    tick_checkboxes(driver, form_selectors, details)
+    pick_option(driver, form_selectors, details)
+    tick_captcha_checkbox(driver)
+    take_screenshot(driver, "After filling out the form")
+
+
+def submit(driver: WebDriver) -> ModuleType:
+    take_screenshot(driver, "Before submitting the form")
+    button = find_element(
+        driver, SUBMIT_BUTTON, element_name="Submit button", wait_for_it=False
+    )
+    button.click()
+    take_screenshot(driver, "After submitting the form")
+    return contact_us_short_domestic_thank_you

--- a/tests/browser/pages/exread/contact_us_long_export_advice_comment.py
+++ b/tests/browser/pages/exread/contact_us_long_export_advice_comment.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""Export Readiness - First page of Long Contact us form"""
+from types import ModuleType
+
+from urllib.parse import urljoin
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from pages import ElementType
+from pages.common_actions import (
+    Selector,
+    check_url,
+    find_element,
+    go_to_url,
+    take_screenshot,
+)
+from pages.exread import contact_us_triage_domestic
+from settings import EXRED_UI_URL
+
+NAME = "Long (Export Advice Comment)"
+SERVICE = "Export Readiness"
+TYPE = "Contact us"
+URL = urljoin(EXRED_UI_URL, "contact/export-advice/comment/")
+PAGE_TITLE = "Welcome to great.gov.uk"
+
+SUBMIT_BUTTON = Selector(By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON)
+SELECTORS = {
+    "form": {
+        "itself": Selector(By.CSS_SELECTOR, "#lede form"),
+        "comment": Selector(By.ID, "id_comment-comment", type=ElementType.TEXTAREA),
+        "submit": SUBMIT_BUTTON,
+    }
+}
+
+
+def visit(driver: WebDriver, *, first_time: bool = False):
+    go_to_url(driver, URL, NAME, first_time=first_time)
+
+
+def should_be_here(driver: WebDriver):
+    take_screenshot(driver, NAME)
+    check_url(driver, URL)
+
+
+def submit(driver: WebDriver) -> ModuleType:
+    take_screenshot(driver, "Before submitting the form")
+    button = find_element(
+        driver, SUBMIT_BUTTON, element_name="Submit button", wait_for_it=False
+    )
+    button.click()
+    take_screenshot(driver, "After submitting the form")
+    return contact_us_triage_domestic

--- a/tests/browser/pages/exread/contact_us_long_export_advice_comment.py
+++ b/tests/browser/pages/exread/contact_us_long_export_advice_comment.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Export Readiness - First page of Long Contact us form"""
 from types import ModuleType
-
 from urllib.parse import urljoin
 
 from selenium.webdriver.common.by import By
@@ -9,13 +8,15 @@ from selenium.webdriver.remote.webdriver import WebDriver
 
 from pages import ElementType
 from pages.common_actions import (
+    Actor,
     Selector,
     check_url,
+    fill_out_textarea_fields,
     find_element,
     go_to_url,
     take_screenshot,
 )
-from pages.exread import contact_us_triage_domestic
+from pages.exread import contact_us_long_export_advice_personal
 from settings import EXRED_UI_URL
 
 NAME = "Long (Export Advice Comment)"
@@ -24,7 +25,9 @@ TYPE = "Contact us"
 URL = urljoin(EXRED_UI_URL, "contact/export-advice/comment/")
 PAGE_TITLE = "Welcome to great.gov.uk"
 
-SUBMIT_BUTTON = Selector(By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON)
+SUBMIT_BUTTON = Selector(
+    By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON
+)
 SELECTORS = {
     "form": {
         "itself": Selector(By.CSS_SELECTOR, "#lede form"),
@@ -43,6 +46,17 @@ def should_be_here(driver: WebDriver):
     check_url(driver, URL)
 
 
+def generate_form_details(actor: Actor) -> dict:
+    result = {"comment": f"Submitted by automated test {actor.alias}"}
+    return result
+
+
+def fill_out(driver: WebDriver, details: dict):
+    form_selectors = SELECTORS["form"]
+    fill_out_textarea_fields(driver, form_selectors, details)
+    take_screenshot(driver, "After filling out the form")
+
+
 def submit(driver: WebDriver) -> ModuleType:
     take_screenshot(driver, "Before submitting the form")
     button = find_element(
@@ -50,4 +64,4 @@ def submit(driver: WebDriver) -> ModuleType:
     )
     button.click()
     take_screenshot(driver, "After submitting the form")
-    return contact_us_triage_domestic
+    return contact_us_long_export_advice_personal

--- a/tests/browser/pages/exread/contact_us_long_export_advice_personal.py
+++ b/tests/browser/pages/exread/contact_us_long_export_advice_personal.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""Export Readiness - First page of Long Contact us form"""
+from types import ModuleType
+from urllib.parse import urljoin
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from pages import ElementType
+from pages.common_actions import (
+    Actor,
+    Selector,
+    check_url,
+    fill_out_input_fields,
+    find_element,
+    go_to_url,
+    take_screenshot,
+)
+from pages.exread import contact_us_long_export_advice_business
+from settings import EXRED_UI_URL
+
+NAME = "Long (Personal details)"
+SERVICE = "Export Readiness"
+TYPE = "Contact us"
+URL = urljoin(EXRED_UI_URL, "contact/export-advice/personal/")
+PAGE_TITLE = "Welcome to great.gov.uk"
+
+SUBMIT_BUTTON = Selector(
+    By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON
+)
+SELECTORS = {
+    "form": {
+        "itself": Selector(By.CSS_SELECTOR, "#lede form"),
+        "first name": Selector(By.ID, "id_personal-first_name", type=ElementType.INPUT),
+        "last name": Selector(By.ID, "id_personal-last_name", type=ElementType.INPUT),
+        "position": Selector(By.ID, "id_personal-position", type=ElementType.INPUT),
+        "email": Selector(By.ID, "id_personal-email", type=ElementType.INPUT),
+        "phone": Selector(By.ID, "id_personal-phone", type=ElementType.INPUT),
+        "submit": SUBMIT_BUTTON,
+    }
+}
+
+
+def visit(driver: WebDriver, *, first_time: bool = False):
+    go_to_url(driver, URL, NAME, first_time=first_time)
+
+
+def should_be_here(driver: WebDriver):
+    take_screenshot(driver, NAME)
+    check_url(driver, URL)
+
+
+def generate_form_details(actor: Actor) -> dict:
+    result = {
+        "first name": f"send by {actor.alias} - automated tests",
+        "last name": actor.alias,
+        "position": "automated test",
+        "email": actor.email,
+        "phone": "automated tests",
+    }
+    return result
+
+
+def fill_out(driver: WebDriver, details: dict):
+    form_selectors = SELECTORS["form"]
+    fill_out_input_fields(driver, form_selectors, details)
+    take_screenshot(driver, "After filling out the form")
+
+
+def submit(driver: WebDriver) -> ModuleType:
+    take_screenshot(driver, "Before submitting the form")
+    button = find_element(
+        driver, SUBMIT_BUTTON, element_name="Submit button", wait_for_it=False
+    )
+    button.click()
+    take_screenshot(driver, "After submitting the form")
+    return contact_us_long_export_advice_business

--- a/tests/browser/pages/exread/contact_us_short_domestic.py
+++ b/tests/browser/pages/exread/contact_us_short_domestic.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-"""Export Readiness - First page of Long Contact us form"""
+"""Export Readiness - Sort Domestic Contact us form"""
+import logging
+import random
 from types import ModuleType
-
 from urllib.parse import urljoin
 
 from selenium.webdriver.common.by import By
@@ -9,11 +10,17 @@ from selenium.webdriver.remote.webdriver import WebDriver
 
 from pages import ElementType
 from pages.common_actions import (
+    Actor,
     Selector,
+    check_radio,
     check_url,
+    fill_out_input_fields,
+    fill_out_textarea_fields,
     find_element,
     go_to_url,
     take_screenshot,
+    tick_captcha_checkbox,
+    tick_checkboxes,
 )
 from pages.exread import contact_us_short_domestic_thank_you
 from settings import EXRED_UI_URL
@@ -31,7 +38,9 @@ TYPE = "Contact us"
 URL = urljoin(EXRED_UI_URL, "contact/domestic/")
 PAGE_TITLE = "Welcome to great.gov.uk"
 
-SUBMIT_BUTTON = Selector(By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON)
+SUBMIT_BUTTON = Selector(
+    By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON
+)
 SELECTORS = {
     "form": {
         "itself": Selector(By.CSS_SELECTOR, "#lede form"),
@@ -39,26 +48,48 @@ SELECTORS = {
         "first name": Selector(By.ID, "id_given_name", type=ElementType.INPUT),
         "last name": Selector(By.ID, "id_family_name", type=ElementType.INPUT),
         "email": Selector(By.ID, "id_email", type=ElementType.INPUT),
-        "uk private or public limited company": Selector(By.ID, "id_company_type_0", type=ElementType.CHECKBOX),
-        "other type of uk organisation": Selector(By.ID, "id_company_type_1", type=ElementType.CHECKBOX),
-        "organisation name": Selector(By.ID, "id_organisation_name", type=ElementType.INPUT),
+        "uk private or public limited company": Selector(
+            By.ID, "id_company_type_0", type=ElementType.RADIO
+        ),
+        "other type of uk organisation": Selector(
+            By.ID, "id_company_type_1", type=ElementType.RADIO
+        ),
+        "organisation name": Selector(
+            By.ID, "id_organisation_name", type=ElementType.INPUT
+        ),
         "postcode": Selector(By.ID, "id_postcode", type=ElementType.INPUT),
-        "terms and conditions": Selector(By.ID, "id_terms_agreed", type=ElementType.CHECKBOX),
+        "terms and conditions": Selector(
+            By.ID, "id_terms_agreed", type=ElementType.CHECKBOX
+        ),
         "submit": SUBMIT_BUTTON,
     }
 }
+OTHER_SELECTORS = {
+    "charity": Selector(By.ID, "id_company_type_other_0", type=ElementType.RADIO),
+    "government department": Selector(
+        By.ID, "id_company_type_other_1", type=ElementType.RADIO
+    ),
+    "intermediary": Selector(By.ID, "id_company_type_other_2", type=ElementType.RADIO),
+    "limited partnership": Selector(
+        By.ID, "id_company_type_other_3", type=ElementType.RADIO
+    ),
+    "sole trader": Selector(By.ID, "id_company_type_other_4", type=ElementType.RADIO),
+    "uk branch of foreign company (BR)": Selector(
+        By.ID, "id_company_type_other_5", type=ElementType.RADIO
+    ),
+    "other": Selector(By.ID, "id_company_type_other_6", type=ElementType.RADIO),
+}
 
 URLs = {
-    "short contact form (tell us how we can help)":
-        URL,
-    "short contact form (events)":
-        urljoin(URL, "/contact/events/"),
-    "short contact form (defence and security organisation (dso))":
-        urljoin(URL, "/contact/defence-and-security-organisation/"),
-    "short contact form (other)":
-        URL,
-    "short contact form (buying from the uk)":
-        urljoin(URL, "/contact/find-uk-companies/"),
+    "short contact form (tell us how we can help)": URL,
+    "short contact form (events)": urljoin(URL, "/contact/events/"),
+    "short contact form (defence and security organisation (dso))": urljoin(
+        URL, "/contact/defence-and-security-organisation/"
+    ),
+    "short contact form (other)": URL,
+    "short contact form (buying from the uk)": urljoin(
+        URL, "/contact/find-uk-companies/"
+    ),
 }
 
 
@@ -70,6 +101,58 @@ def should_be_here(driver: WebDriver, *, page_name: str = None):
     take_screenshot(driver, NAME)
     url = URLs[page_name.lower()] if page_name else URL
     check_url(driver, url, exact_match=True)
+
+
+def generate_form_details(actor: Actor) -> dict:
+    is_company = random.choice([True, False])
+    result = {
+        "comment": f"Submitted by automated test {actor.alias}",
+        "first name": f"send by {actor.alias} - automated tests",
+        "last name": actor.alias,
+        "email": actor.email,
+        "uk private or public limited company": is_company,
+        "other type of uk organisation": not is_company,
+        "organisation name": "automated tests",
+        "postcode": "SW1H 0TL",
+        "terms and conditions": True,
+    }
+    if not is_company:
+        other_type_of_uk_organisation = [
+            "charity",
+            "government department",
+            "intermediary",
+            "limited partnership",
+            "sole trader",
+            "uk branch of foreign company (BR)",
+            "other",
+        ]
+        other_choices = len(other_type_of_uk_organisation) * [False]
+        other_choices[random.randint(0, len(other_choices) - 1)] = True
+        other = {
+            other_type_of_uk_organisation[i]: other_choices[i]
+            for i in range(len(other_type_of_uk_organisation))
+        }
+        result.update(other)
+        SELECTORS["form"].update(OTHER_SELECTORS)
+    else:
+        # In order to avoid situation when previous scenario example modified
+        # SELECTORS we have to remove OTHER_SELECTORS that were then added
+        SELECTORS["form"] = dict(
+            set(SELECTORS["form"].items()) - set(OTHER_SELECTORS.items())
+        )
+
+    logging.debug(f"Generated form details: {result}")
+    return result
+
+
+def fill_out(driver: WebDriver, details: dict):
+    form_selectors = SELECTORS["form"]
+    fill_out_textarea_fields(driver, form_selectors, details)
+    fill_out_input_fields(driver, form_selectors, details)
+    check_radio(driver, form_selectors, details)
+    tick_checkboxes(driver, form_selectors, details)
+    tick_captcha_checkbox(driver)
+    take_screenshot(driver, "After filling out the form")
 
 
 def submit(driver: WebDriver) -> ModuleType:

--- a/tests/browser/pages/exread/contact_us_short_domestic.py
+++ b/tests/browser/pages/exread/contact_us_short_domestic.py
@@ -15,7 +15,7 @@ from pages.common_actions import (
     go_to_url,
     take_screenshot,
 )
-from pages.exread import contact_us_triage_domestic
+from pages.exread import contact_us_short_domestic_thank_you
 from settings import EXRED_UI_URL
 
 NAME = "Short contact form (Tell us how we can help)"
@@ -79,4 +79,4 @@ def submit(driver: WebDriver) -> ModuleType:
     )
     button.click()
     take_screenshot(driver, "After submitting the form")
-    return contact_us_triage_domestic
+    return contact_us_short_domestic_thank_you

--- a/tests/browser/pages/exread/contact_us_short_domestic.py
+++ b/tests/browser/pages/exread/contact_us_short_domestic.py
@@ -21,6 +21,7 @@ from pages.common_actions import (
     take_screenshot,
     tick_captcha_checkbox,
     tick_checkboxes,
+    pick_option
 )
 from pages.exread import contact_us_short_domestic_thank_you
 from settings import EXRED_UI_URL
@@ -65,19 +66,7 @@ SELECTORS = {
     }
 }
 OTHER_SELECTORS = {
-    "charity": Selector(By.ID, "id_company_type_other_0", type=ElementType.RADIO),
-    "government department": Selector(
-        By.ID, "id_company_type_other_1", type=ElementType.RADIO
-    ),
-    "intermediary": Selector(By.ID, "id_company_type_other_2", type=ElementType.RADIO),
-    "limited partnership": Selector(
-        By.ID, "id_company_type_other_3", type=ElementType.RADIO
-    ),
-    "sole trader": Selector(By.ID, "id_company_type_other_4", type=ElementType.RADIO),
-    "uk branch of foreign company (BR)": Selector(
-        By.ID, "id_company_type_other_5", type=ElementType.RADIO
-    ),
-    "other": Selector(By.ID, "id_company_type_other_6", type=ElementType.RADIO),
+    "other": Selector(By.ID, "id_company_type_other", type=ElementType.SELECT),
 }
 
 URLs = {
@@ -116,30 +105,14 @@ def generate_form_details(actor: Actor) -> dict:
         "postcode": "SW1H 0TL",
         "terms and conditions": True,
     }
-    if not is_company:
-        other_type_of_uk_organisation = [
-            "charity",
-            "government department",
-            "intermediary",
-            "limited partnership",
-            "sole trader",
-            "uk branch of foreign company (BR)",
-            "other",
-        ]
-        other_choices = len(other_type_of_uk_organisation) * [False]
-        other_choices[random.randint(0, len(other_choices) - 1)] = True
-        other = {
-            other_type_of_uk_organisation[i]: other_choices[i]
-            for i in range(len(other_type_of_uk_organisation))
-        }
-        result.update(other)
-        SELECTORS["form"].update(OTHER_SELECTORS)
-    else:
+    if is_company:
         # In order to avoid situation when previous scenario example modified
         # SELECTORS we have to remove OTHER_SELECTORS that were then added
         SELECTORS["form"] = dict(
             set(SELECTORS["form"].items()) - set(OTHER_SELECTORS.items())
         )
+    else:
+        SELECTORS["form"].update(OTHER_SELECTORS)
 
     logging.debug(f"Generated form details: {result}")
     return result
@@ -151,6 +124,7 @@ def fill_out(driver: WebDriver, details: dict):
     fill_out_input_fields(driver, form_selectors, details)
     check_radio(driver, form_selectors, details)
     tick_checkboxes(driver, form_selectors, details)
+    pick_option(driver, form_selectors, details)
     tick_captcha_checkbox(driver)
     take_screenshot(driver, "After filling out the form")
 

--- a/tests/browser/pages/exread/contact_us_short_domestic.py
+++ b/tests/browser/pages/exread/contact_us_short_domestic.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Export Readiness - First page of Long Contact us form"""
+from types import ModuleType
+
+from urllib.parse import urljoin
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from pages import ElementType
+from pages.common_actions import (
+    Selector,
+    check_url,
+    find_element,
+    go_to_url,
+    take_screenshot,
+)
+from pages.exread import contact_us_triage_domestic
+from settings import EXRED_UI_URL
+
+NAME = "Short contact form (Tell us how we can help)"
+NAMES = [
+    "Short contact form (Tell us how we can help)",
+    "Short contact form (Events)",
+    "Short contact form (Defence and Security Organisation (DSO))",
+    "Short contact form (Buying from the UK)",
+    "Short contact form (Other)",
+]
+SERVICE = "Export Readiness"
+TYPE = "Contact us"
+URL = urljoin(EXRED_UI_URL, "contact/domestic/")
+PAGE_TITLE = "Welcome to great.gov.uk"
+
+SUBMIT_BUTTON = Selector(By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON)
+SELECTORS = {
+    "form": {
+        "itself": Selector(By.CSS_SELECTOR, "#lede form"),
+        "comment": Selector(By.ID, "id_comment", type=ElementType.TEXTAREA),
+        "first name": Selector(By.ID, "id_given_name", type=ElementType.INPUT),
+        "last name": Selector(By.ID, "id_family_name", type=ElementType.INPUT),
+        "email": Selector(By.ID, "id_email", type=ElementType.INPUT),
+        "uk private or public limited company": Selector(By.ID, "id_company_type_0", type=ElementType.CHECKBOX),
+        "other type of uk organisation": Selector(By.ID, "id_company_type_1", type=ElementType.CHECKBOX),
+        "organisation name": Selector(By.ID, "id_organisation_name", type=ElementType.INPUT),
+        "postcode": Selector(By.ID, "id_postcode", type=ElementType.INPUT),
+        "terms and conditions": Selector(By.ID, "id_terms_agreed", type=ElementType.CHECKBOX),
+        "submit": SUBMIT_BUTTON,
+    }
+}
+
+URLs = {
+    "short contact form (tell us how we can help)":
+        URL,
+    "short contact form (events)":
+        urljoin(URL, "/contact/events/"),
+    "short contact form (defence and security organisation (dso))":
+        urljoin(URL, "/contact/defence-and-security-organisation/"),
+    "short contact form (other)":
+        URL,
+    "short contact form (buying from the uk)":
+        urljoin(URL, "/contact/find-uk-companies/"),
+}
+
+
+def visit(driver: WebDriver, *, first_time: bool = False):
+    go_to_url(driver, URL, NAME, first_time=first_time)
+
+
+def should_be_here(driver: WebDriver, *, page_name: str = None):
+    take_screenshot(driver, NAME)
+    if page_name:
+        url = URLs[page_name.lower()]
+        check_url(driver, url, exact_match=True)
+    else:
+        check_url(driver, URL, exact_match=False)
+
+
+def submit(driver: WebDriver) -> ModuleType:
+    take_screenshot(driver, "Before submitting the form")
+    button = find_element(
+        driver, SUBMIT_BUTTON, element_name="Submit button", wait_for_it=False
+    )
+    button.click()
+    take_screenshot(driver, "After submitting the form")
+    return contact_us_triage_domestic

--- a/tests/browser/pages/exread/contact_us_short_domestic.py
+++ b/tests/browser/pages/exread/contact_us_short_domestic.py
@@ -68,11 +68,8 @@ def visit(driver: WebDriver, *, first_time: bool = False):
 
 def should_be_here(driver: WebDriver, *, page_name: str = None):
     take_screenshot(driver, NAME)
-    if page_name:
-        url = URLs[page_name.lower()]
-        check_url(driver, url, exact_match=True)
-    else:
-        check_url(driver, URL, exact_match=False)
+    url = URLs[page_name.lower()] if page_name else URL
+    check_url(driver, url, exact_match=True)
 
 
 def submit(driver: WebDriver) -> ModuleType:

--- a/tests/browser/pages/exread/contact_us_short_domestic_thank_you.py
+++ b/tests/browser/pages/exread/contact_us_short_domestic_thank_you.py
@@ -14,6 +14,13 @@ NAMES = [
     "Thank you for your enquiry (Events)",
     "Thank you for your enquiry (Defence and Security Organisation (DSO))",
     "Thank you for your enquiry (Other)",
+    "Thank you for your enquiry (I haven't had a response from the opportunity I applied for)",
+    "Thank you for your enquiry (My daily alerts are not relevant to me)",
+    "Thank you for your enquiry (I have not received an email confirmation)",
+    "Thank you for your enquiry (I need to reset my password)",
+    "Thank you for your enquiry (My Companies House login is not working)",
+    "Thank you for your enquiry (I do not know where to enter my verification code)",
+    "Thank you for your enquiry (I have not received my letter containing the verification code)",
 ]
 SERVICE = "Export Readiness"
 TYPE = "Short Domestic Contact us"
@@ -43,10 +50,16 @@ SELECTORS = {
 URLs = {
     "thank you for your enquiry": URL,
     "thank you for your enquiry (events)": urljoin(URL, "/contact/events/success/"),
-    "thank you for your enquiry (defence and security organisation (dso))": urljoin(
-        URL, "/contact/defence-and-security-organisation/success/"
-    ),
+    "thank you for your enquiry (defence and security organisation (dso))":
+        urljoin(URL, "/contact/defence-and-security-organisation/success/"),
     "thank you for your enquiry (other)": URL,
+    "thank you for your enquiry (i haven't had a response from the opportunity i applied for)": URL,
+    "thank you for your enquiry (my daily alerts are not relevant to me)": URL,
+    "thank you for your enquiry (i have not received an email confirmation)": URL,
+    "thank you for your enquiry (i need to reset my password)": URL,
+    "thank you for your enquiry (my companies house login is not working)": URL,
+    "thank you for your enquiry (i do not know where to enter my verification code)": URL,
+    "thank you for your enquiry (i have not received my letter containing the verification code)": URL,
 }
 
 

--- a/tests/browser/pages/exread/contact_us_short_domestic_thank_you.py
+++ b/tests/browser/pages/exread/contact_us_short_domestic_thank_you.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""Export Readiness - Short Domestic Contact us - Thank you for your enquiry."""
+from urllib.parse import urljoin
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from pages.common_actions import Selector, check_url, take_screenshot
+from settings import EXRED_UI_URL
+
+NAME = "Thank you for your enquiry"
+NAMES = [
+    "Thank you for your enquiry",
+    "Thank you for your enquiry (Events)",
+    "Thank you for your enquiry (Defence and Security Organisation (DSO))",
+    "Thank you for your enquiry (Other)",
+]
+SERVICE = "Export Readiness"
+TYPE = "Short Domestic Contact us"
+URL = urljoin(EXRED_UI_URL, "contact/domestic/success/")
+PAGE_TITLE = "Welcome to great.gov.uk"
+
+PDF_LINKS = Selector(By.CSS_SELECTOR, "#documents-section a.link")
+SELECTORS = {
+    "confirmation": {
+        "itself": Selector(By.ID, "confirmation-section"),
+        "heading": Selector(
+            By.CSS_SELECTOR, "#confirmation-section div.heading-container"
+        ),
+    },
+    "what happens next": {
+        "itself": Selector(By.ID, "next-container"),
+        "heading": Selector(By.CSS_SELECTOR, "#next-container h2"),
+        "text": Selector(By.CSS_SELECTOR, "#next-container p"),
+        "continue to great.gov.uk": Selector(By.CSS_SELECTOR, "#next-container a"),
+    },
+    "report this page": {
+        "self": Selector(By.CSS_SELECTOR, "section.error-reporting"),
+        "report link": Selector(By.CSS_SELECTOR, "section.error-reporting a"),
+    },
+}
+
+URLs = {
+    "thank you for your enquiry": URL,
+    "thank you for your enquiry (events)": urljoin(URL, "/contact/events/success/"),
+    "thank you for your enquiry (defence and security organisation (dso))": urljoin(
+        URL, "/contact/defence-and-security-organisation/success/"
+    ),
+    "thank you for your enquiry (other)": URL,
+}
+
+
+def should_be_here(driver: WebDriver, *, page_name: str = None):
+    take_screenshot(driver, NAME)
+    url = URLs[page_name.lower()] if page_name else URL
+    check_url(driver, url, exact_match=True)

--- a/tests/browser/pages/exread/contact_us_triage_domestic.py
+++ b/tests/browser/pages/exread/contact_us_triage_domestic.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """Export Readiness - Domestic Contact us - What can we help you with?"""
 import logging
-from typing import List
 from types import ModuleType
-
+from typing import List
 from urllib.parse import urljoin
 
 from selenium.webdriver.common.by import By
@@ -22,7 +21,9 @@ from pages.common_actions import (
 )
 from pages.exread import (
     contact_us_long_export_advice_comment,
+    contact_us_short_domestic,
     contact_us_triage_great_services,
+    domestic_eu_exit_contact_us,
     ukef_what_would_you_like_to_know,
 )
 from pages.external import office_finder
@@ -34,21 +35,53 @@ TYPE = "Domestic Contact us"
 URL = urljoin(EXRED_UI_URL, "contact/triage/domestic/")
 PAGE_TITLE = "Welcome to great.gov.uk"
 
-SUBMIT_BUTTON = Selector(By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON)
+SUBMIT_BUTTON = Selector(
+    By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON
+)
 SELECTORS = {
     "form": {
         "itself": Selector(By.CSS_SELECTOR, "#lede form"),
-        "find your local trade office": Selector(By.ID, "id_domestic-choice_0", type=ElementType.RADIO, is_visible=False),
-        "advice to export from the uk": Selector(By.ID, "id_domestic-choice_1", type=ElementType.RADIO, is_visible=False),
-        "great.gov.uk account and services support": Selector(By.ID, "id_domestic-choice_2", type=ElementType.RADIO, is_visible=False),
-        "uk export finance (ukef)": Selector(By.ID, "id_domestic-choice_3", type=ElementType.RADIO, is_visible=False),
-        "eu exit": Selector(By.ID, "id_domestic-choice_4", type=ElementType.RADIO, is_visible=False),
-        "events": Selector(By.ID, "id_domestic-choice_5", type=ElementType.RADIO, is_visible=False),
-        "defence and security organisation (dso)": Selector(By.ID, "id_domestic-choice_6", type=ElementType.RADIO, is_visible=False),
-        "other": Selector(By.ID, "id_domestic-choice_7", type=ElementType.RADIO, is_visible=False),
+        "find your local trade office": Selector(
+            By.ID, "id_domestic-choice_0", type=ElementType.RADIO, is_visible=False
+        ),
+        "advice to export from the uk": Selector(
+            By.ID, "id_domestic-choice_1", type=ElementType.RADIO, is_visible=False
+        ),
+        "great.gov.uk account and services support": Selector(
+            By.ID, "id_domestic-choice_2", type=ElementType.RADIO, is_visible=False
+        ),
+        "uk export finance (ukef)": Selector(
+            By.ID, "id_domestic-choice_3", type=ElementType.RADIO, is_visible=False
+        ),
+        "eu exit": Selector(
+            By.ID, "id_domestic-choice_4", type=ElementType.RADIO, is_visible=False
+        ),
+        "events": Selector(
+            By.ID, "id_domestic-choice_5", type=ElementType.RADIO, is_visible=False
+        ),
+        "defence and security organisation (dso)": Selector(
+            By.ID, "id_domestic-choice_6", type=ElementType.RADIO, is_visible=False
+        ),
+        "other": Selector(
+            By.ID, "id_domestic-choice_7", type=ElementType.RADIO, is_visible=False
+        ),
         "submit": SUBMIT_BUTTON,
-        "back": Selector(By.CSS_SELECTOR, "form button[name='wizard_goto_step']", type=ElementType.LINK)
+        "back": Selector(
+            By.CSS_SELECTOR,
+            "form button[name='wizard_goto_step']",
+            type=ElementType.LINK,
+        ),
     }
+}
+POs = {
+    "find your local trade office": office_finder,
+    "advice to export from the uk": contact_us_long_export_advice_comment,
+    "great.gov.uk account and services support": contact_us_triage_great_services,
+    "uk export finance (ukef)": ukef_what_would_you_like_to_know,
+    "eu exit": domestic_eu_exit_contact_us,
+    "events": contact_us_short_domestic,
+    "defence and security organisation (dso)": contact_us_short_domestic,
+    "other": contact_us_short_domestic,
 }
 
 
@@ -65,12 +98,10 @@ def should_see_form_choices(driver: WebDriver, names: List[str]):
     radio_selectors = get_selectors(SELECTORS["form"], ElementType.RADIO)
     for name in names:
         radio_selector = radio_selectors[name.lower()]
-        find_element(
-            driver, radio_selector, element_name=name, wait_for_it=False
-        )
+        find_element(driver, radio_selector, element_name=name, wait_for_it=False)
     logging.debug(
-        f"All expected form choices: '{names}' are visible on "
-        f"{driver.current_url}")
+        f"All expected form choices: '{names}' are visible on " f"{driver.current_url}"
+    )
 
 
 def pick_radio_option_and_submit(driver: WebDriver, name: str) -> ModuleType:
@@ -82,16 +113,6 @@ def pick_radio_option_and_submit(driver: WebDriver, name: str) -> ModuleType:
     )
     button.click()
     take_screenshot(driver, "After submitting the form")
-    POs = {
-        "find your local trade office": office_finder,
-        "advice to export from the uk": contact_us_long_export_advice_comment,
-        "great.gov.uk account and services support": contact_us_triage_great_services,
-        "uk export finance (ukef)": ukef_what_would_you_like_to_know,
-        "eu exit": None,
-        "events": None,
-        "defence and security organisation (dso)": None,
-        "other": None,
-    }
     return POs[name.lower()]
 
 

--- a/tests/browser/pages/exread/contact_us_triage_domestic.py
+++ b/tests/browser/pages/exread/contact_us_triage_domestic.py
@@ -13,11 +13,12 @@ from pages import ElementType
 from pages.common_actions import (
     Selector,
     check_url,
+    choose_one_form_option,
+    find_and_click_on_page_element,
     find_element,
+    get_selectors,
     go_to_url,
     take_screenshot,
-    choose_one_form_option,
-    get_selectors,
 )
 from pages.exread import (
     contact_us_long_export_advice_comment,
@@ -92,3 +93,8 @@ def pick_radio_option_and_submit(driver: WebDriver, name: str) -> ModuleType:
         "other": None,
     }
     return POs[name.lower()]
+
+
+def click_on_page_element(driver: WebDriver, element_name: str):
+    find_and_click_on_page_element(driver, SELECTORS, element_name)
+    take_screenshot(driver, NAME + " after clicking on " + element_name)

--- a/tests/browser/pages/exread/contact_us_triage_domestic.py
+++ b/tests/browser/pages/exread/contact_us_triage_domestic.py
@@ -42,28 +42,28 @@ SELECTORS = {
     "form": {
         "itself": Selector(By.CSS_SELECTOR, "#lede form"),
         "find your local trade office": Selector(
-            By.ID, "id_domestic-choice_0", type=ElementType.RADIO, is_visible=False
+            By.CSS_SELECTOR, "input[value='trade-office']", type=ElementType.RADIO, is_visible=False
         ),
         "advice to export from the uk": Selector(
-            By.ID, "id_domestic-choice_1", type=ElementType.RADIO, is_visible=False
+            By.CSS_SELECTOR, "input[value='export-advice']", type=ElementType.RADIO, is_visible=False
         ),
         "great.gov.uk account and services support": Selector(
-            By.ID, "id_domestic-choice_2", type=ElementType.RADIO, is_visible=False
+            By.CSS_SELECTOR, "input[value='great-services']", type=ElementType.RADIO, is_visible=False
         ),
         "uk export finance (ukef)": Selector(
-            By.ID, "id_domestic-choice_3", type=ElementType.RADIO, is_visible=False
+            By.CSS_SELECTOR, "input[value='finance']", type=ElementType.RADIO, is_visible=False
         ),
         "eu exit": Selector(
-            By.ID, "id_domestic-choice_4", type=ElementType.RADIO, is_visible=False
+            By.CSS_SELECTOR, "input[value='eu-exit']", type=ElementType.RADIO, is_visible=False
         ),
         "events": Selector(
-            By.ID, "id_domestic-choice_5", type=ElementType.RADIO, is_visible=False
+            By.CSS_SELECTOR, "input[value='events']", type=ElementType.RADIO, is_visible=False
         ),
         "defence and security organisation (dso)": Selector(
-            By.ID, "id_domestic-choice_6", type=ElementType.RADIO, is_visible=False
+            By.CSS_SELECTOR, "input[value='dso']", type=ElementType.RADIO, is_visible=False
         ),
         "other": Selector(
-            By.ID, "id_domestic-choice_7", type=ElementType.RADIO, is_visible=False
+            By.CSS_SELECTOR, "input[value='other']", type=ElementType.RADIO, is_visible=False
         ),
         "submit": SUBMIT_BUTTON,
         "back": Selector(

--- a/tests/browser/pages/exread/contact_us_triage_export_opportunities.py
+++ b/tests/browser/pages/exread/contact_us_triage_export_opportunities.py
@@ -14,6 +14,7 @@ from pages.common_actions import (
     check_url,
     choose_one_form_option,
     choose_one_form_option_except,
+    find_and_click_on_page_element,
     find_element,
     get_selectors,
     go_to_url,
@@ -95,3 +96,8 @@ def pick_random_radio_option_and_submit(driver: WebDriver, ignored: List[str]):
     button.click()
     take_screenshot(driver, "After submitting the form")
     return POs[selected.lower()]
+
+
+def click_on_page_element(driver: WebDriver, element_name: str):
+    find_and_click_on_page_element(driver, SELECTORS, element_name)
+    take_screenshot(driver, NAME + " after clicking on " + element_name)

--- a/tests/browser/pages/exread/contact_us_triage_export_opportunities.py
+++ b/tests/browser/pages/exread/contact_us_triage_export_opportunities.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""Export Readiness - Domestic Contact us - Great.gov.uk account"""
+import logging
+from typing import List
+from types import ModuleType
+
+from urllib.parse import urljoin
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from pages import ElementType
+from pages.common_actions import (
+    Selector,
+    check_url,
+    find_element,
+    go_to_url,
+    take_screenshot,
+    choose_one_form_option,
+    get_selectors,
+)
+from pages.exread import contact_us_short_domestic
+from settings import EXRED_UI_URL
+
+NAME = "Export opportunities service"
+SERVICE = "Export Readiness"
+TYPE = "Domestic Contact us"
+URL = urljoin(EXRED_UI_URL, "contact/triage/export-opportunities/")
+PAGE_TITLE = "Welcome to great.gov.uk"
+
+SUBMIT_BUTTON = Selector(By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON)
+SELECTORS = {
+    "form": {
+        "itself": Selector(By.CSS_SELECTOR, "#lede form"),
+        "i haven't had a response from the opportunity i applied for": Selector(By.ID, "id_export-opportunities-choice_0", type=ElementType.RADIO, is_visible=False),
+        "my daily alerts are not relevant to me": Selector(By.ID, "id_export-opportunities-choice_1", type=ElementType.RADIO, is_visible=False),
+        "i need more details about the opportunity": Selector(By.ID, "id_export-opportunities-choice_2", type=ElementType.RADIO, is_visible=False),
+        "other": Selector(By.ID, "id_export-opportunities-choice_3", type=ElementType.RADIO, is_visible=False),
+        "submit": SUBMIT_BUTTON,
+        "back": Selector(By.CSS_SELECTOR, "form button[name='wizard_goto_step']", type=ElementType.LINK)
+    }
+}
+
+
+def visit(driver: WebDriver, *, first_time: bool = False):
+    go_to_url(driver, URL, NAME, first_time=first_time)
+
+
+def should_be_here(driver: WebDriver):
+    take_screenshot(driver, NAME)
+    check_url(driver, URL)
+
+
+def should_see_form_choices(driver: WebDriver, names: List[str]):
+    radio_selectors = get_selectors(SELECTORS["form"], ElementType.RADIO)
+    for name in names:
+        radio_selector = radio_selectors[name.lower()]
+        find_element(
+            driver, radio_selector, element_name=name, wait_for_it=False
+        )
+    logging.debug(
+        f"All expected form choices: '{names}' are visible on "
+        f"{driver.current_url}")
+
+
+def pick_radio_option_and_submit(driver: WebDriver, name: str) -> ModuleType:
+    radio_selectors = get_selectors(SELECTORS["form"], ElementType.RADIO)
+    choose_one_form_option(driver, radio_selectors, name)
+    take_screenshot(driver, "Before submitting the form")
+    button = find_element(
+        driver, SUBMIT_BUTTON, element_name="Submit button", wait_for_it=False
+    )
+    button.click()
+    take_screenshot(driver, "After submitting the form")
+    POs = {
+        "i haven't had a response from the opportunity i applied for": None,
+        "my daily alerts are not relevant to me": None,
+        "i need more details about the opportunity": None,
+        "other": contact_us_short_domestic,
+    }
+    return POs[name.lower()]

--- a/tests/browser/pages/exread/contact_us_triage_export_opportunities.py
+++ b/tests/browser/pages/exread/contact_us_triage_export_opportunities.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """Export Readiness - Domestic Contact us - Great.gov.uk account"""
 import logging
-from typing import List
 from types import ModuleType
-
+from typing import List
 from urllib.parse import urljoin
 
 from selenium.webdriver.common.by import By
@@ -13,13 +12,17 @@ from pages import ElementType
 from pages.common_actions import (
     Selector,
     check_url,
+    choose_one_form_option,
+    choose_one_form_option_except,
     find_element,
+    get_selectors,
     go_to_url,
     take_screenshot,
-    choose_one_form_option,
-    get_selectors,
 )
-from pages.exread import contact_us_short_domestic
+from pages.exread import (
+    contact_us_short_domestic,
+    contact_us_triage_export_opportunities_dedicated_support_content,
+)
 from settings import EXRED_UI_URL
 
 NAME = "Export opportunities service"
@@ -39,6 +42,16 @@ SELECTORS = {
         "submit": SUBMIT_BUTTON,
         "back": Selector(By.CSS_SELECTOR, "form button[name='wizard_goto_step']", type=ElementType.LINK)
     }
+}
+
+POs = {
+    "i haven't had a response from the opportunity i applied for":
+        contact_us_short_domestic,
+    "my daily alerts are not relevant to me":
+        contact_us_triage_export_opportunities_dedicated_support_content,
+    "i need more details about the opportunity":
+        contact_us_short_domestic,
+    "other": contact_us_short_domestic,
 }
 
 
@@ -72,10 +85,16 @@ def pick_radio_option_and_submit(driver: WebDriver, name: str) -> ModuleType:
     )
     button.click()
     take_screenshot(driver, "After submitting the form")
-    POs = {
-        "i haven't had a response from the opportunity i applied for": None,
-        "my daily alerts are not relevant to me": None,
-        "i need more details about the opportunity": None,
-        "other": contact_us_short_domestic,
-    }
     return POs[name.lower()]
+
+
+def pick_random_radio_option_and_submit(driver: WebDriver, ignored: List[str]):
+    radio_selectors = get_selectors(SELECTORS["form"], ElementType.RADIO)
+    selected = choose_one_form_option_except(driver, radio_selectors, ignored)
+    take_screenshot(driver, "Before submitting the form")
+    button = find_element(
+        driver, SUBMIT_BUTTON, element_name="Submit button", wait_for_it=False
+    )
+    button.click()
+    take_screenshot(driver, "After submitting the form")
+    return POs[selected.lower()]

--- a/tests/browser/pages/exread/contact_us_triage_export_opportunities.py
+++ b/tests/browser/pages/exread/contact_us_triage_export_opportunities.py
@@ -37,8 +37,7 @@ SELECTORS = {
         "itself": Selector(By.CSS_SELECTOR, "#lede form"),
         "i haven't had a response from the opportunity i applied for": Selector(By.ID, "id_export-opportunities-choice_0", type=ElementType.RADIO, is_visible=False),
         "my daily alerts are not relevant to me": Selector(By.ID, "id_export-opportunities-choice_1", type=ElementType.RADIO, is_visible=False),
-        "i need more details about the opportunity": Selector(By.ID, "id_export-opportunities-choice_2", type=ElementType.RADIO, is_visible=False),
-        "other": Selector(By.ID, "id_export-opportunities-choice_3", type=ElementType.RADIO, is_visible=False),
+        "other": Selector(By.ID, "id_export-opportunities-choice_2", type=ElementType.RADIO, is_visible=False),
         "submit": SUBMIT_BUTTON,
         "back": Selector(By.CSS_SELECTOR, "form button[name='wizard_goto_step']", type=ElementType.LINK)
     }
@@ -49,8 +48,6 @@ POs = {
         contact_us_short_domestic,
     "my daily alerts are not relevant to me":
         contact_us_triage_export_opportunities_dedicated_support_content,
-    "i need more details about the opportunity":
-        contact_us_short_domestic,
     "other": contact_us_short_domestic,
 }
 

--- a/tests/browser/pages/exread/contact_us_triage_export_opportunities.py
+++ b/tests/browser/pages/exread/contact_us_triage_export_opportunities.py
@@ -32,23 +32,42 @@ TYPE = "Domestic Contact us"
 URL = urljoin(EXRED_UI_URL, "contact/triage/export-opportunities/")
 PAGE_TITLE = "Welcome to great.gov.uk"
 
-SUBMIT_BUTTON = Selector(By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON)
+SUBMIT_BUTTON = Selector(
+    By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON
+)
 SELECTORS = {
     "form": {
         "itself": Selector(By.CSS_SELECTOR, "#lede form"),
-        "i haven't had a response from the opportunity i applied for": Selector(By.ID, "id_export-opportunities-choice_0", type=ElementType.RADIO, is_visible=False),
-        "my daily alerts are not relevant to me": Selector(By.ID, "id_export-opportunities-choice_1", type=ElementType.RADIO, is_visible=False),
-        "other": Selector(By.ID, "id_export-opportunities-choice_2", type=ElementType.RADIO, is_visible=False),
+        "i haven't had a response from the opportunity i applied for": Selector(
+            By.ID,
+            "id_export-opportunities-choice_0",
+            type=ElementType.RADIO,
+            is_visible=False,
+        ),
+        "my daily alerts are not relevant to me": Selector(
+            By.ID,
+            "id_export-opportunities-choice_1",
+            type=ElementType.RADIO,
+            is_visible=False,
+        ),
+        "other": Selector(
+            By.ID,
+            "id_export-opportunities-choice_2",
+            type=ElementType.RADIO,
+            is_visible=False,
+        ),
         "submit": SUBMIT_BUTTON,
-        "back": Selector(By.CSS_SELECTOR, "form button[name='wizard_goto_step']", type=ElementType.LINK)
+        "back": Selector(
+            By.CSS_SELECTOR,
+            "form button[name='wizard_goto_step']",
+            type=ElementType.LINK,
+        ),
     }
 }
 
 POs = {
-    "i haven't had a response from the opportunity i applied for":
-        contact_us_short_domestic,
-    "my daily alerts are not relevant to me":
-        contact_us_triage_export_opportunities_dedicated_support_content,
+    "i haven't had a response from the opportunity i applied for": contact_us_short_domestic,
+    "my daily alerts are not relevant to me": contact_us_triage_export_opportunities_dedicated_support_content,
     "other": contact_us_short_domestic,
 }
 
@@ -66,12 +85,10 @@ def should_see_form_choices(driver: WebDriver, names: List[str]):
     radio_selectors = get_selectors(SELECTORS["form"], ElementType.RADIO)
     for name in names:
         radio_selector = radio_selectors[name.lower()]
-        find_element(
-            driver, radio_selector, element_name=name, wait_for_it=False
-        )
+        find_element(driver, radio_selector, element_name=name, wait_for_it=False)
     logging.debug(
-        f"All expected form choices: '{names}' are visible on "
-        f"{driver.current_url}")
+        f"All expected form choices: '{names}' are visible on " f"{driver.current_url}"
+    )
 
 
 def pick_radio_option_and_submit(driver: WebDriver, name: str) -> ModuleType:

--- a/tests/browser/pages/exread/contact_us_triage_export_opportunities_dedicated_support_content.py
+++ b/tests/browser/pages/exread/contact_us_triage_export_opportunities_dedicated_support_content.py
@@ -58,6 +58,8 @@ def should_be_here(driver: WebDriver, *, page_name: str = None):
     take_screenshot(driver, NAME)
     url = URLs[page_name.lower()] if page_name else URL
     check_url(driver, url, exact_match=False)
+    msg = f"Got 404 on {driver.current_url}"
+    assert "This page cannot be found" not in driver.page_source, msg
 
 
 def click_on_page_element(driver: WebDriver, element_name: str):

--- a/tests/browser/pages/exread/contact_us_triage_export_opportunities_dedicated_support_content.py
+++ b/tests/browser/pages/exread/contact_us_triage_export_opportunities_dedicated_support_content.py
@@ -6,7 +6,13 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 
 from pages import ElementType
-from pages.common_actions import Selector, check_url, go_to_url, take_screenshot
+from pages.common_actions import (
+    Selector,
+    check_url,
+    find_and_click_on_page_element,
+    go_to_url,
+    take_screenshot,
+)
 from settings import EXRED_UI_URL
 
 NAME = "Export opportunities service"
@@ -52,3 +58,8 @@ def should_be_here(driver: WebDriver, *, page_name: str = None):
     take_screenshot(driver, NAME)
     url = URLs[page_name.lower()] if page_name else URL
     check_url(driver, url, exact_match=False)
+
+
+def click_on_page_element(driver: WebDriver, element_name: str):
+    find_and_click_on_page_element(driver, SELECTORS, element_name)
+    take_screenshot(driver, NAME + " after clicking on " + element_name)

--- a/tests/browser/pages/exread/contact_us_triage_export_opportunities_dedicated_support_content.py
+++ b/tests/browser/pages/exread/contact_us_triage_export_opportunities_dedicated_support_content.py
@@ -16,7 +16,11 @@ from pages.common_actions import (
 from settings import EXRED_UI_URL
 
 NAME = "Export opportunities service"
-NAMES = ["Export opportunities service", "My daily alerts are not relevant to me"]
+NAMES = [
+    "Export opportunities service",
+    "I haven't had a response from the opportunity I applied for",
+    "My daily alerts are not relevant to me",
+]
 SERVICE = "Export Readiness"
 TYPE = "Dedicated Support Content"
 URL = urljoin(EXRED_UI_URL, "contact/triage/export-opportunities/")
@@ -24,6 +28,9 @@ PAGE_TITLE = "Welcome to great.gov.uk"
 
 URLs = {
     "export opportunities service": URL,
+    "i haven't had a response from the opportunity i applied for": urljoin(
+        URL, "opportunity-no-response/"
+    ),
     "my daily alerts are not relevant to me": urljoin(URL, "alerts-not-relevant/"),
 }
 

--- a/tests/browser/pages/exread/contact_us_triage_export_opportunities_dedicated_support_content.py
+++ b/tests/browser/pages/exread/contact_us_triage_export_opportunities_dedicated_support_content.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""Export Readiness - Domestic Contact us - Great.gov.uk account"""
+from urllib.parse import urljoin
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from pages import ElementType
+from pages.common_actions import Selector, check_url, go_to_url, take_screenshot
+from settings import EXRED_UI_URL
+
+NAME = "Export opportunities service"
+NAMES = ["Export opportunities service", "My daily alerts are not relevant to me"]
+SERVICE = "Export Readiness"
+TYPE = "Dedicated Support Content"
+URL = urljoin(EXRED_UI_URL, "contact/triage/export-opportunities/")
+PAGE_TITLE = "Welcome to great.gov.uk"
+
+URLs = {
+    "export opportunities service": URL,
+    "my daily alerts are not relevant to me": urljoin(URL, "alerts-not-relevant/"),
+}
+
+SUBMIT_BUTTON = Selector(
+    By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON
+)
+SELECTORS = {
+    "breadcrumbs": {
+        "itself": Selector(By.CSS_SELECTOR, "div.breadcrumbs"),
+        "links": Selector(By.CSS_SELECTOR, "div.breadcrumbs a"),
+    },
+    "support content": {
+        "itself": Selector(By.CSS_SELECTOR, "div.container section"),
+        "heading": Selector(By.CSS_SELECTOR, "section h1"),
+        "content": Selector(By.CSS_SELECTOR, "section p"),
+        "submit an enquiry": Selector(
+            By.CSS_SELECTOR, "#further-help-link > a", type=ElementType.LINK
+        ),
+    },
+    "error reporting": {
+        "itself": Selector(By.CSS_SELECTOR, "section.error-reporting"),
+        "link": Selector(By.ID, "error-reporting-section-contact-us"),
+    },
+}
+
+
+def visit(driver: WebDriver, *, first_time: bool = False):
+    go_to_url(driver, URL, NAME, first_time=first_time)
+
+
+def should_be_here(driver: WebDriver, *, page_name: str = None):
+    take_screenshot(driver, NAME)
+    url = URLs[page_name.lower()] if page_name else URL
+    check_url(driver, url, exact_match=False)

--- a/tests/browser/pages/exread/contact_us_triage_great_account.py
+++ b/tests/browser/pages/exread/contact_us_triage_great_account.py
@@ -14,6 +14,7 @@ from pages.common_actions import (
     check_url,
     choose_one_form_option,
     choose_one_form_option_except,
+    find_and_click_on_page_element,
     find_element,
     get_selectors,
     go_to_url,
@@ -104,3 +105,8 @@ def pick_random_radio_option_and_submit(driver: WebDriver, ignored: List[str]):
     button.click()
     take_screenshot(driver, "After submitting the form")
     return POs[selected.lower()]
+
+
+def click_on_page_element(driver: WebDriver, element_name: str):
+    find_and_click_on_page_element(driver, SELECTORS, element_name)
+    take_screenshot(driver, NAME + " after clicking on " + element_name)

--- a/tests/browser/pages/exread/contact_us_triage_great_account.py
+++ b/tests/browser/pages/exread/contact_us_triage_great_account.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Export Readiness - Domestic Contact us - Great.gov.uk account"""
+import logging
+from typing import List
+from types import ModuleType
+
+from urllib.parse import urljoin
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from pages import ElementType
+from pages.common_actions import (
+    Selector,
+    check_url,
+    find_element,
+    go_to_url,
+    take_screenshot,
+    choose_one_form_option,
+    get_selectors,
+)
+from pages.exread import contact_us_short_domestic
+from settings import EXRED_UI_URL
+
+NAME = "Great.gov.uk account"
+SERVICE = "Export Readiness"
+TYPE = "Domestic Contact us"
+URL = urljoin(EXRED_UI_URL, "contact/triage/great-account/")
+PAGE_TITLE = "Welcome to great.gov.uk"
+
+SUBMIT_BUTTON = Selector(By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON)
+SELECTORS = {
+    "form": {
+        "itself": Selector(By.CSS_SELECTOR, "#lede form"),
+        "i have not received an email confirmation": Selector(By.ID, "id_great-account-choice_0", type=ElementType.RADIO, is_visible=False),
+        "i need to reset my password": Selector(By.ID, "id_great-account-choice_1", type=ElementType.RADIO, is_visible=False),
+        "my companies house login is not working": Selector(By.ID, "id_great-account-choice_2", type=ElementType.RADIO, is_visible=False),
+        "i do not know where to enter my verification code": Selector(By.ID, "id_great-account-choice_3", type=ElementType.RADIO, is_visible=False),
+        "i have not received my letter containing the verification code": Selector(By.ID, "id_great-account-choice_4", type=ElementType.RADIO, is_visible=False),
+        "other": Selector(By.ID, "id_great-account-choice_5", type=ElementType.RADIO, is_visible=False),
+        "submit": SUBMIT_BUTTON,
+        "back": Selector(By.CSS_SELECTOR, "form button[name='wizard_goto_step']", type=ElementType.LINK)
+    }
+}
+
+
+def visit(driver: WebDriver, *, first_time: bool = False):
+    go_to_url(driver, URL, NAME, first_time=first_time)
+
+
+def should_be_here(driver: WebDriver):
+    take_screenshot(driver, NAME)
+    check_url(driver, URL)
+
+
+def should_see_form_choices(driver: WebDriver, names: List[str]):
+    radio_selectors = get_selectors(SELECTORS["form"], ElementType.RADIO)
+    for name in names:
+        radio_selector = radio_selectors[name.lower()]
+        find_element(
+            driver, radio_selector, element_name=name, wait_for_it=False
+        )
+    logging.debug(
+        f"All expected form choices: '{names}' are visible on "
+        f"{driver.current_url}")
+
+
+def pick_radio_option_and_submit(driver: WebDriver, name: str) -> ModuleType:
+    radio_selectors = get_selectors(SELECTORS["form"], ElementType.RADIO)
+    choose_one_form_option(driver, radio_selectors, name)
+    take_screenshot(driver, "Before submitting the form")
+    button = find_element(
+        driver, SUBMIT_BUTTON, element_name="Submit button", wait_for_it=False
+    )
+    button.click()
+    take_screenshot(driver, "After submitting the form")
+    POs = {
+        "i have not received an email confirmation": None,
+        "i need to reset my password": None,
+        "my companies house login is not working": None,
+        "i do not know where to enter my verification code": None,
+        "i have not received my letter containing the verification code": None,
+        "other": contact_us_short_domestic,
+    }
+    return POs[name.lower()]

--- a/tests/browser/pages/exread/contact_us_triage_great_account.py
+++ b/tests/browser/pages/exread/contact_us_triage_great_account.py
@@ -32,32 +32,45 @@ TYPE = "Domestic Contact us"
 URL = urljoin(EXRED_UI_URL, "contact/triage/great-account/")
 PAGE_TITLE = "Welcome to great.gov.uk"
 
-SUBMIT_BUTTON = Selector(By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON)
+SUBMIT_BUTTON = Selector(
+    By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON
+)
 SELECTORS = {
     "form": {
         "itself": Selector(By.CSS_SELECTOR, "#lede form"),
-        "i have not received an email confirmation": Selector(By.ID, "id_great-account-choice_0", type=ElementType.RADIO, is_visible=False),
-        "i need to reset my password": Selector(By.ID, "id_great-account-choice_1", type=ElementType.RADIO, is_visible=False),
-        "my companies house login is not working": Selector(By.ID, "id_great-account-choice_2", type=ElementType.RADIO, is_visible=False),
-        "i do not know where to enter my verification code": Selector(By.ID, "id_great-account-choice_3", type=ElementType.RADIO, is_visible=False),
-        "i have not received my letter containing the verification code": Selector(By.ID, "id_great-account-choice_4", type=ElementType.RADIO, is_visible=False),
-        "other": Selector(By.ID, "id_great-account-choice_5", type=ElementType.RADIO, is_visible=False),
+        "i have not received an email confirmation": Selector(
+            By.ID, "id_great-account-choice_0", type=ElementType.RADIO, is_visible=False
+        ),
+        "i need to reset my password": Selector(
+            By.ID, "id_great-account-choice_1", type=ElementType.RADIO, is_visible=False
+        ),
+        "my companies house login is not working": Selector(
+            By.ID, "id_great-account-choice_2", type=ElementType.RADIO, is_visible=False
+        ),
+        "i do not know where to enter my verification code": Selector(
+            By.ID, "id_great-account-choice_3", type=ElementType.RADIO, is_visible=False
+        ),
+        "i have not received my letter containing the verification code": Selector(
+            By.ID, "id_great-account-choice_4", type=ElementType.RADIO, is_visible=False
+        ),
+        "other": Selector(
+            By.ID, "id_great-account-choice_5", type=ElementType.RADIO, is_visible=False
+        ),
         "submit": SUBMIT_BUTTON,
-        "back": Selector(By.CSS_SELECTOR, "form button[name='wizard_goto_step']", type=ElementType.LINK)
+        "back": Selector(
+            By.CSS_SELECTOR,
+            "form button[name='wizard_goto_step']",
+            type=ElementType.LINK,
+        ),
     }
 }
 
 POs = {
-    "i have not received an email confirmation":
-        contact_us_triage_great_account_dedicated_support_content,
-    "i need to reset my password":
-        contact_us_triage_great_account_dedicated_support_content,
-    "my companies house login is not working":
-        contact_us_triage_great_account_dedicated_support_content,
-    "i do not know where to enter my verification code":
-        contact_us_triage_great_account_dedicated_support_content,
-    "i have not received my letter containing the verification code":
-        contact_us_triage_great_account_dedicated_support_content,
+    "i have not received an email confirmation": contact_us_triage_great_account_dedicated_support_content,
+    "i need to reset my password": contact_us_triage_great_account_dedicated_support_content,
+    "my companies house login is not working": contact_us_triage_great_account_dedicated_support_content,
+    "i do not know where to enter my verification code": contact_us_triage_great_account_dedicated_support_content,
+    "i have not received my letter containing the verification code": contact_us_triage_great_account_dedicated_support_content,
     "other": contact_us_short_domestic,
 }
 
@@ -75,12 +88,10 @@ def should_see_form_choices(driver: WebDriver, names: List[str]):
     radio_selectors = get_selectors(SELECTORS["form"], ElementType.RADIO)
     for name in names:
         radio_selector = radio_selectors[name.lower()]
-        find_element(
-            driver, radio_selector, element_name=name, wait_for_it=False
-        )
+        find_element(driver, radio_selector, element_name=name, wait_for_it=False)
     logging.debug(
-        f"All expected form choices: '{names}' are visible on "
-        f"{driver.current_url}")
+        f"All expected form choices: '{names}' are visible on " f"{driver.current_url}"
+    )
 
 
 def pick_radio_option_and_submit(driver: WebDriver, name: str) -> ModuleType:

--- a/tests/browser/pages/exread/contact_us_triage_great_account.py
+++ b/tests/browser/pages/exread/contact_us_triage_great_account.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """Export Readiness - Domestic Contact us - Great.gov.uk account"""
 import logging
-from typing import List
 from types import ModuleType
-
+from typing import List
 from urllib.parse import urljoin
 
 from selenium.webdriver.common.by import By
@@ -13,13 +12,17 @@ from pages import ElementType
 from pages.common_actions import (
     Selector,
     check_url,
+    choose_one_form_option,
+    choose_one_form_option_except,
     find_element,
+    get_selectors,
     go_to_url,
     take_screenshot,
-    choose_one_form_option,
-    get_selectors,
 )
-from pages.exread import contact_us_short_domestic
+from pages.exread import (
+    contact_us_short_domestic,
+    contact_us_triage_great_account_dedicated_support_content,
+)
 from settings import EXRED_UI_URL
 
 NAME = "Great.gov.uk account"
@@ -41,6 +44,20 @@ SELECTORS = {
         "submit": SUBMIT_BUTTON,
         "back": Selector(By.CSS_SELECTOR, "form button[name='wizard_goto_step']", type=ElementType.LINK)
     }
+}
+
+POs = {
+    "i have not received an email confirmation":
+        contact_us_triage_great_account_dedicated_support_content,
+    "i need to reset my password":
+        contact_us_triage_great_account_dedicated_support_content,
+    "my companies house login is not working":
+        contact_us_triage_great_account_dedicated_support_content,
+    "i do not know where to enter my verification code":
+        contact_us_triage_great_account_dedicated_support_content,
+    "i have not received my letter containing the verification code":
+        contact_us_triage_great_account_dedicated_support_content,
+    "other": contact_us_short_domestic,
 }
 
 
@@ -74,12 +91,16 @@ def pick_radio_option_and_submit(driver: WebDriver, name: str) -> ModuleType:
     )
     button.click()
     take_screenshot(driver, "After submitting the form")
-    POs = {
-        "i have not received an email confirmation": None,
-        "i need to reset my password": None,
-        "my companies house login is not working": None,
-        "i do not know where to enter my verification code": None,
-        "i have not received my letter containing the verification code": None,
-        "other": contact_us_short_domestic,
-    }
     return POs[name.lower()]
+
+
+def pick_random_radio_option_and_submit(driver: WebDriver, ignored: List[str]):
+    radio_selectors = get_selectors(SELECTORS["form"], ElementType.RADIO)
+    selected = choose_one_form_option_except(driver, radio_selectors, ignored)
+    take_screenshot(driver, "Before submitting the form")
+    button = find_element(
+        driver, SUBMIT_BUTTON, element_name="Submit button", wait_for_it=False
+    )
+    button.click()
+    take_screenshot(driver, "After submitting the form")
+    return POs[selected.lower()]

--- a/tests/browser/pages/exread/contact_us_triage_great_account_dedicated_support_content.py
+++ b/tests/browser/pages/exread/contact_us_triage_great_account_dedicated_support_content.py
@@ -6,7 +6,13 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 
 from pages import ElementType
-from pages.common_actions import Selector, check_url, go_to_url, take_screenshot
+from pages.common_actions import (
+    Selector,
+    check_url,
+    find_and_click_on_page_element,
+    go_to_url,
+    take_screenshot,
+)
 from settings import EXRED_UI_URL
 
 NAME = "Great.gov.uk account"
@@ -66,3 +72,10 @@ def should_be_here(driver: WebDriver, *, page_name: str = None):
     take_screenshot(driver, NAME)
     url = URLs[page_name.lower()] if page_name else URL
     check_url(driver, url, exact_match=False)
+    msg = f"Got 404 on {driver.current_url}"
+    assert "This page cannot be found" not in driver.page_source, msg
+
+
+def click_on_page_element(driver: WebDriver, element_name: str):
+    find_and_click_on_page_element(driver, SELECTORS, element_name)
+    take_screenshot(driver, NAME + " after clicking on " + element_name)

--- a/tests/browser/pages/exread/contact_us_triage_great_account_dedicated_support_content.py
+++ b/tests/browser/pages/exread/contact_us_triage_great_account_dedicated_support_content.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""Export Readiness - Domestic Contact us - Great.gov.uk account"""
+from urllib.parse import urljoin
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from pages import ElementType
+from pages.common_actions import Selector, check_url, go_to_url, take_screenshot
+from settings import EXRED_UI_URL
+
+NAME = "Great.gov.uk account"
+NAMES = [
+    "I have not received an email confirmation",
+    "I need to reset my password",
+    "My Companies House login is not working",
+    "I do not know where to enter my verification code",
+    "I have not received my letter containing the verification code",
+]
+SERVICE = "Export Readiness"
+TYPE = "Dedicated Support Content"
+URL = urljoin(EXRED_UI_URL, "contact/triage/great-account/")
+PAGE_TITLE = "Welcome to great.gov.uk"
+
+URLs = {
+    "great.gov.uk account": URL,
+    "i have not received an email confirmation": urljoin(URL, "no-verification-email/"),
+    "i need to reset my password": urljoin(URL, "password-reset/"),
+    "my companies house login is not working": urljoin(URL, "companies-house-login/"),
+    "i do not know where to enter my verification code": urljoin(
+        URL, "verification-letter-code/"
+    ),
+    "i have not received my letter containing the verification code": urljoin(
+        URL, "no-verification-letter/"
+    ),
+}
+
+SUBMIT_BUTTON = Selector(
+    By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON
+)
+SELECTORS = {
+    "breadcrumbs": {
+        "itself": Selector(By.CSS_SELECTOR, "div.breadcrumbs"),
+        "links": Selector(By.CSS_SELECTOR, "div.breadcrumbs a"),
+    },
+    "support content": {
+        "itself": Selector(By.CSS_SELECTOR, "div.container section"),
+        "heading": Selector(By.CSS_SELECTOR, "section h1"),
+        "content": Selector(By.CSS_SELECTOR, "section p"),
+        "submit an enquiry": Selector(
+            By.CSS_SELECTOR, "#further-help-link > a", type=ElementType.LINK
+        ),
+    },
+    "error reporting": {
+        "itself": Selector(By.CSS_SELECTOR, "section.error-reporting"),
+        "link": Selector(By.ID, "error-reporting-section-contact-us"),
+    },
+}
+
+
+def visit(driver: WebDriver, *, first_time: bool = False):
+    go_to_url(driver, URL, NAME, first_time=first_time)
+
+
+def should_be_here(driver: WebDriver, *, page_name: str = None):
+    take_screenshot(driver, NAME)
+    url = URLs[page_name.lower()] if page_name else URL
+    check_url(driver, url, exact_match=False)

--- a/tests/browser/pages/exread/contact_us_triage_great_services.py
+++ b/tests/browser/pages/exread/contact_us_triage_great_services.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""Export Readiness - Domestic Contact us - Great.gov.uk account and services support"""
+import logging
+from typing import List
+from types import ModuleType
+
+from urllib.parse import urljoin
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from pages import ElementType
+from pages.common_actions import (
+    Selector,
+    check_url,
+    find_element,
+    go_to_url,
+    take_screenshot,
+    choose_one_form_option,
+    get_selectors,
+)
+from pages.exread import (
+    contact_us_triage_export_opportunities,
+    contact_us_triage_great_account,
+)
+from settings import EXRED_UI_URL
+
+NAME = "Great.gov.uk account and services support"
+SERVICE = "Export Readiness"
+TYPE = "Domestic Contact us"
+URL = urljoin(EXRED_UI_URL, "contact/triage/great-services/")
+PAGE_TITLE = "Welcome to great.gov.uk"
+
+SUBMIT_BUTTON = Selector(By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON)
+SELECTORS = {
+    "form": {
+        "itself": Selector(By.CSS_SELECTOR, "#lede form"),
+        "export opportunities service": Selector(By.ID, "id_great-services-choice_0", type=ElementType.RADIO, is_visible=False),
+        "your account on great.gov.uk": Selector(By.ID, "id_great-services-choice_1", type=ElementType.RADIO, is_visible=False),
+        "other": Selector(By.ID, "id_great-services-choice_2", type=ElementType.RADIO, is_visible=False),
+        "submit": SUBMIT_BUTTON,
+        "back": Selector(By.CSS_SELECTOR, "form button[name='wizard_goto_step']", type=ElementType.LINK)
+    }
+}
+
+
+def visit(driver: WebDriver, *, first_time: bool = False):
+    go_to_url(driver, URL, NAME, first_time=first_time)
+
+
+def should_be_here(driver: WebDriver):
+    take_screenshot(driver, NAME)
+    check_url(driver, URL)
+
+
+def should_see_form_choices(driver: WebDriver, names: List[str]):
+    radio_selectors = get_selectors(SELECTORS["form"], ElementType.RADIO)
+    for name in names:
+        radio_selector = radio_selectors[name.lower()]
+        find_element(
+            driver, radio_selector, element_name=name, wait_for_it=False
+        )
+    logging.debug(
+        f"All expected form choices: '{names}' are visible on "
+        f"{driver.current_url}")
+
+
+def pick_radio_option_and_submit(driver: WebDriver, name: str) -> ModuleType:
+    radio_selectors = get_selectors(SELECTORS["form"], ElementType.RADIO)
+    choose_one_form_option(driver, radio_selectors, name)
+    take_screenshot(driver, "Before submitting the form")
+    button = find_element(
+        driver, SUBMIT_BUTTON, element_name="Submit button", wait_for_it=False
+    )
+    button.click()
+    take_screenshot(driver, "After submitting the form")
+    POs = {
+        "export opportunities service": contact_us_triage_export_opportunities,
+        "your account on great.gov.uk": contact_us_triage_great_account,
+        "other": None,
+    }
+    return POs[name.lower()]

--- a/tests/browser/pages/exread/contact_us_triage_great_services.py
+++ b/tests/browser/pages/exread/contact_us_triage_great_services.py
@@ -13,11 +13,12 @@ from pages import ElementType
 from pages.common_actions import (
     Selector,
     check_url,
+    choose_one_form_option,
+    find_and_click_on_page_element,
     find_element,
+    get_selectors,
     go_to_url,
     take_screenshot,
-    choose_one_form_option,
-    get_selectors,
 )
 from pages.exread import (
     contact_us_triage_export_opportunities,
@@ -80,3 +81,8 @@ def pick_radio_option_and_submit(driver: WebDriver, name: str) -> ModuleType:
         "other": None,
     }
     return POs[name.lower()]
+
+
+def click_on_page_element(driver: WebDriver, element_name: str):
+    find_and_click_on_page_element(driver, SELECTORS, element_name)
+    take_screenshot(driver, NAME + " after clicking on " + element_name)

--- a/tests/browser/pages/exread/contact_us_triage_great_services.py
+++ b/tests/browser/pages/exread/contact_us_triage_great_services.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """Export Readiness - Domestic Contact us - Great.gov.uk account and services support"""
 import logging
-from typing import List
 from types import ModuleType
-
+from typing import List
 from urllib.parse import urljoin
 
 from selenium.webdriver.common.by import By
@@ -32,15 +31,36 @@ TYPE = "Domestic Contact us"
 URL = urljoin(EXRED_UI_URL, "contact/triage/great-services/")
 PAGE_TITLE = "Welcome to great.gov.uk"
 
-SUBMIT_BUTTON = Selector(By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON)
+SUBMIT_BUTTON = Selector(
+    By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON
+)
 SELECTORS = {
     "form": {
         "itself": Selector(By.CSS_SELECTOR, "#lede form"),
-        "export opportunities service": Selector(By.ID, "id_great-services-choice_0", type=ElementType.RADIO, is_visible=False),
-        "your account on great.gov.uk": Selector(By.ID, "id_great-services-choice_1", type=ElementType.RADIO, is_visible=False),
-        "other": Selector(By.ID, "id_great-services-choice_2", type=ElementType.RADIO, is_visible=False),
+        "export opportunities service": Selector(
+            By.ID,
+            "id_great-services-choice_0",
+            type=ElementType.RADIO,
+            is_visible=False,
+        ),
+        "your account on great.gov.uk": Selector(
+            By.ID,
+            "id_great-services-choice_1",
+            type=ElementType.RADIO,
+            is_visible=False,
+        ),
+        "other": Selector(
+            By.ID,
+            "id_great-services-choice_2",
+            type=ElementType.RADIO,
+            is_visible=False,
+        ),
         "submit": SUBMIT_BUTTON,
-        "back": Selector(By.CSS_SELECTOR, "form button[name='wizard_goto_step']", type=ElementType.LINK)
+        "back": Selector(
+            By.CSS_SELECTOR,
+            "form button[name='wizard_goto_step']",
+            type=ElementType.LINK,
+        ),
     }
 }
 
@@ -58,12 +78,10 @@ def should_see_form_choices(driver: WebDriver, names: List[str]):
     radio_selectors = get_selectors(SELECTORS["form"], ElementType.RADIO)
     for name in names:
         radio_selector = radio_selectors[name.lower()]
-        find_element(
-            driver, radio_selector, element_name=name, wait_for_it=False
-        )
+        find_element(driver, radio_selector, element_name=name, wait_for_it=False)
     logging.debug(
-        f"All expected form choices: '{names}' are visible on "
-        f"{driver.current_url}")
+        f"All expected form choices: '{names}' are visible on " f"{driver.current_url}"
+    )
 
 
 def pick_radio_option_and_submit(driver: WebDriver, name: str) -> ModuleType:

--- a/tests/browser/pages/exread/contact_us_triage_international.py
+++ b/tests/browser/pages/exread/contact_us_triage_international.py
@@ -20,10 +20,10 @@ from pages.common_actions import (
     take_screenshot,
 )
 from pages.exread import (
-    contact_us_short_domestic,
     international_contact_us,
     international_eu_exit_contact_us,
 )
+from pages.fas import contact_us as fas_contact_us
 from pages.invest import contact_us as invest_contact_us
 from settings import EXRED_UI_URL
 
@@ -61,7 +61,7 @@ SELECTORS = {
 }
 POs = {
     "investing in the uk": invest_contact_us,
-    "buying from the uk": contact_us_short_domestic,
+    "buying from the uk": fas_contact_us,
     "eu exit": international_eu_exit_contact_us,
     "other": international_contact_us,
 }

--- a/tests/browser/pages/exread/contact_us_triage_international.py
+++ b/tests/browser/pages/exread/contact_us_triage_international.py
@@ -40,16 +40,16 @@ SELECTORS = {
     "form": {
         "itself": Selector(By.CSS_SELECTOR, "#lede form"),
         "investing in the uk": Selector(
-            By.ID, "id_international-choice_0", type=ElementType.RADIO, is_visible=False
+            By.CSS_SELECTOR, "input[value='investing']", type=ElementType.RADIO, is_visible=False
         ),
         "buying from the uk": Selector(
-            By.ID, "id_international-choice_1", type=ElementType.RADIO, is_visible=False
+            By.CSS_SELECTOR, "input[value='buying']", type=ElementType.RADIO, is_visible=False
         ),
         "eu exit": Selector(
-            By.ID, "id_international-choice_2", type=ElementType.RADIO, is_visible=False
+            By.CSS_SELECTOR, "input[value='eu-exit']", type=ElementType.RADIO, is_visible=False
         ),
         "other": Selector(
-            By.ID, "id_international-choice_3", type=ElementType.RADIO, is_visible=False
+            By.CSS_SELECTOR, "input[value='other']", type=ElementType.RADIO, is_visible=False
         ),
         "submit": SUBMIT_BUTTON,
         "back": Selector(

--- a/tests/browser/pages/exread/contact_us_triage_international.py
+++ b/tests/browser/pages/exread/contact_us_triage_international.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """Export Readiness - International Contact us - What would you like to know more about?"""
 import logging
-from typing import List
 from types import ModuleType
-
+from typing import List
 from urllib.parse import urljoin
 
 from selenium.webdriver.common.by import By
@@ -20,6 +19,11 @@ from pages.common_actions import (
     go_to_url,
     take_screenshot,
 )
+from pages.exread import (
+    contact_us_short_domestic,
+    international_contact_us,
+    international_eu_exit_contact_us,
+)
 from pages.invest import contact_us as invest_contact_us
 from settings import EXRED_UI_URL
 
@@ -29,17 +33,37 @@ TYPE = "International Contact us"
 URL = urljoin(EXRED_UI_URL, "contact/triage/international/")
 PAGE_TITLE = "Welcome to great.gov.uk"
 
-SUBMIT_BUTTON = Selector(By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON)
+SUBMIT_BUTTON = Selector(
+    By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON
+)
 SELECTORS = {
     "form": {
         "itself": Selector(By.CSS_SELECTOR, "#lede form"),
-        "investing in the uk": Selector(By.ID, "id_international-choice_0", type=ElementType.RADIO, is_visible=False),
-        "buying from the uk": Selector(By.ID, "id_international-choice_1", type=ElementType.RADIO, is_visible=False),
-        "eu exit": Selector(By.ID, "id_international-choice_2", type=ElementType.RADIO, is_visible=False),
-        "other": Selector(By.ID, "id_international-choice_3", type=ElementType.RADIO, is_visible=False),
+        "investing in the uk": Selector(
+            By.ID, "id_international-choice_0", type=ElementType.RADIO, is_visible=False
+        ),
+        "buying from the uk": Selector(
+            By.ID, "id_international-choice_1", type=ElementType.RADIO, is_visible=False
+        ),
+        "eu exit": Selector(
+            By.ID, "id_international-choice_2", type=ElementType.RADIO, is_visible=False
+        ),
+        "other": Selector(
+            By.ID, "id_international-choice_3", type=ElementType.RADIO, is_visible=False
+        ),
         "submit": SUBMIT_BUTTON,
-        "back": Selector(By.CSS_SELECTOR, "form button[name='wizard_goto_step']", type=ElementType.LINK)
+        "back": Selector(
+            By.CSS_SELECTOR,
+            "form button[name='wizard_goto_step']",
+            type=ElementType.LINK,
+        ),
     }
+}
+POs = {
+    "investing in the uk": invest_contact_us,
+    "buying from the uk": contact_us_short_domestic,
+    "eu exit": international_eu_exit_contact_us,
+    "other": international_contact_us,
 }
 
 
@@ -56,12 +80,10 @@ def should_see_form_choices(driver: WebDriver, names: List[str]):
     radio_selectors = get_selectors(SELECTORS["form"], ElementType.RADIO)
     for name in names:
         radio_selector = radio_selectors[name.lower()]
-        find_element(
-            driver, radio_selector, element_name=name, wait_for_it=False
-        )
+        find_element(driver, radio_selector, element_name=name, wait_for_it=False)
     logging.debug(
-        f"All expected form choices: '{names}' are visible on "
-        f"{driver.current_url}")
+        f"All expected form choices: '{names}' are visible on " f"{driver.current_url}"
+    )
 
 
 def pick_radio_option_and_submit(driver: WebDriver, name: str) -> ModuleType:
@@ -73,10 +95,7 @@ def pick_radio_option_and_submit(driver: WebDriver, name: str) -> ModuleType:
     )
     button.click()
     take_screenshot(driver, "After submitting the form")
-    if name.lower() == "investing in the uk":
-        return invest_contact_us
-    else:
-        return None
+    return POs[name.lower()]
 
 
 def click_on_page_element(driver: WebDriver, element_name: str):

--- a/tests/browser/pages/exread/contact_us_triage_international.py
+++ b/tests/browser/pages/exread/contact_us_triage_international.py
@@ -13,11 +13,12 @@ from pages import ElementType
 from pages.common_actions import (
     Selector,
     check_url,
+    choose_one_form_option,
+    find_and_click_on_page_element,
     find_element,
+    get_selectors,
     go_to_url,
     take_screenshot,
-    choose_one_form_option,
-    get_selectors,
 )
 from pages.invest import contact_us as invest_contact_us
 from settings import EXRED_UI_URL
@@ -76,3 +77,8 @@ def pick_radio_option_and_submit(driver: WebDriver, name: str) -> ModuleType:
         return invest_contact_us
     else:
         return None
+
+
+def click_on_page_element(driver: WebDriver, element_name: str):
+    find_and_click_on_page_element(driver, SELECTORS, element_name)
+    take_screenshot(driver, NAME + " after clicking on " + element_name)

--- a/tests/browser/pages/exread/contact_us_triage_location.py
+++ b/tests/browser/pages/exread/contact_us_triage_location.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """Export Readiness - Contact us - Triage location"""
 import logging
-from typing import List
 from types import ModuleType
-
+from typing import List
 from urllib.parse import urljoin
 
 from selenium.webdriver.common.by import By
@@ -13,16 +12,13 @@ from pages import ElementType
 from pages.common_actions import (
     Selector,
     check_url,
+    choose_one_form_option,
     find_element,
+    get_selectors,
     go_to_url,
     take_screenshot,
-    choose_one_form_option,
-    get_selectors,
 )
-from pages.exread import (
-    contact_us_triage_domestic,
-    contact_us_triage_international,
-)
+from pages.exread import contact_us_triage_domestic, contact_us_triage_international
 from settings import EXRED_UI_URL
 
 NAME = "Contact Us"
@@ -31,14 +27,24 @@ TYPE = "Contact us"
 URL = urljoin(EXRED_UI_URL, "contact/triage/location/")
 PAGE_TITLE = "Welcome to great.gov.uk"
 
-THE_UK = Selector(By.ID, "id_location-choice_0", type=ElementType.RADIO, is_visible=False)
-OUTSIDE_THE_UK = Selector(By.ID, "id_location-choice_1", type=ElementType.RADIO, is_visible=False)
-SUBMIT_BUTTON = Selector(By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON)
+THE_UK = Selector(
+    By.ID, "id_location-choice_0", type=ElementType.RADIO, is_visible=False
+)
+OUTSIDE_THE_UK = Selector(
+    By.ID, "id_location-choice_1", type=ElementType.RADIO, is_visible=False
+)
+SUBMIT_BUTTON = Selector(
+    By.CSS_SELECTOR, "form button[type=submit]", type=ElementType.BUTTON
+)
 SELECTORS = {
     "form": {
         "itself": Selector(By.CSS_SELECTOR, "#lede form"),
-        "the uk": Selector(By.ID, "id_location-choice_0", type=ElementType.RADIO, is_visible=False),
-        "outside the uk": Selector(By.ID, "id_location-choice_1", type=ElementType.RADIO, is_visible=False),
+        "the uk": Selector(
+            By.ID, "id_location-choice_0", type=ElementType.RADIO, is_visible=False
+        ),
+        "outside the uk": Selector(
+            By.ID, "id_location-choice_1", type=ElementType.RADIO, is_visible=False
+        ),
         "submit": SUBMIT_BUTTON,
     }
 }
@@ -57,12 +63,10 @@ def should_see_form_choices(driver: WebDriver, names: List[str]):
     radio_selectors = get_selectors(SELECTORS["form"], ElementType.RADIO)
     for name in names:
         radio_selector = radio_selectors[name.lower()]
-        find_element(
-            driver, radio_selector, element_name=name, wait_for_it=False
-        )
+        find_element(driver, radio_selector, element_name=name, wait_for_it=False)
     logging.debug(
-        f"All expected form choices: '{names}' are visible on "
-        f"{driver.current_url}")
+        f"All expected form choices: '{names}' are visible on " f"{driver.current_url}"
+    )
 
 
 def pick_radio_option_and_submit(driver: WebDriver, name: str) -> ModuleType:

--- a/tests/browser/pages/exread/domestic_eu_exit_contact_us.py
+++ b/tests/browser/pages/exread/domestic_eu_exit_contact_us.py
@@ -9,19 +9,19 @@ from selenium.webdriver.remote.webdriver import WebDriver
 
 from pages import ElementType
 from pages.common_actions import (
+    Actor,
+    AssertionExecutor,
     Selector,
+    check_for_sections,
     check_url,
+    fill_out_input_fields,
+    fill_out_textarea_fields,
     find_element,
     go_to_url,
-    take_screenshot,
-    check_for_sections,
-    AssertionExecutor,
-    Actor,
-    fill_out_textarea_fields,
-    tick_checkboxes,
-    tick_captcha_checkbox,
-    fill_out_input_fields,
     pick_option,
+    take_screenshot,
+    tick_captcha_checkbox,
+    tick_checkboxes,
 )
 from settings import EXRED_UI_URL
 
@@ -34,9 +34,7 @@ PAGE_TITLE = ""
 
 SUBMIT_BUTTON = Selector(By.CSS_SELECTOR, "form button")
 SELECTORS = {
-    "header bar": {
-        "itself": Selector(By.ID, "header-bar"),
-    },
+    "header bar": {"itself": Selector(By.ID, "header-bar")},
     "header menu": {
         "itself": Selector(By.ID, "header-menu"),
         "logo": Selector(By.ID, "header-logo"),
@@ -44,22 +42,23 @@ SELECTORS = {
     },
     "heading": {
         "itself": Selector(By.CSS_SELECTOR, "#content h1"),
-        "text": Selector(By.CSS_SELECTOR, "#content p.body-text")
+        "text": Selector(By.CSS_SELECTOR, "#content p.body-text"),
     },
     "form": {
         "itself": Selector(By.CSS_SELECTOR, "#content form"),
-        "fist name": Selector(By.ID, "id_first_name", type=ElementType.INPUT),
+        "first name": Selector(By.ID, "id_first_name", type=ElementType.INPUT),
         "last name": Selector(By.ID, "id_last_name", type=ElementType.INPUT),
         "email": Selector(By.ID, "id_email", type=ElementType.INPUT),
-        "company": Selector(By.ID, "id_organisation_type_0", type=ElementType.CHECKBOX, is_visible=False),
-        "other type of organisation": Selector(By.ID, "id_organisation_type_0", type=ElementType.CHECKBOX, is_visible=False),
+        "company": Selector(
+            By.ID, "id_organisation_type_0", type=ElementType.CHECKBOX, is_visible=False
+        ),
+        "other type of organisation": Selector(
+            By.ID, "id_organisation_type_0", type=ElementType.CHECKBOX, is_visible=False
+        ),
         "company name": Selector(By.ID, "id_company_name", type=ElementType.INPUT),
         "your question": Selector(By.ID, "id_comment", type=ElementType.TEXTAREA),
         "terms and conditions": Selector(
-            By.ID,
-            "id_terms_agreed",
-            type=ElementType.CHECKBOX,
-            is_visible=False,
+            By.ID, "id_terms_agreed", type=ElementType.CHECKBOX, is_visible=False
         ),
         "submit": SUBMIT_BUTTON,
     },

--- a/tests/browser/pages/exread/domestic_eu_exit_contact_us_thank_you.py
+++ b/tests/browser/pages/exread/domestic_eu_exit_contact_us_thank_you.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Export Readiness - Domestic EU Exit Contact us - Thank you for your enquiry."""
+import logging
+from urllib.parse import urljoin
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from pages.common_actions import (
+    Selector,
+    check_url,
+    take_screenshot,
+)
+from settings import EXRED_UI_URL
+
+NAME = "Thank you for your enquiry"
+SERVICE = "Export Readiness"
+TYPE = "Domestic EU Exit Contact us"
+URL = urljoin(EXRED_UI_URL, "eu-exit-news/contact/success/")
+PAGE_TITLE = "Welcome to great.gov.uk"
+
+PDF_LINKS = Selector(By.CSS_SELECTOR, "#documents-section a.link")
+SELECTORS = {
+    "beta bar": {
+        "self": Selector(By.ID, "header-beta-bar"),
+        "beta bar": Selector(By.CSS_SELECTOR, "#header-beta-bar strong"),
+        "feedback": Selector(By.CSS_SELECTOR, "#header-beta-bar a"),
+    },
+    "confirmation": {
+        "itself": Selector(By.ID, "confirmation-section"),
+        "heading": Selector(
+            By.CSS_SELECTOR, "#confirmation-section div.heading-container"
+        ),
+    },
+    "report this page": {
+        "self": Selector(By.CSS_SELECTOR, "section.error-reporting"),
+        "report link": Selector(By.CSS_SELECTOR, "section.error-reporting a"),
+    },
+}
+
+
+def should_be_here(driver: WebDriver):
+    take_screenshot(driver, PAGE_TITLE)
+    check_url(driver, URL, exact_match=True)
+    logging.debug(f"All expected elements are visible on '{URL}'")

--- a/tests/browser/pages/exread/guidance_common.py
+++ b/tests/browser/pages/exread/guidance_common.py
@@ -78,7 +78,7 @@ SELECTORS = {
 }
 
 
-def should_be_here(driver: WebDriver):
+def should_be_here(driver: WebDriver, *, page_name: str):
     take_screenshot(driver, PAGE_TITLE)
     check_url(driver, URL, exact_match=False)
     logging.debug("All expected elements are visible on '%s' page", PAGE_TITLE)

--- a/tests/browser/pages/exread/header.py
+++ b/tests/browser/pages/exread/header.py
@@ -60,7 +60,7 @@ SELECTORS = {
     "services": {
         "menu": Selector(By.ID, "header-services-links"),
         "find a buyer": Selector(By.ID, "header-services-find-a-buyer"),
-        "selling online overseas": Selector(By.ID, "header-services-"),
+        "selling online overseas": Selector(By.ID, "header-services-selling-online-overseas"),
         "export opportunities": Selector(By.ID, "header-services-export-opportunities"),
         "get finance": Selector(By.ID, "header-services-get-finance"),
         "events": Selector(By.ID, "header-services-events"),

--- a/tests/browser/pages/exread/home.py
+++ b/tests/browser/pages/exread/home.py
@@ -45,12 +45,12 @@ CONTINUE_EXPORT_JOURNEY = Selector(By.ID, "triage-section-continue-your-journey"
 NEW_TO_EXPORTING_LINK = Selector(By.ID, "personas-section-new")
 OCCASIONAL_EXPORTER_LINK = Selector(By.ID, "personas-section-occasional")
 REGULAR_EXPORTED_LINK = Selector(By.ID, "personas-section-regular")
-FIND_A_BUYER_SERVICE_LINK = Selector(By.CSS_SELECTOR, "#services-section-find-a-buyer a")
+FIND_A_BUYER_SERVICE_LINK = Selector(By.ID, "services-section-find-a-buyer-link")
 SELLING_ONLINE_OVERSEAS_SERVICE_LINK = Selector(
-    By.CSS_SELECTOR, "#services-section-selling-online-overseas a"
+    By.ID, "services-section-selling-online-overseas-link"
 )
 EXPORT_OPPORTUNITIES_SERVICE_LINK = Selector(
-    By.CSS_SELECTOR, "#services-section-export-opportunities a"
+    By.ID, "services-section-export-opportunities-link"
 )
 CAROUSEL_INDICATORS_SECTION = Selector(
     By.CSS_SELECTOR, "#carousel  div.ed-carousel__indicators"

--- a/tests/browser/pages/exread/home.py
+++ b/tests/browser/pages/exread/home.py
@@ -116,14 +116,14 @@ SELECTORS = {
         "link": Selector(By.CSS_SELECTOR, "#header-beta-bar a"),
     },
     "hero": {
-        "itself": Selector(By.CSS_SELECTOR, "#content > section.hero"),
+        "itself": Selector(By.CSS_SELECTOR, "section.hero-campaign-section"),
         "title": Selector(By.ID, "hero-campaign-section-title"),
         "description": Selector(By.ID, "hero-campaign-section-description"),
         "logo": Selector(By.ID, "hero-campaign-section-eig-logo"),
         "watch video": Selector(By.ID, "hero-campaign-section-watch-video-button"),
     },
     "exporting journey": {
-        "itself": Selector(By.ID, "triage"),
+        "itself": Selector(By.CSS_SELECTOR, "section.triage"),
         "heading": Selector(By.ID, "triage-section-title"),
         "introduction": Selector(By.ID, "triage-section-description"),
         "get_started_button": GET_STARTED_BUTTON,
@@ -156,7 +156,7 @@ SELECTORS = {
         "itself": Selector(By.ID, "resource-guidance"),
         "title": Selector(By.ID, "guidance-section-title"),
         "description": Selector(By.ID, "guidance-section-description"),
-        "groups": Selector(By.CSS_SELECTOR, "#resource-guidance .card-grid"),
+        "groups": Selector(By.CSS_SELECTOR, "#resource-guidance .resources"),
         "market research - group": Selector(By.ID, "guidance-section-market-research"),
         "customer insight - group": Selector(
             By.ID, "guidance-section-customer-insight"
@@ -184,7 +184,7 @@ SELECTORS = {
             By.ID, "guidance-section-operations-and-compliance-icon"
         ),
         "market research - description": Selector(
-            By.CSS_SELECTOR, "#guidance-section-market-research-link p"
+            By.CSS_SELECTOR, "#guidance-market-research-link p"
         ),
         "customer insight - description": Selector(
             By.CSS_SELECTOR, "#guidance-section-customer-insight-link p"
@@ -212,25 +212,25 @@ SELECTORS = {
         "itself": Selector(By.ID, "services"),
         "title": Selector(By.ID, "services-section-title"),
         "description": Selector(By.ID, "services-section-description"),
-        "groups": Selector(By.CSS_SELECTOR, "#services .card-grid"),
+        "groups": Selector(By.CSS_SELECTOR, "#services .service-teaser"),
         "find a buyer": FIND_A_BUYER_SERVICE_LINK,
         "find a buyer - image": Selector(By.ID, "services-section-find-a-buyer-image"),
         "find a buyer - description": Selector(
-            By.CSS_SELECTOR, "#services-section-find-a-buyer a h3 ~ p"
+            By.ID, "services-section-find-a-buyer-description"
         ),
         "selling online overseas": SELLING_ONLINE_OVERSEAS_SERVICE_LINK,
         "selling online overseas - image": Selector(
             By.ID, "services-section-selling-online-overseas-image"
         ),
         "selling online overseas - description": Selector(
-            By.CSS_SELECTOR, "#services-section-selling-online-overseas a h3 ~ p"
+            By.ID, "services-section-selling-online-overseas-description"
         ),
         "export opportunities": EXPORT_OPPORTUNITIES_SERVICE_LINK,
         "export opportunities - image": Selector(
             By.ID, "services-section-export-opportunities-image"
         ),
         "export opportunities - description": Selector(
-            By.CSS_SELECTOR, "#services-section-export-opportunities a h3 ~ p"
+            By.ID, "services-section-export-opportunities-description"
         ),
     },
     "case studies": {

--- a/tests/browser/pages/exread/home.py
+++ b/tests/browser/pages/exread/home.py
@@ -71,7 +71,7 @@ CASE_STUDIES_LINK = Selector(By.CSS_SELECTOR, "#carousel h3 > a")
 CASE_STUDY_LINK = Selector(
     By.CSS_SELECTOR, "#carousel div.ed-carousel__slide:nth-child({}) h3 > a"
 )
-MARKET_RESEARCH_LINK = Selector(By.ID, "guidance-section-market-research-link")
+MARKET_RESEARCH_LINK = Selector(By.ID, "guidance-market-research-link")
 CUSTOMER_INSIGHT_LINK = Selector(By.ID, "guidance-section-customer-insight-link")
 FINANCE_LINK = Selector(By.ID, "guidance-section-finance-link")
 BUSINESS_LINK = Selector(By.ID, "guidance-section-business-planning-link")

--- a/tests/browser/pages/external/office_finder.py
+++ b/tests/browser/pages/external/office_finder.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""Existing Office Finder - Home Page Object."""
+import logging
+
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from pages.common_actions import check_url, take_screenshot
+
+NAME = "Home"
+SERVICE = "EXISTING Office Finder"
+TYPE = "home"
+URL = "https://www.contactus.trade.gov.uk/office-finder"
+SELECTORS = {}
+
+
+def should_be_here(driver: WebDriver):
+    take_screenshot(driver, NAME)
+    check_url(driver, URL, exact_match=False)
+    logging.debug(f"Actor got to the expected page: {URL}")

--- a/tests/browser/pages/fas/industry.py
+++ b/tests/browser/pages/fas/industry.py
@@ -122,7 +122,7 @@ def visit(driver: WebDriver, *, first_time: bool = False, page_name: str = None)
     go_to_url(driver, url, NAME, first_time=first_time)
 
 
-def should_be_here(driver: WebDriver):
+def should_be_here(driver: WebDriver, *, page_name: str):
     take_screenshot(driver, NAME)
     check_url(driver, URL, exact_match=False)
     logging.debug("All expected elements are visible on '%s' page", NAME)

--- a/tests/browser/pages/invest/feedback.py
+++ b/tests/browser/pages/invest/feedback.py
@@ -14,7 +14,7 @@ from settings import DIRECTORY_CONTACT_US_UI_URL
 NAME = "Feedback"
 SERVICE = "invest"
 TYPE = "contact"
-URL = urljoin(DIRECTORY_CONTACT_US_UI_URL, "directory/")
+URL = urljoin(DIRECTORY_CONTACT_US_UI_URL, "triage/location/")
 PAGE_TITLE = "Contact us - great.gov.uk"
 SELECTORS = {}
 

--- a/tests/browser/pages/invest/hpo.py
+++ b/tests/browser/pages/invest/hpo.py
@@ -198,7 +198,7 @@ def visit(
     visit_url(executor, url)
 
 
-def should_be_here(executor: Executor):
+def should_be_here(executor: Executor, *, page_name: str):
     take_screenshot(executor, PAGE_TITLE)
     check_url(executor, URL, exact_match=False)
     logging.debug("All expected elements are visible on '%s' page", PAGE_TITLE)

--- a/tests/browser/pages/invest/hpo_contact_us.py
+++ b/tests/browser/pages/invest/hpo_contact_us.py
@@ -143,7 +143,7 @@ def visit(
     visit_url(executor, url)
 
 
-def should_be_here(executor: Executor):
+def should_be_here(executor: Executor, *, page_name: str):
     take_screenshot(executor, PAGE_TITLE)
     check_url(executor, URL, exact_match=False)
     logging.debug("All expected elements are visible on '%s' page", NAME)

--- a/tests/browser/pages/invest/hpo_contact_us_thank_you.py
+++ b/tests/browser/pages/invest/hpo_contact_us_thank_you.py
@@ -72,7 +72,7 @@ UNEXPECTED_ELEMENTS = {
 }
 
 
-def should_be_here(executor: Executor):
+def should_be_here(executor: Executor, *, page_name: str):
     take_screenshot(executor, PAGE_TITLE)
     check_url(executor, URL, exact_match=False)
     logging.debug("All expected elements are visible on '%s' page", NAME)

--- a/tests/browser/pages/invest/industry.py
+++ b/tests/browser/pages/invest/industry.py
@@ -175,7 +175,7 @@ def visit(
     visit_url(executor, url)
 
 
-def should_be_here(executor: Executor):
+def should_be_here(executor: Executor, *, page_name: str):
     take_screenshot(executor, PAGE_TITLE)
     check_url(executor, URL, exact_match=False)
     logging.debug("All expected elements are visible on '%s' page", PAGE_TITLE)

--- a/tests/browser/pages/invest/region.py
+++ b/tests/browser/pages/invest/region.py
@@ -102,7 +102,7 @@ def visit(
     visit_url(executor, url)
 
 
-def should_be_here(executor: Executor):
+def should_be_here(executor: Executor, *, page_name: str):
     take_screenshot(executor, PAGE_TITLE)
     check_url(executor, URL, exact_match=False)
     logging.debug("All expected elements are visible on '%s' page", PAGE_TITLE)

--- a/tests/browser/pages/invest/uk_setup_guide_pages.py
+++ b/tests/browser/pages/invest/uk_setup_guide_pages.py
@@ -100,7 +100,7 @@ def visit(
     visit_url(executor, url)
 
 
-def should_be_here(executor: Executor):
+def should_be_here(executor: Executor, *, page_name: str):
     take_screenshot(executor, PAGE_TITLE)
     check_url(executor, URL, exact_match=False)
     logging.debug("All expected elements are visible on '%s' page", PAGE_TITLE)

--- a/tests/browser/steps/__init__.py
+++ b/tests/browser/steps/__init__.py
@@ -2,7 +2,4 @@ from types import ModuleType
 
 
 def has_action(page: ModuleType, name: str):
-    assert hasattr(page, name), (
-        f"{page.SERVICE} - {page.NAME} has no '{name}' action"
-    )
-
+    assert hasattr(page, name), f"{page.__name__} has no '{name}' action"

--- a/tests/browser/steps/given_def.py
+++ b/tests/browser/steps/given_def.py
@@ -20,10 +20,13 @@ from steps.when_impl import (
     articles_show_all,
     case_studies_go_to_random,
     click_on_page_element,
+    contact_us_get_to_page_via,
     export_readiness_open_category,
     generic_at_least_n_news_articles,
     generic_get_in_touch,
+    generic_open_any_news_article,
     generic_open_industry_page,
+    generic_open_random_news_article,
     get_geo_ip,
     guidance_open_category,
     guidance_open_random_category,
@@ -35,8 +38,6 @@ from steps.when_impl import (
     triage_classify_as,
     triage_create_exporting_journey,
     visit_page,
-    generic_open_any_news_article,
-    generic_open_random_news_article
 )
 
 
@@ -256,3 +257,9 @@ def given_actor_opens_any_news_article(context, actor_alias):
 def given_actor_opened_random_news_article(
         context: Context, actor_alias: str, article_type: str):
     generic_open_random_news_article(context, actor_alias, article_type)
+
+
+@given('"{actor_alias}" got to the "{final_page}" page via "{via}"')
+def given_actor_gets_to_a_page_via(
+        context: Context, actor_alias: str, final_page: str, via: str):
+    contact_us_get_to_page_via(context, actor_alias, final_page, via)

--- a/tests/browser/steps/given_def.py
+++ b/tests/browser/steps/given_def.py
@@ -38,6 +38,7 @@ from steps.when_impl import (
     triage_classify_as,
     triage_create_exporting_journey,
     visit_page,
+    contact_us_navigate_through_options
 )
 
 

--- a/tests/browser/steps/given_def.py
+++ b/tests/browser/steps/given_def.py
@@ -264,3 +264,9 @@ def given_actor_opened_random_news_article(
 def given_actor_gets_to_a_page_via(
         context: Context, actor_alias: str, final_page: str, via: str):
     contact_us_get_to_page_via(context, actor_alias, final_page, via)
+
+
+@given('"{actor_alias}" navigates via "{via}"')
+def given_actor_navigates_via_contact_us_options(
+        context: Context, actor_alias: str, via: str):
+    contact_us_navigate_through_options(context, actor_alias, via)

--- a/tests/browser/steps/then_def.py
+++ b/tests/browser/steps/then_def.py
@@ -23,6 +23,7 @@ from steps.then_impl import (
     articles_should_see_time_to_complete_decrease,
     articles_total_number_of_articles_should_not_change,
     case_studies_should_see_case_study,
+    eu_exit_contact_us_should_receive_confirmation_email,
     expected_page_elements_should_not_be_visible_on_get_finance,
     export_readiness_expected_page_elements_should_be_visible,
     export_readiness_should_see_articles,
@@ -30,6 +31,7 @@ from steps.then_impl import (
     form_check_state_of_element,
     form_should_see_error_messages,
     generic_should_see_expected_page_content,
+    generic_should_see_form_choices,
     guidance_check_if_link_to_next_category_is_displayed,
     guidance_expected_page_elements_should_be_visible,
     guidance_ribbon_should_be_visible,
@@ -61,6 +63,7 @@ from steps.then_impl import (
     should_be_on_page,
     should_be_on_page_or_international_page,
     should_not_see_sections,
+    should_see_articles_filtered_by_tag,
     should_see_links_to_services,
     should_see_page_in_preferred_language,
     should_see_sections,
@@ -69,9 +72,6 @@ from steps.then_impl import (
     stats_and_tracking_elements_should_not_be_present,
     triage_should_be_classified_as,
     triage_should_see_change_your_answers_link,
-    zendesk_should_receive_confirmation_email,
-    should_see_articles_filtered_by_tag,
-    eu_exit_contact_us_should_receive_confirmation_email
 )
 from steps.when_impl import (
     triage_answer_questions_again,
@@ -458,3 +458,8 @@ def then_should_see_an_error_message(context: Context, actor_alias: str):
 @then('"{actor_alias}" should see list of news articles filtered by selected tag')
 def then_should_see_articles_filtered_by_tag(context: Context, actor_alias: str):
     should_see_articles_filtered_by_tag(context, actor_alias)
+
+
+@then('"{actor_alias}" should see following form choices')
+def then_should_see_form_choices(context: Context, actor_alias: str):
+    generic_should_see_form_choices(context, actor_alias, context.table)

--- a/tests/browser/steps/then_def.py
+++ b/tests/browser/steps/then_def.py
@@ -409,7 +409,9 @@ def then_should_receive_contact_confirmation_email(
 
 
 @then('"{actor_alias}" should receive an "{subject}" confirmation email')
-def then_should_receive_confirmation_email_from_zendesk(
+@then('"{actor_alias}" should receive a "{subject}" confirmation email')
+@then('"{actor_alias}" should receive "{subject}" confirmation email')
+def then_should_receive_confirmation_email_from_govnotify(
         context: Context, actor_alias: str, subject: str):
     eu_exit_contact_us_should_receive_confirmation_email(context, actor_alias, subject)
 

--- a/tests/browser/steps/then_def.py
+++ b/tests/browser/steps/then_def.py
@@ -72,6 +72,7 @@ from steps.then_impl import (
     stats_and_tracking_elements_should_not_be_present,
     triage_should_be_classified_as,
     triage_should_see_change_your_answers_link,
+    zendesk_should_receive_confirmation_email,
 )
 from steps.when_impl import (
     triage_answer_questions_again,
@@ -465,3 +466,9 @@ def then_should_see_articles_filtered_by_tag(context: Context, actor_alias: str)
 @then('"{actor_alias}" should see following form choices')
 def then_should_see_form_choices(context: Context, actor_alias: str):
     generic_should_see_form_choices(context, actor_alias, context.table)
+
+
+@then('"{actor_alias}" should receive a "{subject}" confirmation email from Zendesk')
+@then('"{actor_alias}" should receive a "{subject}" email from Zendesk')
+def step_impl(context: Context, actor_alias: str, subject: str):
+    zendesk_should_receive_confirmation_email(context, actor_alias, subject)

--- a/tests/browser/steps/then_impl.py
+++ b/tests/browser/steps/then_impl.py
@@ -45,7 +45,11 @@ from utils.zendesk import find_tickets
 def should_be_on_page(context: Context, actor_alias: str, page_name: str):
     page = get_page_object(page_name)
     has_action(page, "should_be_here")
-    page.should_be_here(context.driver)
+    if hasattr(page, "URLs"):
+        special_page_name = page_name.split(" - ")[1]
+        page.should_be_here(context.driver, page_name=special_page_name)
+    else:
+        page.should_be_here(context.driver)
     update_actor(context, actor_alias, visited_page=page)
     logging.debug(f"{actor_alias} is on {page.SERVICE} - {page.NAME} - {page.TYPE} -> {page}")
 
@@ -902,3 +906,11 @@ def eu_exit_contact_us_should_receive_confirmation_email(
         subject=subject,
     )
     assert confirmation
+
+
+def generic_should_see_form_choices(
+        context: Context, actor_alias: str, option_names: Table):
+    option_names = [row[0] for row in option_names]
+    page = get_last_visited_page(context, actor_alias)
+    has_action(page, "should_see_form_choices")
+    page.should_see_form_choices(context.driver, option_names)

--- a/tests/browser/steps/then_impl.py
+++ b/tests/browser/steps/then_impl.py
@@ -887,6 +887,7 @@ def zendesk_should_receive_confirmation_email(
     error_msg = (f"Expected to find only 1 '{subject}' ticket for {email} but "
                  f"found {len(tickets)} instead")
     assert len(tickets) == 1, error_msg
+    logging.debug(f"{actor_alias} received '{subject}' email from Zendesk")
 
 
 def should_see_articles_filtered_by_tag(context: Context, actor_alias: str):

--- a/tests/browser/steps/when_def.py
+++ b/tests/browser/steps/when_def.py
@@ -27,14 +27,15 @@ from steps.when_impl import (
     fas_view_article,
     fas_view_more_companies,
     fas_view_selected_company_profile,
-    generic_open_any_tag,
     generic_click_on_random_industry,
     generic_click_on_uk_gov_logo,
     generic_download_all_pdfs,
     generic_fill_out_and_submit_form,
+    generic_open_any_tag,
     generic_open_guide_link,
     generic_open_industry_page,
     generic_open_news_article,
+    generic_pick_radio_option_and_submit,
     generic_see_more_industries,
     generic_submit_form,
     generic_unfold_topics,
@@ -414,6 +415,14 @@ def fas_when_actor_fills_out_and_submits_contact_us_form_wo_captcha(
 def fas_when_actor_fills_out_and_submits_contact_us_form(
         context: Context, actor_alias: str):
     fas_fill_out_and_submit_contact_us_form(context, actor_alias)
+
+
+@when('"{actor_alias}" says that his business is in "{option}"')
+@when('"{actor_alias}" says that his business is "{option}"')
+@when('"{actor_alias}" chooses "{option}" option')
+def when_actor_chooses_form_option(
+        context: Context, actor_alias: str, option: str):
+    generic_pick_radio_option_and_submit(context, actor_alias, option)
 
 
 @when('"{actor_alias}" decides to see more UK industries')

--- a/tests/browser/steps/when_def.py
+++ b/tests/browser/steps/when_def.py
@@ -19,6 +19,7 @@ from steps.when_impl import (
     case_studies_go_to,
     clear_the_cookies,
     click_on_page_element,
+    contact_us_navigate_through_options,
     continue_export_journey,
     export_readiness_open_category,
     fas_fill_out_and_submit_contact_us_form,
@@ -521,6 +522,10 @@ def when_actor_chooses_random_form_option_except(
     generic_pick_random_radio_option_and_submit(context, actor_alias, ignored)
 
 
+@when('"{actor_alias}" navigates via "{via}"')
+def given_actor_navigates_via_contact_us_options(
+        context: Context, actor_alias: str, via: str):
+    contact_us_navigate_through_options(context, actor_alias, via)
 
 
 @when('"{actor_alias}" is on the "{page_name}" page')

--- a/tests/browser/steps/when_def.py
+++ b/tests/browser/steps/when_def.py
@@ -36,6 +36,7 @@ from steps.when_impl import (
     generic_open_industry_page,
     generic_open_news_article,
     generic_pick_radio_option_and_submit,
+    generic_pick_random_radio_option_and_submit,
     generic_see_more_industries,
     generic_submit_form,
     generic_unfold_topics,
@@ -512,3 +513,9 @@ def when_actor_open_tag(context: Context, actor_alias: str):
 @when('"{actor_alias}" decides to read about one of listed industries')
 def when_actor_clicks_on_random_industry(context: Context, actor_alias: str):
     generic_click_on_random_industry(context, actor_alias)
+
+
+@when('"{actor_alias}" chooses any available option except "{ignored}"')
+def when_actor_chooses_random_form_option_except(
+        context: Context, actor_alias: str, ignored: str):
+    generic_pick_random_radio_option_and_submit(context, actor_alias, ignored)

--- a/tests/browser/steps/when_def.py
+++ b/tests/browser/steps/when_def.py
@@ -5,7 +5,7 @@
 from behave import when
 from behave.runner import Context
 
-from steps.then_impl import triage_should_be_classified_as
+from steps.then_impl import triage_should_be_classified_as, should_be_on_page
 from steps.when_impl import (
     articles_found_useful_or_not,
     articles_go_back_to_article_list,
@@ -519,3 +519,10 @@ def when_actor_clicks_on_random_industry(context: Context, actor_alias: str):
 def when_actor_chooses_random_form_option_except(
         context: Context, actor_alias: str, ignored: str):
     generic_pick_random_radio_option_and_submit(context, actor_alias, ignored)
+
+
+
+
+@when('"{actor_alias}" is on the "{page_name}" page')
+def step_impl(context: Context, actor_alias: str, page_name: str):
+    should_be_on_page(context, actor_alias, page_name)

--- a/tests/browser/steps/when_impl.py
+++ b/tests/browser/steps/when_impl.py
@@ -1921,3 +1921,10 @@ def generic_click_on_random_industry(context: Context, actor_alias: str):
     page = get_last_visited_page(context, actor_alias)
     has_action(page, "open_any_article")
     page.open_any_article(context.driver)
+
+
+def generic_pick_radio_option_and_submit(context: Context, actor_alias: str, option: str):
+    page = get_last_visited_page(context, actor_alias)
+    has_action(page, "pick_radio_option_and_submit")
+    new_page = page.pick_radio_option_and_submit(context.driver, option)
+    update_actor(context, actor_alias, visited_page=new_page)

--- a/tests/browser/steps/when_impl.py
+++ b/tests/browser/steps/when_impl.py
@@ -1946,3 +1946,12 @@ def contact_us_get_to_page_via(
         generic_pick_radio_option_and_submit(context, actor_alias, option)
     # 3) check if we're on the appropriate page
     should_be_on_page(context, actor_alias, final_page)
+
+
+def contact_us_navigate_through_options(context: Context, actor_alias: str, via: str):
+    intermediate = [name.strip() for name in via.split("->")]
+    # 1) start at the Contact us "choose location" page
+    visit_page(context, actor_alias, "Export Readiness - Contact us")
+    # 2) click through every listed option
+    for option in intermediate:
+        generic_pick_radio_option_and_submit(context, actor_alias, option)

--- a/tests/browser/steps/when_impl.py
+++ b/tests/browser/steps/when_impl.py
@@ -1929,7 +1929,7 @@ def generic_pick_radio_option_and_submit(context: Context, actor_alias: str, opt
 
 def generic_pick_random_radio_option_and_submit(
         context: Context, actor_alias: str, ignored: str):
-    ignored = [item.strip() for item in ignored.split(",")]
+    ignored = [item.strip().lower() for item in ignored.split(",")]
     page = get_last_visited_page(context, actor_alias)
     has_action(page, "pick_random_radio_option_and_submit")
     new_page = page.pick_random_radio_option_and_submit(context.driver, ignored)

--- a/tests/browser/steps/when_impl.py
+++ b/tests/browser/steps/when_impl.py
@@ -8,17 +8,10 @@ from behave.model import Table
 from behave.runner import Context
 from retrying import retry
 from selenium.common.exceptions import TimeoutException, WebDriverException
-
 from utils.cms_api import get_news_articles
 from utils.gov_notify import get_verification_link
 
-from pages import (
-    common_language_selector,
-    exread,
-    fas,
-    get_page_object,
-    sso,
-)
+from pages import common_language_selector, exread, fas, get_page_object, sso
 from pages.common_actions import (
     VisitedArticle,
     add_actor,
@@ -1927,6 +1920,15 @@ def generic_pick_radio_option_and_submit(context: Context, actor_alias: str, opt
     page = get_last_visited_page(context, actor_alias)
     has_action(page, "pick_radio_option_and_submit")
     new_page = page.pick_radio_option_and_submit(context.driver, option)
+    update_actor(context, actor_alias, visited_page=new_page)
+
+
+def generic_pick_random_radio_option_and_submit(
+        context: Context, actor_alias: str, ignored: str):
+    ignored = [item.strip() for item in ignored.split(",")]
+    page = get_last_visited_page(context, actor_alias)
+    has_action(page, "pick_random_radio_option_and_submit")
+    new_page = page.pick_random_radio_option_and_submit(context.driver, ignored)
     update_actor(context, actor_alias, visited_page=new_page)
 
 

--- a/tests/browser/steps/when_impl.py
+++ b/tests/browser/steps/when_impl.py
@@ -1928,3 +1928,15 @@ def generic_pick_radio_option_and_submit(context: Context, actor_alias: str, opt
     has_action(page, "pick_radio_option_and_submit")
     new_page = page.pick_radio_option_and_submit(context.driver, option)
     update_actor(context, actor_alias, visited_page=new_page)
+
+
+def contact_us_get_to_page_via(
+        context: Context, actor_alias: str, final_page: str, via: str):
+    intermediate = [name.strip() for name in via.split("->")]
+    # 1) start at the Contact us "choose location" page
+    visit_page(context, actor_alias, "Export Readiness - Contact us")
+    # 2) click through every listed option
+    for option in intermediate:
+        generic_pick_radio_option_and_submit(context, actor_alias, option)
+    # 3) check if we're on the appropriate page
+    should_be_on_page(context, actor_alias, final_page)

--- a/tests/browser/steps/when_impl.py
+++ b/tests/browser/steps/when_impl.py
@@ -91,7 +91,11 @@ def visit_page(
 def should_be_on_page(context: Context, actor_alias: str, page_name: str):
     page = get_page_object(page_name)
     has_action(page, "should_be_here")
-    page.should_be_here(context.driver)
+    if hasattr(page, "URLs"):
+        special_page_name = page_name.split(" - ")[1]
+        page.should_be_here(context.driver, page_name=special_page_name)
+    else:
+        page.should_be_here(context.driver)
     update_actor(context, actor_alias, visited_page=page)
     logging.debug(f"{actor_alias} is on {page.SERVICE} - {page.NAME} - {page.TYPE} -> {page}")
 

--- a/tests/browser/utils/gov_notify.py
+++ b/tests/browser/utils/gov_notify.py
@@ -43,8 +43,6 @@ def get_email_confirmation_notification(
     user_notifications = filter_by_recipient(notifications, email)
     email_confirmations = filter_by_subject(user_notifications, subject)
 
-    # logging.debug(pformat(notifications))
-    # logging.debug(pformat(user_notifications))
     logging.debug(pformat(email_confirmations))
     assert len(email_confirmations) == 1, (
         "Expected to find 1 email confirmation notification for {} but found "

--- a/tests/browser/utils/gov_notify.py
+++ b/tests/browser/utils/gov_notify.py
@@ -43,7 +43,8 @@ def get_email_confirmation_notification(
     user_notifications = filter_by_recipient(notifications, email)
     email_confirmations = filter_by_subject(user_notifications, subject)
 
-    logging.debug(pformat(email_confirmations))
+    if email_confirmations:
+        logging.debug(pformat(email_confirmations))
     assert len(email_confirmations) == 1, (
         "Expected to find 1 email confirmation notification for {} but found "
         "{}".format(email, len(email_confirmations)))

--- a/tests/browser/utils/zendesk.py
+++ b/tests/browser/utils/zendesk.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import datetime
 from typing import List
 

--- a/tests/functional/features/sud/profile.feature
+++ b/tests/functional/features/sud/profile.feature
@@ -53,6 +53,9 @@ Feature: SUD (Profile) pages
         |SUD Selling Online Overseas|
 
 
+    # I've been told that on non-prod envs ExOpps doesn't keep synced state
+    # between different services and thus ExOpps page on SUD displays
+    # different content based on user ID
     @ED-2267
     @sso
     @account

--- a/tests/functional/pages/sud_ui_export_opportunities.py
+++ b/tests/functional/pages/sud_ui_export_opportunities.py
@@ -13,15 +13,7 @@ EXPECTED_STRINGS = [
     "Export opportunities",
     "Business profile",
     "Selling online overseas",
-    "Start applying for export opportunities. You can quickly and easily:",
-    "find thousands of exporting opportunities",
-    "search for opportunities within your industry or in a specific country",
-    (
-        "sign up for email alerts so you're the first to know of new "
-        "opportunities"
-    ),
-    "apply for any export opportunity and track your applications",
-    "Find and apply",
+    "Applications",
 ]
 
 


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/TT-758)

Scenarios:
```gherkin
  @TT-758 @enquirer_location
  Scenario: Enquirers should see all expected contact location options on the "Export Readiness - Contact us" 
    Given "Robert" visits the "Export Readiness - Contact us" page
    Then "Robert" should be on the "Export Readiness - Contact us" page
    And "Robert" should see following form choices
      | radio elements |
      | The UK         |
      | Outside the UK |

  @TT-758 @enquirer_location @domestic_enquiry_page
  Scenario: Domestic Enquirers should see all expected contact options on the "Domestic - What can we help you with?" page 
    Given "Robert" visits the "Export Readiness - Contact us" page
    When "Robert" says that his business is in "The UK"
    Then "Robert" should be on the "Export Readiness - What can we help you with? - Domestic Contact us" page
    And "Robert" should see following form choices
      | radio elements                            |
      | Find your local trade office              |
      | Advice to export from the UK              |
      | Great.gov.uk account and services support |
      | UK Export Finance (UKEF)                  |
      | EU Exit                                   |
      | Events                                    |
      | Defence and Security Organisation (DSO)   |
      | Other                                     |

  @TT-758 @office_finder
  Scenario: Domestic Enquirers should be able to get to the "Existing Office finder - Home" page 
    Given "Robert" visits the "Export Readiness - Contact us" page
    When "Robert" says that his business is in "the UK"
    And "Robert" chooses "Find your local trade office" option
    Then "Robert" should be on the "EXISTING Office finder - Home" page

  @TT-758 @exporting_from_the_UK
  Scenario: Domestic Enquirers should be able to get to the "Long (Export Advice Comment) - Contact us" form 
    Given "Robert" visits the "Export Readiness - Contact us" page
    When "Robert" says that his business is in "the UK"
    And "Robert" chooses "Advice to export from the UK" option
    Then "Robert" should be on the "Export Readiness - Long (Export Advice Comment) - Contact us" page

  @TT-758 @account_support
  Scenario: Domestic enquirers should see all expected help options on the "Great.gov.uk account and services support" page 
    Given "Robert" got to the "Export Readiness - Great.gov.uk account and services support" page via "The UK -> Great.gov.uk account and services support"
    Then "Robert" should see following form choices
      | radio elements               |
      | Export opportunities service |
      | Your account on Great.gov.uk |
      | Other                        |

  @TT-758 @account_support
  Scenario: Domestic enquirers should see all expected help options for "Export opportunities service" 
    Given "Robert" got to the "Export Readiness - Export opportunities service" page via "The UK -> Great.gov.uk account and services support -> Export opportunities service"
    Then "Robert" should see following form choices
      | radio elements                                              |
      | I haven't had a response from the opportunity I applied for |
      | My daily alerts are not relevant to me                      |
      | Other                                                       |

  @TT-758 @account_support
  Scenario: Domestic enquirers should see all expected help options for "Great.gov.uk account" 
    Given "Robert" got to the "Export Readiness - Great.gov.uk account" page via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk"
    Then "Robert" should see following form choices
      | radio elements                                                 |
      | I have not received an email confirmation                      |
      | I need to reset my password                                    |
      | My Companies House login is not working                        |
      | I do not know where to enter my verification code              |
      | I have not received my letter containing the verification code |
      | Other                                                          |

  @TT-758 @account_support
  Scenario: Domestic enquirers should be able to get to the "Short Contact Us" form via "The UK -> Great.gov.uk account and services support -> Other" 
    Given "Robert" got to the "Export Readiness - Great.gov.uk account and services support" page via "The UK -> Great.gov.uk account and services support"
    When "Robert" chooses "Other" option
    Then "Robert" should be on the "Export Readiness - Short contact form (Tell us how we can help)" page

  @TT-758 @account_support
  Scenario: Domestic enquirers should be able to get to the "Short Contact Us" form via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk -> Other" 
    Given "Robert" got to the "Export Readiness - Great.gov.uk account" page via "The UK -> Great.gov.uk account and services support -> Your account on Great.gov.uk"
    When "Robert" chooses "Other" option
    Then "Robert" should be on the "Export Readiness - Short contact form (Tell us how we can help)" page

  @TT-758 @export_opportunities
  Scenario: Exporters should be able to find answers to "My daily alerts are not relevant to me" topic 
    Given "Robert" got to the "Export Readiness - Export opportunities service" page via "The UK -> Great.gov.uk account and services support -> Export opportunities service"
    When "Robert" chooses "My daily alerts are not relevant to me" option
    Then "Robert" should be on the "Export Readiness - My daily alerts are not relevant to me - Dedicated Support Content" page

  @TT-758 @ukef
  Scenario: Exporters should be able to get to the UKEF Check your eligibility contact-us form 
    Given "Robert" got to the "Export Readiness - What can we help you with? - Domestic Contact us" page via "The UK"
    When "Robert" chooses "UK Export Finance (UKEF)" option
    Then "Robert" should be on the "Export Readiness - What would you like to know more about? - UKEF Contact us" page

  @TT-758 @investing_overseas @events @dso @short_form
  Scenario Outline: Domestic enquirers should get to the "Short contact us form" via "The UK -> Events" -- @1.1  
    Given "Robert" got to the "Export Readiness - What can we help you with? - Domestic Contact us" page via "The UK"
    When "Robert" chooses "Events" option
    Then "Robert" should be on the "Export Readiness - Short contact form (Events)" page

  @TT-758 @investing_overseas @events @dso @short_form
  Scenario Outline: Domestic enquirers should get to the "Short contact us form" via "The UK -> Defence and Security Organisation (DSO)" -- @1.2  
    Given "Robert" got to the "Export Readiness - What can we help you with? - Domestic Contact us" page via "The UK"
    When "Robert" chooses "Defence and Security Organisation (DSO)" option
    Then "Robert" should be on the "Export Readiness - Short contact form (Defence and Security Organisation (DSO))" page

  @TT-758 @investing_overseas @events @dso @short_form
  Scenario Outline: Domestic enquirers should get to the "Short contact us form" via "The UK -> Other" -- @1.3  
    Given "Robert" got to the "Export Readiness - What can we help you with? - Domestic Contact us" page via "The UK"
    When "Robert" chooses "Other" option
    Then "Robert" should be on the "Export Readiness - Short contact form (Other)" page

  @TT-758 @CMS-506 @eu_exit @feature_flagged
  Scenario: Exporters should be able to get to the "Domestic EU Exit short contact-us form" 
    Given "Robert" got to the "Export Readiness - What can we help you with? - Domestic Contact us" page via "The UK"
    When "Robert" chooses "EU Exit" option
    Then "Robert" should be on the "Export Readiness - Domestic EU Exit contact form" page

  @TT-758 @CMS-506 @dev-only @captcha @eu_exit @feature_flagged
  Scenario: Exporters should be able to contact "EU Exit mailbox" 
    Given "Robert" got to the "Export Readiness - Domestic EU Exit contact form" page via "The UK -> EU Exit"
    When "Robert" fills out and submits the form
    Then "Robert" should be on the "Export Readiness - Thank you for your enquiry - Domestic EU Exit Contact us" page
    And "Robert" should receive an "Thank you for your EU exit enquiry" confirmation email

  @TT-758 @dev-only @captcha @short_form
  Scenario Outline: Exporters should be able to contact "Events mailbox" using "Short contact form (Events)" page accessed via "The UK -> Events" -- @1.1  
    Given "Robert" got to the "Export Readiness - Short contact form (Events)" page via "The UK -> Events"
    When "Robert" fills out and submits the form
    Then "Robert" should be on the "Export Readiness - Thank you for your enquiry (Events) - Short Domestic Contact us" page
    And "Robert" should receive an "Thank you for your Events enquiry" confirmation email

  @TT-758 @dev-only @captcha @short_form
  Scenario Outline: Exporters should be able to contact "DSO mailbox" using "Short contact form (Defence and Security Organisation (DSO))" page accessed via "The UK -> Defence and Security Organisation (DSO)" -- @1.2  
    Given "Robert" got to the "Export Readiness - Short contact form (Defence and Security Organisation (DSO))" page via "The UK -> Defence and Security Organisation (DSO)"
    When "Robert" fills out and submits the form
    Then "Robert" should be on the "Export Readiness - Thank you for your enquiry (Defence and Security Organisation (DSO)) - Short Domestic Contact us" page
    And "Robert" should receive an "Thank you for your Defence and Security Organisation enquiry" confirmation email

  @TT-758 @dev-only @captcha @short_form
  Scenario Outline: Exporters should be able to contact "DIT Enquiry unit" using "Short contact form (Other)" page accessed via "The UK -> Other" -- @1.3  
    Given "Robert" got to the "Export Readiness - Short contact form (Other)" page via "The UK -> Other"
    When "Robert" fills out and submits the form
    Then "Robert" should be on the "Export Readiness - Thank you for your enquiry (Other) - Short Domestic Contact us" page
    And "Robert" should receive an "Thank you for your enquiry" confirmation email

  @TT-758 @international
  Scenario: International Enquirers should be able to see all expected contact options on the "International - What would you like to know more about?" page 
    Given "Robert" visits the "Export Readiness - Contact us" page
    When "Robert" says that his business is "Outside the UK"
    Then "Robert" should be on the "Export Readiness - What would you like to know more about? - International Contact us" page
    And "Robert" should see following form choices
      | radio elements      |
      | Investing in the UK |
      | Buying from the UK  |
      | EU Exit             |
      | Other               |

  @TT-758 @international
  Scenario Outline: International Enquirers should be able to get to the "Invest - Contact us" form for "Investing in the UK" -- @1.1  
    Given "Robert" got to the "Export Readiness - What would you like to know more about? - International Contact us" page via "Outside the UK"
    When "Robert" chooses "Investing in the UK" option
    Then "Robert" should be on the "Invest - Contact us" page

  @TT-758 @international
  Scenario Outline: International Enquirers should be able to get to the "Export Readiness - Short contact form (Buying from the UK)" form for "Buying from the UK" -- @1.2  
    Given "Robert" got to the "Export Readiness - What would you like to know more about? - International Contact us" page via "Outside the UK"
    When "Robert" chooses "Buying from the UK" option
    Then "Robert" should be on the "Export Readiness - Short contact form (Buying from the UK)" page

  @TT-758 @international
  Scenario Outline: International Enquirers should be able to get to the "Export Readiness - International EU Exit - Contact Us" form for "EU Exit" -- @1.3  
    Given "Robert" got to the "Export Readiness - What would you like to know more about? - International Contact us" page via "Outside the UK"
    When "Robert" chooses "EU Exit" option
    Then "Robert" should be on the "Export Readiness - International EU Exit - Contact Us" page

  @TT-758 @international
  Scenario Outline: International Enquirers should be able to get to the "Export Readiness - International Contact us" form for "Other" -- @1.4  
    Given "Robert" got to the "Export Readiness - What would you like to know more about? - International Contact us" page via "Outside the UK"
    When "Robert" chooses "Other" option
    Then "Robert" should be on the "Export Readiness - International Contact us" page
```