### PR TITLE
CMS-686 new scenarios and cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,7 +346,6 @@ jobs:
       TEST_ENV: "dev"
       BROWSER: "chrome"
       <<: *chrome_version
-      TAGS: "-decommissioned"
     <<: *steps_run_browser_tests
 
   browser_all_firefox_dev:
@@ -356,7 +355,6 @@ jobs:
       TEST_ENV: "dev"
       BROWSER: "firefox"
       <<: *firefox_version
-      TAGS: "-decommissioned"
     <<: *steps_run_browser_tests
 
   browser_selected_chrome_dev:
@@ -366,7 +364,7 @@ jobs:
       TEST_ENV: "dev"
       BROWSER: "chrome"
       <<: *chrome_version
-      TAGS: "-full,-decommissioned"
+      TAGS: "-full"
     <<: *steps_run_browser_tests
 
   browser_selected_firefox_dev:
@@ -376,7 +374,7 @@ jobs:
       TEST_ENV: "dev"
       BROWSER: "firefox"
       <<: *firefox_version
-      TAGS: "-full,-decommissioned"
+      TAGS: "-full"
     <<: *steps_run_browser_tests
 
   browser_all_chrome_stage:
@@ -386,7 +384,7 @@ jobs:
       TEST_ENV: "stage"
       BROWSER: "chrome"
       <<: *chrome_version
-      TAGS: "-dev-only,-decommissioned"
+      TAGS: "-dev-only"
     <<: *steps_run_browser_tests
 
   browser_all_firefox_stage:
@@ -396,7 +394,7 @@ jobs:
       TEST_ENV: "stage"
       BROWSER: "firefox"
       <<: *firefox_version
-      TAGS: "-dev-only,-decommissioned"
+      TAGS: "-dev-only"
     <<: *steps_run_browser_tests
 
   browser_selected_chrome_stage:
@@ -406,7 +404,7 @@ jobs:
       TEST_ENV: "stage"
       BROWSER: "chrome"
       <<: *chrome_version
-      TAGS: "-full,-dev-only,-decommissioned"
+      TAGS: "-full,-dev-only"
     <<: *steps_run_browser_tests
 
   browser_selected_firefox_stage:
@@ -416,7 +414,7 @@ jobs:
       TEST_ENV: "stage"
       BROWSER: "firefox"
       <<: *firefox_version
-      TAGS: "-full,-dev-only,-decommissioned"
+      TAGS: "-full,-dev-only"
     <<: *steps_run_browser_tests
 
   load_cms_tests_stage:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-This [ticket](https://uktrade.atlassian.net/browse/ED-)
+This [ticket](https://uktrade.atlassian.net/browse/CMS-)
 
 Scenario:
 ```gherkin

--- a/tests/browser/features/exred/accessing-services.feature
+++ b/tests/browser/features/exred/accessing-services.feature
@@ -10,7 +10,7 @@ Feature: Accessing Services
   Scenario Outline: Any Exporter visiting the home page should be able to see links to selected Services in/on "<link_location>"
     Given "Robert" visits the "Export Readiness - Home" page
 
-    Then "Robert" should see links to following Services "<services>" in "Export Readiness - <link_location>"
+    Then "Robert" should see links to following "Services" "<services>" in "Export Readiness - <link_location>"
 
     Examples:
       | services                                                                         | link_location |

--- a/tests/browser/features/exred/advice.feature
+++ b/tests/browser/features/exred/advice.feature
@@ -159,3 +159,19 @@ Feature: Advice articles
       | header        |
       | home          |
       | footer        |
+
+
+  @CMS-686
+  @breadcrumbs
+  Scenario Outline: Any Exporter should see be to use "<breadcrumb>" breadcrumb on "Advice article" page to get to "<target>" page
+    Given "Robert" is on randomly selected Advice article page
+
+    When "Robert" decides to open "<breadcrumb>"
+
+    Then "Robert" should be on the "Export Readiness - <target>" page
+
+    Examples:
+      | breadcrumb   | target                |
+      | great.gov.uk | Home                  |
+      | Advice       | Advice - Landing      |
+      | Article list | Advice - article list |

--- a/tests/browser/features/exred/advice.feature
+++ b/tests/browser/features/exred/advice.feature
@@ -125,3 +125,24 @@ Feature: Advice articles
 
     Then "Robert" should be on the "Export Readiness - Feedback - contact us" page
 
+
+  @CMS-686
+  Scenario Outline: Any Exporter visiting the home page should be able to see links to all Advice categories in "Export Readiness - <link_location>"
+    Given "Robert" visits the "Export Readiness - Home" page
+
+    Then "Robert" should see links to following "Advice" categories in "Export Readiness - <link_location>"
+      | categories                                  |
+      | Create an export plan                       |
+      | Find an export market                       |
+      | Define route to market                      |
+      | Get export finance and funding              |
+      | Manage payment for export orders            |
+      | Prepare to do business in a foreign country |
+      | Manage legal and ethical compliance         |
+      | Prepare for export procedures and logistics |
+
+    Examples:
+      | link_location |
+      | header        |
+      | home          |
+      | footer        |

--- a/tests/browser/features/exred/advice.feature
+++ b/tests/browser/features/exred/advice.feature
@@ -96,10 +96,9 @@ Feature: Advice articles
   @CMS-686
   @bug
   @CMS-733
-  @fixme
+  @fixed
   @sharing
   @social-media
-  @<group>
   @<social_media>
   Scenario Outline: Any Exporter should be able to share Advice article via "<social_media>"
     Given "Robert" is on randomly selected Advice article page
@@ -114,6 +113,20 @@ Feature: Advice articles
       | Facebook     |
       | Twitter      |
       | Facebook     |
+
+  @CMS-686
+  @bug
+  @CMS-733
+  @fixed
+  @sharing
+  @social-media
+  @email
+  Scenario: Any Exporter should be able to share Advice article via "email"
+    Given "Robert" is on randomly selected Advice article page
+
+    When "Robert" decides to share the article via "email"
+
+    Then "Robert" should see that the share via email link will pre-populate the message subject and body with Article title and URL
 
 
   @CMS-686

--- a/tests/browser/pages/exred/advice_article.py
+++ b/tests/browser/pages/exred/advice_article.py
@@ -157,3 +157,8 @@ def share_via(driver: WebDriver, social_media: str):
 def report_problem(driver: WebDriver):
     find_and_click_on_page_element(
         driver, SELECTORS, "report page link", wait_for_it=False)
+
+
+def click_on_page_element(driver: WebDriver, element_name: str):
+    find_and_click_on_page_element(driver, SELECTORS, element_name)
+    take_screenshot(driver, NAME + " after clicking on " + element_name)

--- a/tests/browser/pages/exred/advice_article.py
+++ b/tests/browser/pages/exred/advice_article.py
@@ -47,6 +47,14 @@ SELECTORS = {
     "breadcrumbs": {
         "itself": Selector(By.CSS_SELECTOR, "nav.breadcrumbs"),
         "links": Selector(By.CSS_SELECTOR, "nav.breadcrumbs a"),
+        "great.gov.uk":
+            Selector(
+                By.CSS_SELECTOR, ".breadcrumbs a[href='/']"),
+        "advice":
+            Selector(
+                By.CSS_SELECTOR, ".breadcrumbs a[href='/advice/']"),
+        "article list":
+            Selector(By.CSS_SELECTOR, ".breadcrumbs > ol > li:nth-child(3) > a"),
     },
     "article": {
         "article name": ARTICLE_NAME,

--- a/tests/browser/pages/exred/article_list.py
+++ b/tests/browser/pages/exred/article_list.py
@@ -13,11 +13,9 @@ from pages.common_actions import (
     check_for_expected_sections_elements,
     check_for_section,
     check_for_sections,
-    check_if_element_is_not_present,
     check_if_element_is_not_visible,
     find_element,
     take_screenshot,
-    wait_for_page_load_after_action,
 )
 
 NAME = "Article List"
@@ -33,8 +31,6 @@ LIST_OF_ARTICLES = Selector(By.ID, "js-paginate-list")
 TOTAL_NUMBER_OF_ARTICLES = Selector(By.CSS_SELECTOR, "dd.position > span.to")
 ARTICLES_TO_READ_COUNTER = Selector(By.CSS_SELECTOR, "dd.position > span.from")
 TIME_TO_COMPLETE = Selector(By.CSS_SELECTOR, "dd.time span.value")
-REGISTRATION_LINK = Selector(By.CSS_SELECTOR, "#articles p.register > a:nth-child(1)")
-SIGN_IN_LINK = Selector(By.CSS_SELECTOR, "#articles p.register > a:nth-child(2)")
 IS_THERE_ANYTHING_WRONG_WITH_THIS_PAGE_LINK = Selector(
     By.CSS_SELECTOR, "section.error-reporting a"
 )
@@ -87,28 +83,6 @@ def should_not_see_section(driver: WebDriver, name: str):
     section = SELECTORS[name.lower()]
     for key, selector in section.items():
         check_if_element_is_not_visible(driver, selector, element_name=key)
-
-
-def go_to_registration(driver: WebDriver):
-    registration_link = find_element(driver, REGISTRATION_LINK)
-    with wait_for_page_load_after_action(driver):
-        registration_link.click()
-
-
-def go_to_sign_in(driver: WebDriver):
-    sign_in_link = find_element(driver, SIGN_IN_LINK)
-    with wait_for_page_load_after_action(driver):
-        sign_in_link.click()
-
-
-def should_not_see_link_to_register(driver: WebDriver):
-    check_if_element_is_not_present(
-        driver, REGISTRATION_LINK, element_name="Registration link"
-    )
-
-
-def should_not_see_link_to_sign_in(driver: WebDriver):
-    check_if_element_is_not_present(driver, SIGN_IN_LINK, element_name="Sign in link")
 
 
 def show_more(driver: WebDriver):

--- a/tests/browser/pages/exred/footer.py
+++ b/tests/browser/pages/exred/footer.py
@@ -35,21 +35,21 @@ SELECTORS = {
     "advice": {
         "label": Selector(By.ID, "footer-advice-links"),
         "create an export plan":
-            Selector(By.ID, "footer-advice-make-an-export-plan"),
+            Selector(By.ID, "footer-advice-create-an-export-plan"),
         "find an export market":
-            Selector(By.ID, "footer-advice-how-to-find-an-export-market"),
+            Selector(By.ID, "footer-advice-find-an-export-market"),
         "define route to market":
-            Selector(By.ID, "footer-advice-how-to-enter-an-export-market"),
+            Selector(By.ID, "footer-advice-define-route-to-market"),
         "get export finance and funding":
-            Selector(By.ID, "footer-advice-managing-finance"),
+            Selector(By.ID, "footer-advice-get-export-finance-and-funding"),
         "manage payment for export orders":
-            Selector(By.ID, "footer-advice-managing-finance"),
+            Selector(By.ID, "footer-advice-manage-payment-for-export-orders"),
         "prepare to do business in a foreign country":
-            Selector(By.ID, "footer-advice-doing-business-overseas"),
+            Selector(By.ID, "footer-advice-prepare-to-do-business-in-a-foreign-country"),
         "manage legal and ethical compliance":
-            Selector(By.ID, "footer-advice-legal-and-compliance"),
+            Selector(By.ID, "footer-advice-manage-legal-and-ethical-compliance"),
         "prepare for export procedures and logistics":
-            Selector(By.ID, "footer-advice-legal-and-compliance"),
+            Selector(By.ID, "footer-advice-prepare-for-export-procedures-and-logistics"),
     },
     "services": {
         "label": Selector(By.ID, "footer-services-links"),

--- a/tests/browser/pages/exred/header.py
+++ b/tests/browser/pages/exred/header.py
@@ -49,21 +49,21 @@ SELECTORS = {
     "advice": {
         "menu": Selector(By.ID, "header-advice-links"),
         "create an export plan":
-            Selector(By.ID, "footer-advice-make-an-export-plan"),
+            Selector(By.ID, "header-advice-create-an-export-plan"),
         "find an export market":
-            Selector(By.ID, "footer-advice-how-to-find-an-export-market"),
+            Selector(By.ID, "header-advice-find-an-export-market"),
         "define route to market":
-            Selector(By.ID, "footer-advice-how-to-enter-an-export-market"),
+            Selector(By.ID, "header-advice-define-route-to-market"),
         "get export finance and funding":
-            Selector(By.ID, "footer-advice-managing-finance"),
+            Selector(By.ID, "header-advice-get-export-finance-and-funding"),
         "manage payment for export orders":
-            Selector(By.ID, "footer-advice-managing-finance"),
+            Selector(By.ID, "header-advice-manage-payment-for-export-orders"),
         "prepare to do business in a foreign country":
-            Selector(By.ID, "footer-advice-doing-business-overseas"),
+            Selector(By.ID, "header-advice-prepare-to-do-business-in-a-foreign-country"),
         "manage legal and ethical compliance":
-            Selector(By.ID, "footer-advice-legal-and-compliance"),
+            Selector(By.ID, "header-advice-manage-legal-and-ethical-compliance"),
         "prepare for export procedures and logistics":
-            Selector(By.ID, "footer-advice-legal-and-compliance"),
+            Selector(By.ID, "header-advice-prepare-for-export-procedures-and-logistics"),
     },
     "services": {
         "menu": Selector(By.ID, "header-services-links"),

--- a/tests/browser/pages/exred/home.py
+++ b/tests/browser/pages/exred/home.py
@@ -104,15 +104,48 @@ CAROUSEL = {
 HEADER_ADVICE_LINKS = Selector(By.ID, "header-advice-links")
 ARTICLES = Selector(By.CSS_SELECTOR, "#eu-exit-news-section .article a")
 SELECTORS = {
-    "header - advice": {
+    "advice header menu": {
         "links":
             Selector(By.CSS_SELECTOR, "#advice-links-list a", type=ElementType.LINK),
+        "menu": Selector(By.ID, "header-advice-links"),
+        "create an export plan":
+            Selector(By.ID, "header-advice-create-an-export-plan"),
+        "find an export market":
+            Selector(By.ID, "header-advice-find-an-export-market"),
+        "define route to market":
+            Selector(By.ID, "header-advice-define-route-to-market"),
+        "get export finance and funding":
+            Selector(By.ID, "header-advice-get-export-finance-and-funding"),
+        "manage payment for export orders":
+            Selector(By.ID, "header-advice-manage-payment-for-export-orders"),
+        "prepare to do business in a foreign country":
+            Selector(By.ID, "header-advice-prepare-to-do-business-in-a-foreign-country"),
+        "manage legal and ethical compliance":
+            Selector(By.ID, "header-advice-manage-legal-and-ethical-compliance"),
+        "prepare for export procedures and logistics":
+            Selector(By.ID, "header-advice-prepare-for-export-procedures-and-logistics"),
     },
-    "footer - advice": {
+    "advice footer links": {
         "links":
             Selector(
                 By.CSS_SELECTOR, "#footer-advice-links ~ ul a", type=ElementType.LINK
             ),
+        "create an export plan":
+            Selector(By.ID, "footer-advice-create-an-export-plan"),
+        "find an export market":
+            Selector(By.ID, "footer-advice-find-an-export-market"),
+        "define route to market":
+            Selector(By.ID, "footer-advice-define-route-to-market"),
+        "get export finance and funding":
+            Selector(By.ID, "footer-advice-get-export-finance-and-funding"),
+        "manage payment for export orders":
+            Selector(By.ID, "footer-advice-manage-payment-for-export-orders"),
+        "prepare to do business in a foreign country":
+            Selector(By.ID, "footer-advice-prepare-to-do-business-in-a-foreign-country"),
+        "manage legal and ethical compliance":
+            Selector(By.ID, "footer-advice-manage-legal-and-ethical-compliance"),
+        "prepare for export procedures and logistics":
+            Selector(By.ID, "footer-advice-prepare-for-export-procedures-and-logistics"),
     },
     "beta bar": {
         "itself": Selector(By.ID, "header-beta-bar"),
@@ -166,6 +199,22 @@ SELECTORS = {
             Selector(
                 By.CSS_SELECTOR, "#resource-advice .card-link", type=ElementType.LINK
             ),
+        "create an export plan":
+            Selector(By.ID, "create-an-export-plan-link"),
+        "find an export market":
+            Selector(By.ID, "find-an-export-market-link"),
+        "define route to market":
+            Selector(By.ID, "define-route-to-market-link"),
+        "get export finance and funding":
+            Selector(By.ID, "get-export-finance-and-funding-link"),
+        "manage payment for export orders":
+            Selector(By.ID, "manage-payment-for-export-orders-link"),
+        "prepare to do business in a foreign country":
+            Selector(By.ID, "prepare-to-do-business-in-a-foreign-country-link"),
+        "manage legal and ethical compliance":
+            Selector(By.ID, "manage-legal-and-ethical-compliance-link"),
+        "prepare for export procedures and logistics":
+            Selector(By.ID, "prepare-for-export-procedures-and-logistics-link"),
     },
     "services": {
         "itself": Selector(By.ID, "services"),
@@ -388,7 +437,7 @@ def open_any_element_in_section(
     assert selectors, f"Could't find any {element_type} in {section_name} section"
     selector_key = random.choice(list(selectors))
     selector = SELECTORS[section_name.lower()][selector_key]
-    if section_name.lower().startswith("header"):
+    if "header" in section_name.lower():
         find_element(driver, HEADER_ADVICE_LINKS).click()
     elements = find_elements(driver, selector)
     element = random.choice(elements)

--- a/tests/browser/steps/given_def.py
+++ b/tests/browser/steps/given_def.py
@@ -116,10 +116,9 @@ def given_actor_is_registered_and_verified(context, actor_alias):
         context, actor_alias, fake_verification=True)
 
 
-@given('"{actor_alias}" signed in using link in the "{location}"')
 @given('"{actor_alias}" is signed in')
-def given_actor_is_signed_in(context, actor_alias, *, location="top bar"):
-    sign_in(context, actor_alias, location)
+def given_actor_is_signed_in(context, actor_alias):
+    sign_in(context, actor_alias)
 
 
 @given('"{actor_alias}" decided to find out out more about "{industry_name}" industry')

--- a/tests/browser/steps/then_def.py
+++ b/tests/browser/steps/then_def.py
@@ -38,7 +38,7 @@ from steps.then_impl import (
     should_be_on_page_or_international_page,
     should_not_see_sections,
     should_see_articles_filtered_by_tag,
-    should_see_links_to_services,
+    should_see_links_in_specific_location,
     should_see_page_in_preferred_language,
     should_see_sections,
     should_see_share_widget,
@@ -81,11 +81,18 @@ def then_actor_should_see_share_widget(context, actor_alias):
     should_see_share_widget(context, actor_alias)
 
 
-@then('"{actor_alias}" should see links to following Services "{services}" in "{location}"')
+@then('"{actor_alias}" should see links to following "{section}" categories in "{location}"')
 def then_should_see_links_to_services(
-        context, actor_alias, services, location):
-    should_see_links_to_services(
-        context, actor_alias, services.split(", "), location)
+        context, actor_alias, section, location):
+    should_see_links_in_specific_location(
+        context, actor_alias, section, context.table, location)
+
+
+@then('"{actor_alias}" should see links to following "{section}" "{elements}" in "{location}"')
+def then_should_see_links_to_services(
+        context, actor_alias, section, elements, location):
+    should_see_links_in_specific_location(
+        context, actor_alias, section, elements.split(", "), location)
 
 
 @then('"{actor_alias}" should be taken to a new tab with the "{social_media}" share page opened')

--- a/tests/browser/steps/then_impl.py
+++ b/tests/browser/steps/then_impl.py
@@ -166,8 +166,8 @@ def share_page_via_email_should_have_article_details(
 ):
     driver = context.driver
     body = driver.current_url
-    subject = exred.article_common.get_article_name(driver)
-    exred.article_common.check_share_via_email_link_details(driver, subject, body)
+    subject = exred.advice_article.get_article_name(driver)
+    exred.advice_article.check_share_via_email_link_details(driver, subject, body)
     logging.debug(
         "%s checked that the 'share via email' link contain correct subject: "
         "'%s' and message body: '%s'",

--- a/tests/browser/steps/then_impl.py
+++ b/tests/browser/steps/then_impl.py
@@ -2,7 +2,7 @@
 """Then step implementations."""
 import logging
 from time import sleep
-from typing import List
+from typing import List, Union
 from urllib.parse import urlparse
 
 import requests
@@ -123,15 +123,17 @@ def should_see_share_widget(context: Context, actor_alias: str):
     )
 
 
-def should_see_links_to_services(
-    context: Context, actor_alias: str, services: list, location: str
+def should_see_links_in_specific_location(
+    context: Context, actor_alias: str, section: str, links: Union[list, Table], location: str
 ):
     page = get_page_object(location)
     has_action(page, "should_see_link_to")
-    for service in services:
-        page.should_see_link_to(context.driver, "services", service)
+    if isinstance(links, Table):
+        links = [row[0] for row in links]
+    for link in links:
+        page.should_see_link_to(context.driver, section, link)
         logging.debug(
-            "%s can see link to '%s' in '%s'", actor_alias, service, location
+            "%s can see link to '%s' in '%s'", actor_alias, link, location
         )
 
 

--- a/tests/browser/steps/then_impl.py
+++ b/tests/browser/steps/then_impl.py
@@ -177,13 +177,6 @@ def share_page_via_email_should_have_article_details(
     )
 
 
-def triage_should_see_change_your_answers_link(
-    context: Context, actor_alias: str
-):
-    exred.triage_summary.should_see_change_your_answers_link(context.driver)
-    logging.debug("%s can see 'change your answers' link", actor_alias)
-
-
 def promo_video_check_watch_time(
     context: Context, actor_alias: str, expected_watch_time: int
 ):

--- a/tests/browser/steps/when_def.py
+++ b/tests/browser/steps/when_def.py
@@ -302,7 +302,7 @@ def given_actor_navigates_via_contact_us_options(
 
 
 @when('"{actor_alias}" is on the "{page_name}" page')
-def step_impl(context: Context, actor_alias: str, page_name: str):
+def when_actor_is_on_page(context: Context, actor_alias: str, page_name: str):
     should_be_on_page(context, actor_alias, page_name)
 
 

--- a/tests/browser/steps/when_def.py
+++ b/tests/browser/steps/when_def.py
@@ -340,9 +340,8 @@ def when_actor_clears_the_cookies(context, actor_alias):
 
 
 @when('"{actor_alias}" signs in')
-@when('"{actor_alias}" signs in using link visible in the "{location}"')
-def when_actor_signs_in(context, actor_alias, *, location="top bar"):
-    sign_in(context, actor_alias, location)
+def when_actor_signs_in(context, actor_alias):
+    sign_in(context, actor_alias)
 
 
 @when('"{actor_alias}" signs out')

--- a/tests/browser/steps/when_impl.py
+++ b/tests/browser/steps/when_impl.py
@@ -201,19 +201,11 @@ def open_service_link_on_interim_page(
     logging.debug("%s went to %s service page", actor_alias, service)
 
 
-def registration_go_to(context: Context, actor_alias: str, location: str):
+def registration_go_to(context: Context, actor_alias: str):
     logging.debug(
         "%s decided to go to registration via %s link", actor_alias, location
     )
-    if location.lower() == "article list":
-        exred.article_list.go_to_registration(context.driver)
-    elif location.lower() == "top bar":
-        exred.header.go_to_registration(context.driver)
-    else:
-        raise KeyError(
-            "Could not recognise registration link location: %s. Please use "
-            "'article', 'article list' or 'top bar'".format(location)
-        )
+    exred.header.go_to_registration(context.driver)
     sso.registration.should_be_here(context.driver)
 
 
@@ -267,7 +259,7 @@ def registration_create_and_verify_account(
     context: Context, actor_alias: str, *, fake_verification: bool = True
 ):
     visit_page(context, actor_alias, "export readiness - home")
-    registration_go_to(context, actor_alias, "top bar")
+    registration_go_to(context, actor_alias)
     registration_submit_form_and_verify_account(
         context, actor_alias, fake_verification=fake_verification
     )
@@ -289,25 +281,15 @@ def sign_in_go_to(context: Context, actor_alias: str, location: str):
     logging.debug(
         "%s decided to go to sign in page via %s link", actor_alias, location
     )
-    if location.lower() == "article":
-        exred.article_common.go_to_sign_in(context.driver)
-    elif location.lower() == "article list":
-        exred.article_list.go_to_sign_in(context.driver)
-    elif location.lower() == "top bar":
-        exred.header.go_to_sign_in(context.driver)
-    else:
-        raise KeyError(
-            "Could not recognise 'sign in' link location: {}. Please use "
-            "'article', 'article list' or 'top bar'".format(location)
-        )
+    exred.header.go_to_sign_in(context.driver)
     sso.sign_in.should_be_here(context.driver)
 
 
-def sign_in(context: Context, actor_alias: str, location: str):
+def sign_in(context: Context, actor_alias: str):
     actor = get_actor(context, actor_alias)
     email = actor.email
     password = actor.password
-    sign_in_go_to(context, actor_alias, location)
+    sign_in_go_to(context, actor_alias)
     sso.sign_in.fill_out(context.driver, email, password)
     sso.sign_in.submit(context.driver)
 

--- a/tests/browser/steps/when_impl.py
+++ b/tests/browser/steps/when_impl.py
@@ -306,12 +306,12 @@ def articles_share_on_social_media(
 ):
     context.article_url = context.driver.current_url
     if social_media.lower() == "email":
-        exred.article_common.check_if_link_opens_email_client(context.driver)
+        exred.advice_article.check_if_link_opens_email_client(context.driver)
     else:
-        exred.article_common.check_if_link_opens_new_tab(
+        exred.advice_article.check_if_link_opens_new_tab(
             context.driver, social_media
         )
-        exred.article_common.share_via(context.driver, social_media)
+        exred.advice_article.share_via(context.driver, social_media)
     logging.debug(
         "%s successfully got to the share article on '%s'",
         actor_alias,


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/CMS-686)

Scenario:
```gherkin
  @CMS-686
  Scenario Outline: Any Exporter visiting the home page should be able to see links to all Advice categories in "Export Readiness - <link_location>"
    Given "Robert" visits the "Export Readiness - Home" page

    Then "Robert" should see links to following "Advice" categories in "Export Readiness - <link_location>"
      | categories                                  |
      | Create an export plan                       |
      | Find an export market                       |
      | Define route to market                      |
      | Get export finance and funding              |
      | Manage payment for export orders            |
      | Prepare to do business in a foreign country |
      | Manage legal and ethical compliance         |
      | Prepare for export procedures and logistics |

    Examples:
      | link_location |
      | header        |
      | home          |
      | footer        |
```

```gherkin
  @CMS-686
  @bug
  @CMS-733
  @fixed
  @sharing
  @social-media
  @<social_media>
  Scenario Outline: Any Exporter should be able to share Advice article via "<social_media>"
    Given "Robert" is on randomly selected Advice article page

    When "Robert" decides to share the article via "<social_media>"

    Then "Robert" should be taken to a new tab with the "<social_media>" share page opened
    And "Robert" should that "<social_media>" share page has been pre-populated with message and the link to the article

    Examples:
      | social_media |
      | Facebook     |
      | Twitter      |
      | Facebook     |
```

```gherkin
  @CMS-686
  @bug
  @CMS-733
  @fixed
  @sharing
  @social-media
  @email
  Scenario: Any Exporter should be able to share Advice article via "email"
    Given "Robert" is on randomly selected Advice article page

    When "Robert" decides to share the article via "email"

    Then "Robert" should see that the share via email link will pre-populate the message subject and body with Article title and URL
```

```gherkin
  @CMS-686
  @breadcrumbs
  Scenario Outline: Any Exporter should see be to use "<breadcrumb>" breadcrumb on "Advice article" page to get to "<target>" page
    Given "Robert" is on randomly selected Advice article page

    When "Robert" decides to open "<breadcrumb>"

    Then "Robert" should be on the "Export Readiness - <target>" page

    Examples:
      | breadcrumb   | target                |
      | great.gov.uk | Home                  |
      | Advice       | Advice - Landing      |
      | Article list | Advice - article list |
```